### PR TITLE
Fix DSA acceptance tests

### DIFF
--- a/stackit/services/logme/logme_acc_test.go
+++ b/stackit/services/logme/logme_acc_test.go
@@ -19,7 +19,9 @@ import (
 var instanceResource = map[string]string{
 	"project_id": testutil.ProjectId,
 	"name":       testutil.ResourceNameWithDateTime("logme"),
-	"plan_id":    "7a54492c-8a2e-4d3c-b6c2-a4f20cb65912",
+	"plan_id":    "201d743c-0f06-4af2-8f20-649baf4819ae",
+	"plan_name":  "stackit-qa-logme2-1.2.50-replica",
+	"version":    "2",
 	"sgw_acl-1":  "192.168.0.0/16",
 	"sgw_acl-2":  "192.168.0.0/24",
 }
@@ -30,8 +32,9 @@ func resourceConfig(acls string) string {
 
 				resource "stackit_logme_instance" "instance" {
 					project_id = "%s"
-					name    = "%s"
-					plan_id = "%s"
+					name       = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						sgw_acl = "%s"
 					}
@@ -45,7 +48,8 @@ func resourceConfig(acls string) string {
 		testutil.LogMeProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		acls,
 	)
 }
@@ -63,6 +67,8 @@ func TestAccLogMeResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_logme_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl-1"]),
 
@@ -102,12 +108,9 @@ func TestAccLogMeResource(t *testing.T) {
 
 					resource.TestCheckResourceAttrPair("stackit_logme_instance.instance", "instance_id",
 						"data.stackit_logme_instance.instance", "instance_id"),
-
 					resource.TestCheckResourceAttrPair("stackit_logme_credentials.credentials", "credentials_id",
 						"data.stackit_logme_credentials.credentials", "credentials_id"),
-
 					resource.TestCheckResourceAttr("data.stackit_logme_instance.instance", "plan_id", instanceResource["plan_id"]),
-
 					resource.TestCheckResourceAttr("data.stackit_logme_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("data.stackit_logme_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl-1"]),
 
@@ -131,11 +134,11 @@ func TestAccLogMeResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute instance_id")
 					}
-
 					return fmt.Sprintf("%s,%s", testutil.ProjectId, instanceId), nil
 				},
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"plan_name", "version"},
 			},
 			{
 				ResourceName: "stackit_logme_credentials.credentials",
@@ -165,6 +168,8 @@ func TestAccLogMeResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_logme_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_logme_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl-2"]),
 				),

--- a/stackit/services/mariadb/mariadb_acc_test.go
+++ b/stackit/services/mariadb/mariadb_acc_test.go
@@ -20,6 +20,8 @@ var instanceResource = map[string]string{
 	"project_id": testutil.ProjectId,
 	"name":       testutil.ResourceNameWithDateTime("mariadb"),
 	"plan_id":    "683be856-3587-42de-b1b5-a792ff854f52",
+	"plan_name":  "stackit-qa-mariadb-1.4.10-single",
+	"version":    "10.6",
 	"sgw_acl-1":  "192.168.0.0/16",
 	"sgw_acl-2":  "192.168.0.0/24",
 }
@@ -30,8 +32,9 @@ func resourceConfig(acls string) string {
 
 				resource "stackit_mariadb_instance" "instance" {
 					project_id = "%s"
-					name    = "%s"
-					plan_id = "%s"
+					name       = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						sgw_acl = "%s"
 					}
@@ -45,7 +48,8 @@ func resourceConfig(acls string) string {
 		testutil.MariaDBProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		acls,
 	)
 }
@@ -63,6 +67,8 @@ func TestAccMariaDBResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_mariadb_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl-1"]),
 
@@ -99,15 +105,13 @@ func TestAccMariaDBResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance data
 					resource.TestCheckResourceAttr("data.stackit_mariadb_instance.instance", "project_id", instanceResource["project_id"]),
