### PR TITLE
Changes to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,9 +18,6 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if tag belongs to main branch
-        if: endsWith(github.ref, 'main') == false
-        run: exit -1
       - uses: actions/checkout@v4
         with:
           # Allow goreleaser to access older tag information.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 # Releases need permissions to read and write the repository contents.
 # GitHub considers creating releases and uploading assets as writing contents.


### PR DESCRIPTION
- Add workflow_dispatch trigger
- Remove branch check. The check if not very necessary (we may want to release alpha/beta/other major versions from non-main branches) and as it's currently configured, goreleaser will run for all "v*" tags