-
 					resource.TestCheckResourceAttrPair("stackit_mariadb_instance.instance", "instance_id",
 						"data.stackit_mariadb_instance.instance", "instance_id"),
-
 					resource.TestCheckResourceAttrPair("stackit_mariadb_credentials.credentials", "credentials_id",
 						"data.stackit_mariadb_credentials.credentials", "credentials_id"),
-
 					resource.TestCheckResourceAttr("data.stackit_mariadb_instance.instance", "plan_id", instanceResource["plan_id"]),
-
+					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("data.stackit_mariadb_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("data.stackit_mariadb_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl-1"]),
 
@@ -131,11 +135,11 @@ func TestAccMariaDBResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute instance_id")
 					}
-
 					return fmt.Sprintf("%s,%s", testutil.ProjectId, instanceId), nil
 				},
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"plan_name", "version"},
 			},
 			{
 				ResourceName: "stackit_mariadb_credentials.credentials",
@@ -165,6 +169,8 @@ func TestAccMariaDBResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_mariadb_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl-2"]),
 				),

--- a/stackit/services/mariadb/mariadb_acc_test.go
+++ b/stackit/services/mariadb/mariadb_acc_test.go
@@ -110,8 +110,6 @@ func TestAccMariaDBResource(t *testing.T) {
 					resource.TestCheckResourceAttrPair("stackit_mariadb_credentials.credentials", "credentials_id",
 						"data.stackit_mariadb_credentials.credentials", "credentials_id"),
 					resource.TestCheckResourceAttr("data.stackit_mariadb_instance.instance", "plan_id", instanceResource["plan_id"]),
-					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "plan_name", instanceResource["plan_name"]),
-					resource.TestCheckResourceAttr("stackit_mariadb_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("data.stackit_mariadb_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("data.stackit_mariadb_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl-1"]),
 

--- a/stackit/services/opensearch/opensearch_acc_test.go
+++ b/stackit/services/opensearch/opensearch_acc_test.go
@@ -20,6 +20,8 @@ var instanceResource = map[string]string{
 	"project_id": testutil.ProjectId,
 	"name":       testutil.ResourceNameWithDateTime("opensearch"),
 	"plan_id":    "9e4eac4b-b03d-4d7b-b01b-6d1224aa2d68",
+	"plan_name":  "stackit-qa-opensearch-1.2.10-replica",
+	"version":    "2",
 	"sgw_acl":    "192.168.0.0/24",
 }
 
@@ -30,7 +32,8 @@ func resourceConfig() string {
 				resource "stackit_opensearch_instance" "instance" {
 					project_id = "%s"
 					name    = "%s"
-					plan_id = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 				}
 
 				resource "stackit_opensearch_credentials" "credentials" {
@@ -41,7 +44,8 @@ func resourceConfig() string {
 		testutil.OpenSearchProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 	)
 }
 
@@ -52,7 +56,8 @@ func resourceConfigUpdate() string {
 				resource "stackit_opensearch_instance" "instance" {
 					project_id = "%s"
 					name    = "%s"
-					plan_id = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						sgw_acl = "%s"
 					}
@@ -66,7 +71,8 @@ func resourceConfigUpdate() string {
 		testutil.OpenSearchProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		instanceResource["sgw_acl"],
 	)
 }
@@ -85,6 +91,8 @@ func TestAccOpenSearchResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_opensearch_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttrSet("stackit_opensearch_instance.instance", "parameters.sgw_acl"),
 
@@ -121,15 +129,11 @@ func TestAccOpenSearchResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance data
 					resource.TestCheckResourceAttr("data.stackit_opensearch_instance.instance", "project_id", instanceResource["project_id"]),
-
 					resource.TestCheckResourceAttrPair("stackit_opensearch_instance.instance", "instance_id",
 						"data.stackit_opensearch_instance.instance", "instance_id"),
-
 					resource.TestCheckResourceAttrPair("stackit_opensearch_credentials.credentials", "credentials_id",
 						"data.stackit_opensearch_credentials.credentials", "credentials_id"),
-
 					resource.TestCheckResourceAttr("data.stackit_opensearch_instance.instance", "plan_id", instanceResource["plan_id"]),
-
 					resource.TestCheckResourceAttr("data.stackit_opensearch_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttrSet("data.stackit_opensearch_instance.instance", "parameters.sgw_acl"),
 
@@ -156,8 +160,9 @@ func TestAccOpenSearchResource(t *testing.T) {
 
 					return fmt.Sprintf("%s,%s", testutil.ProjectId, instanceId), nil
 				},
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"plan_name", "version"},
 			},
 			{
 				ResourceName: "stackit_opensearch_credentials.credentials",
@@ -187,6 +192,8 @@ func TestAccOpenSearchResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_opensearch_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_opensearch_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl"]),
 				),

--- a/stackit/services/postgresql/postgresql_acc_test.go
+++ b/stackit/services/postgresql/postgresql_acc_test.go
@@ -20,6 +20,8 @@ var instanceResource = map[string]string{
 	"project_id":        testutil.ProjectId,
 	"name":              testutil.ResourceNameWithDateTime("postgresql"),
 	"plan_id":           "57d40175-0f4c-4bcc-b52d-cf5d2ee9f5a7",
+	"plan_name":         "stackit-qa-postgresql-1.4.10-single",
+	"version":           "13",
 	"sgw_acl":           "192.168.0.0/16",
 	"metrics_frequency": "34",
 	"plugins":           "foo-bar",
@@ -31,8 +33,9 @@ func resourceConfig(acls, frequency, plugins string) string {
 
 				resource "stackit_postgresql_instance" "instance" {
 					project_id = "%s"
-					name    = "%s"
-					plan_id = "%s"
+					name       = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						sgw_acl = "%s"
 						plugins = ["%s"] 
@@ -51,7 +54,8 @@ func resourceConfig(acls, frequency, plugins string) string {
 		testutil.PostgreSQLProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		acls,
 		plugins,
 		frequency,
@@ -71,6 +75,8 @@ func TestAccPostgreSQLResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_postgresql_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl"]),
 
@@ -106,15 +112,11 @@ func TestAccPostgreSQLResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance data
 					resource.TestCheckResourceAttr("data.stackit_postgresql_instance.instance", "project_id", instanceResource["project_id"]),
-
 					resource.TestCheckResourceAttrPair("stackit_postgresql_instance.instance", "instance_id",
 						"data.stackit_postgresql_instance.instance", "instance_id"),
-
 					resource.TestCheckResourceAttrPair("stackit_postgresql_credentials.credentials", "credentials_id",
 						"data.stackit_postgresql_credentials.credentials", "credentials_id"),
-
 					resource.TestCheckResourceAttr("data.stackit_postgresql_instance.instance", "plan_id", instanceResource["plan_id"]),
-
 					resource.TestCheckResourceAttr("data.stackit_postgresql_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("data.stackit_postgresql_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl"]),
 					resource.TestCheckResourceAttr("data.stackit_postgresql_instance.instance", "parameters.plugins.#", "1"),
@@ -140,11 +142,11 @@ func TestAccPostgreSQLResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute instance_id")
 					}
-
 					return fmt.Sprintf("%s,%s", testutil.ProjectId, instanceId), nil
 				},
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"plan_name", "version"},
 			},
 			{
 				ResourceName: "stackit_postgresql_credentials.credentials",
@@ -161,7 +163,6 @@ func TestAccPostgreSQLResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute credentials_id")
 					}
-
 					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, instanceId, credentialsId), nil
 				},
 				ImportState:       true,
@@ -175,6 +176,8 @@ func TestAccPostgreSQLResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_postgresql_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl"]),
 					resource.TestCheckResourceAttr("stackit_postgresql_instance.instance", "parameters.plugins.0", fmt.Sprintf("%s-baz", instanceResource["plugins"])),

--- a/stackit/services/rabbitmq/rabbitmq_acc_test.go
+++ b/stackit/services/rabbitmq/rabbitmq_acc_test.go
@@ -21,6 +21,8 @@ var instanceResource = map[string]string{
 	"project_id":      testutil.ProjectId,
 	"name":            testutil.ResourceNameWithDateTime("rabbitmq"),
 	"plan_id":         "7e1f8394-5dd5-40b1-8608-16b4344eb51b",
+	"plan_name":       "stackit-qa-rabbitmq-2.4.10-single",
+	"version":         "3.10",
 	"sgw_acl_invalid": "1.2.3.4/4",
 	"sgw_acl_valid":   "1.2.3.4/31",
 }
@@ -35,8 +37,9 @@ func resourceConfig(acls *string) string {
 
 				resource "stackit_rabbitmq_instance" "instance" {
 					project_id = "%s"
-					name    = "%s"
-					plan_id = "%s"
+					name       = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						%s
 						metrics_frequency = "%s"
@@ -48,7 +51,8 @@ func resourceConfig(acls *string) string {
 		testutil.RabbitMQProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		aclsLine,
 		instanceResource["metrics_frequency"],
 		resourceConfigCredentials(),
@@ -62,7 +66,8 @@ func resourceConfigWithUpdate() string {
 				resource "stackit_rabbitmq_instance" "instance" {
 					project_id = "%s"
 					name    = "%s"
-					plan_id = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						sgw_acl = "%s"
 					}
@@ -73,7 +78,8 @@ func resourceConfigWithUpdate() string {
 		testutil.RabbitMQProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		instanceResource["sgw_acl_valid"],
 		resourceConfigCredentials(),
 	)
@@ -107,6 +113,8 @@ func TestAccRabbitMQResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_rabbitmq_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttrSet("stackit_rabbitmq_instance.instance", "parameters.sgw_acl"),
 
@@ -143,15 +151,11 @@ func TestAccRabbitMQResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance data
 					resource.TestCheckResourceAttr("data.stackit_rabbitmq_instance.instance", "project_id", instanceResource["project_id"]),
-
 					resource.TestCheckResourceAttrPair("stackit_rabbitmq_instance.instance", "instance_id",
 						"data.stackit_rabbitmq_credentials.credentials", "instance_id"),
-
 					resource.TestCheckResourceAttrPair("data.stackit_rabbitmq_instance.instance", "instance_id",
 						"data.stackit_rabbitmq_credentials.credentials", "instance_id"),
-
 					resource.TestCheckResourceAttr("data.stackit_rabbitmq_instance.instance", "plan_id", instanceResource["plan_id"]),
-
 					resource.TestCheckResourceAttr("data.stackit_rabbitmq_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttrSet("data.stackit_rabbitmq_instance.instance", "parameters.sgw_acl"),
 
@@ -175,11 +179,11 @@ func TestAccRabbitMQResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute instance_id")
 					}
-
 					return fmt.Sprintf("%s,%s", testutil.ProjectId, instanceId), nil
 				},
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"plan_name", "version"},
 			},
 			{
 				ResourceName: "stackit_rabbitmq_credentials.credentials",
@@ -196,7 +200,6 @@ func TestAccRabbitMQResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute credentials_id")
 					}
-
 					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, instanceId, credentialsId), nil
 				},
 				ImportState:       true,
@@ -210,6 +213,8 @@ func TestAccRabbitMQResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_rabbitmq_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_rabbitmq_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl_valid"]),
 				),

--- a/stackit/services/redis/redis_acc_test.go
+++ b/stackit/services/redis/redis_acc_test.go
@@ -20,7 +20,9 @@ import (
 var instanceResource = map[string]string{
 	"project_id":      testutil.ProjectId,
 	"name":            testutil.ResourceNameWithDateTime("redis"),
-	"plan_id":         "7e1f8394-5dd5-40b1-8608-16b4344eb51b",
+	"plan_id":         "96e24604-7a43-4ff8-9ba4-609d4235a137",
+	"plan_name":       "stackit-qa-redis-1.4.10-single",
+	"version":         "6",
 	"sgw_acl_invalid": "1.2.3.4/4",
 	"sgw_acl_valid":   "1.2.3.4/31",
 }
@@ -35,8 +37,9 @@ func resourceConfig(acls *string) string {
 
 				resource "stackit_redis_instance" "instance" {
 					project_id = "%s"
-					name    = "%s"
-					plan_id = "%s"
+					name       = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						%s
 						metrics_frequency = "%s"
@@ -48,7 +51,8 @@ func resourceConfig(acls *string) string {
 		testutil.RedisProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		aclsLine,
 		instanceResource["metrics_frequency"],
 		resourceConfigCredentials(),
@@ -61,8 +65,9 @@ func resourceConfigWithUpdate() string {
 
 				resource "stackit_redis_instance" "instance" {
 					project_id = "%s"
-					name    = "%s"
-					plan_id = "%s"
+					name       = "%s"
+					plan_name  = "%s"
+ 				 	version    = "%s"
 					parameters = {
 						sgw_acl = "%s"
 					}
@@ -73,7 +78,8 @@ func resourceConfigWithUpdate() string {
 		testutil.RedisProviderConfig(),
 		instanceResource["project_id"],
 		instanceResource["name"],
-		instanceResource["plan_id"],
+		instanceResource["plan_name"],
+		instanceResource["version"],
 		instanceResource["sgw_acl_valid"],
 		resourceConfigCredentials(),
 	)
@@ -107,6 +113,8 @@ func TestAccRedisResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_redis_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttrSet("stackit_redis_instance.instance", "parameters.sgw_acl"),
 
@@ -143,15 +151,11 @@ func TestAccRedisResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance data
 					resource.TestCheckResourceAttr("data.stackit_redis_instance.instance", "project_id", instanceResource["project_id"]),
-
 					resource.TestCheckResourceAttrPair("stackit_redis_instance.instance", "instance_id",
 						"data.stackit_redis_credentials.credentials", "instance_id"),
-
 					resource.TestCheckResourceAttrPair("data.stackit_redis_instance.instance", "instance_id",
 						"data.stackit_redis_credentials.credentials", "instance_id"),
-
 					resource.TestCheckResourceAttr("data.stackit_redis_instance.instance", "plan_id", instanceResource["plan_id"]),
-
 					resource.TestCheckResourceAttr("data.stackit_redis_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttrSet("data.stackit_redis_instance.instance", "parameters.sgw_acl"),
 
@@ -175,11 +179,11 @@ func TestAccRedisResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute instance_id")
 					}
-
 					return fmt.Sprintf("%s,%s", testutil.ProjectId, instanceId), nil
 				},
-				ImportState:       true,
-				ImportStateVerify: true,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"plan_name", "version"},
 			},
 			{
 				ResourceName: "stackit_redis_credentials.credentials",
@@ -196,7 +200,6 @@ func TestAccRedisResource(t *testing.T) {
 					if !ok {
 						return "", fmt.Errorf("couldn't find attribute credentials_id")
 					}
-
 					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, instanceId, credentialsId), nil
 				},
 				ImportState:       true,
@@ -210,6 +213,8 @@ func TestAccRedisResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "project_id", instanceResource["project_id"]),
 					resource.TestCheckResourceAttrSet("stackit_redis_instance.instance", "instance_id"),
 					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "plan_id", instanceResource["plan_id"]),
+					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "plan_name", instanceResource["plan_name"]),
+					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "name", instanceResource["name"]),
 					resource.TestCheckResourceAttr("stackit_redis_instance.instance", "parameters.sgw_acl", instanceResource["sgw_acl_valid"]),
 				),


### PR DESCRIPTION
- Updates tests after change to use `plan_name` and `version` to compute `plan_id` in the provider