### PR TITLE
SKE Cluster: fix extensions and hibernations mapping

### DIFF
--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -1042,7 +1042,7 @@ func mapTaints(t *[]ske.Taint, nodePool map[string]attr.Value) error {
 func mapHibernations(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) error {
 	if cl.Hibernation == nil {
 		if !m.Hibernations.IsNull() {
-			emptyHibernations, diags := basetypes.NewListValueFrom(ctx, basetypes.ObjectType{AttrTypes: hibernationTypes}, []attr.Value{})
+			emptyHibernations, diags := basetypes.NewListValue(basetypes.ObjectType{AttrTypes: hibernationTypes}, []attr.Value{})
 			if diags.HasError() {
 				return fmt.Errorf("hibernations is an empty list, converting to terraform empty list: %w", core.DiagsToError(diags))
 			}
@@ -1054,7 +1054,7 @@ func mapHibernations(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) e
 	}
 
 	if cl.Hibernation.Schedules == nil {
-		emptyHibernations, diags := basetypes.NewListValueFrom(ctx, basetypes.ObjectType{AttrTypes: hibernationTypes}, []attr.Value{})
+		emptyHibernations, diags := basetypes.NewListValue(basetypes.ObjectType{AttrTypes: hibernationTypes}, []attr.Value{})
 		if diags.HasError() {
 			return fmt.Errorf("hibernations is an empty list, converting to terraform empty list: %w", core.DiagsToError(diags))
 		}

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -1243,6 +1243,10 @@ func mapExtensions(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) err
 			return fmt.Errorf("creating acl: %w", core.DiagsToError(diags))
 		}
 	} else if aclDisabled {
+		diags = ex.ACL.As(ctx, &acl, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return fmt.Errorf("converting extensions.acl object: %v", diags.Errors())
+		}
 		acl = ex.ACL
 	}
 
@@ -1268,6 +1272,10 @@ func mapExtensions(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) err
 			return fmt.Errorf("creating argus extension: %w", core.DiagsToError(diags))
 		}
 	} else if argusDisabled {
+		diags = ex.Argus.As(ctx, &argusExtension, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return fmt.Errorf("converting extensions.argus object: %v", diags.Errors())
+		}
 		argusExtension = ex.Argus
 	}
 

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -821,9 +821,9 @@ func toExtensionsPayload(ctx context.Context, m *Cluster) (*ske.Extension, error
 	var skeArgusExtension *ske.Argus
 	if !(ex.Argus.IsNull() || ex.Argus.IsUnknown()) {
 		argus := argusExtension{}
-		diags = ex.ACL.As(ctx, &argus, basetypes.ObjectAsOptions{})
+		diags = ex.Argus.As(ctx, &argus, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
-			return nil, fmt.Errorf("converting extensions.acl object: %v", diags.Errors())
+			return nil, fmt.Errorf("converting extensions.argus object: %v", diags.Errors())
 		}
 		argusEnabled := conversion.BoolValueToPointer(argus.Enabled)
 		argusInstanceId := conversion.StringValueToPointer(argus.ArgusInstanceId)

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -922,7 +922,7 @@ func mapFields(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) error {
 	if err != nil {
 		return fmt.Errorf("mapping maintenance: %w", err)
 	}
-	err = mapHibernations(ctx, cl, m)
+	err = mapHibernations(cl, m)
 	if err != nil {
 		return fmt.Errorf("mapping hibernations: %w", err)
 	}
@@ -1039,7 +1039,7 @@ func mapTaints(t *[]ske.Taint, nodePool map[string]attr.Value) error {
 	return nil
 }
 
-func mapHibernations(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) error {
+func mapHibernations(cl *ske.ClusterResponse, m *Cluster) error {
 	if cl.Hibernation == nil {
 		if !m.Hibernations.IsNull() {
 			emptyHibernations, diags := basetypes.NewListValue(basetypes.ObjectType{AttrTypes: hibernationTypes}, []attr.Value{})

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -154,7 +154,7 @@ type extensions struct {
 
 // Types corresponding to extensions
 var extensionsTypes = map[string]attr.Type{
-	"argus": basetypes.ObjectType{AttrTypes: argusExtensionTypes},
+	"argus": basetypes.ObjectType{AttrTypes: argusTypes},
 	"acl":   basetypes.ObjectType{AttrTypes: aclTypes},
 }
 
@@ -169,13 +169,13 @@ var aclTypes = map[string]attr.Type{
 	"allowed_cidrs": basetypes.ListType{ElemType: types.StringType},
 }
 
-type argusExtension struct {
+type argus struct {
 	Enabled         types.Bool   `tfsdk:"enabled"`
 	ArgusInstanceId types.String `tfsdk:"argus_instance_id"`
 }
 
 // Types corresponding to argusExtension
-var argusExtensionTypes = map[string]attr.Type{
+var argusTypes = map[string]attr.Type{
 	"enabled":           basetypes.BoolType{},
 	"argus_instance_id": basetypes.StringType{},
 }
@@ -818,16 +818,16 @@ func toExtensionsPayload(ctx context.Context, m *Cluster) (*ske.Extension, error
 		}
 	}
 
-	var skeArgusExtension *ske.Argus
+	var skeArgus *ske.Argus
 	if !(ex.Argus.IsNull() || ex.Argus.IsUnknown()) {
-		argus := argusExtension{}
+		argus := argus{}
 		diags = ex.Argus.As(ctx, &argus, basetypes.ObjectAsOptions{})
 		if diags.HasError() {
 			return nil, fmt.Errorf("converting extensions.argus object: %v", diags.Errors())
 		}
 		argusEnabled := conversion.BoolValueToPointer(argus.Enabled)
 		argusInstanceId := conversion.StringValueToPointer(argus.ArgusInstanceId)
-		skeArgusExtension = &ske.Argus{
+		skeArgus = &ske.Argus{
 			Enabled:         argusEnabled,
 			ArgusInstanceId: argusInstanceId,
 		}
@@ -835,7 +835,7 @@ func toExtensionsPayload(ctx context.Context, m *Cluster) (*ske.Extension, error
 
 	return &ske.Extension{
 		Acl:   skeAcl,
-		Argus: skeArgusExtension,
+		Argus: skeArgus,
 	}, nil
 }
 
@@ -1041,6 +1041,14 @@ func mapTaints(t *[]ske.Taint, nodePool map[string]attr.Value) error {
 
 func mapHibernations(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) error {
 	if cl.Hibernation == nil {
+		if !m.Hibernations.IsNull() {
+			emptyHibernations, diags := basetypes.NewListValueFrom(ctx, basetypes.ObjectType{AttrTypes: hibernationTypes}, []attr.Value{})
+			if diags.HasError() {
+				return fmt.Errorf("hibernations is an empty list, converting to terraform empty list: %w", core.DiagsToError(diags))
+			}
+			m.Hibernations = emptyHibernations
+			return nil
+		}
 		m.Hibernations = basetypes.NewListNull(basetypes.ObjectType{AttrTypes: hibernationTypes})
 		return nil
 	}
@@ -1170,7 +1178,7 @@ func checkDisabledExtensions(ctx context.Context, ex extensions) (aclDisabled, a
 		}
 	}
 
-	argus := argusExtension{}
+	argus := argus{}
 	if ex.Argus.IsNull() {
 		argus.Enabled = types.BoolValue(false)
 	} else {
@@ -1218,10 +1226,13 @@ func mapExtensions(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) err
 
 	emptyExtensions := &ske.Extension{}
 	if *cl.Extensions == *emptyExtensions && (disabledExtensions || m.Extensions.IsNull()) {
+		if m.Extensions.Attributes() == nil {
+			m.Extensions = types.ObjectNull(extensionsTypes)
+		}
 		return nil
 	}
 
-	acl := types.ObjectNull(aclTypes)
+	aclExtension := types.ObjectNull(aclTypes)
 	if cl.Extensions.Acl != nil {
 		enabled := types.BoolNull()
 		if cl.Extensions.Acl.Enabled != nil {
@@ -1238,19 +1249,15 @@ func mapExtensions(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) err
 			"allowed_cidrs": cidrsList,
 		}
 
-		acl, diags = types.ObjectValue(aclTypes, aclValues)
+		aclExtension, diags = types.ObjectValue(aclTypes, aclValues)
 		if diags.HasError() {
 			return fmt.Errorf("creating acl: %w", core.DiagsToError(diags))
 		}
-	} else if aclDisabled {
-		diags = ex.ACL.As(ctx, &acl, basetypes.ObjectAsOptions{})
-		if diags.HasError() {
-			return fmt.Errorf("converting extensions.acl object: %v", diags.Errors())
-		}
-		acl = ex.ACL
+	} else if aclDisabled && !ex.ACL.IsNull() {
+		aclExtension = ex.ACL
 	}
 
-	argusExtension := types.ObjectNull(argusExtensionTypes)
+	argusExtension := types.ObjectNull(argusTypes)
 	if cl.Extensions.Argus != nil {
 		enabled := types.BoolNull()
 		if cl.Extensions.Argus.Enabled != nil {
@@ -1267,20 +1274,16 @@ func mapExtensions(ctx context.Context, cl *ske.ClusterResponse, m *Cluster) err
 			"argus_instance_id": argusInstanceId,
 		}
 
-		argusExtension, diags = types.ObjectValue(argusExtensionTypes, argusExtensionValues)
+		argusExtension, diags = types.ObjectValue(argusTypes, argusExtensionValues)
 		if diags.HasError() {
 			return fmt.Errorf("creating argus extension: %w", core.DiagsToError(diags))
 		}
-	} else if argusDisabled {
-		diags = ex.Argus.As(ctx, &argusExtension, basetypes.ObjectAsOptions{})
-		if diags.HasError() {
-			return fmt.Errorf("converting extensions.argus object: %v", diags.Errors())
-		}
+	} else if argusDisabled && !ex.Argus.IsNull() {
 		argusExtension = ex.Argus
 	}
 
 	extensionsValues := map[string]attr.Value{
-		"acl":   acl,
+		"acl":   aclExtension,
 		"argus": argusExtension,
 	}
 

--- a/stackit/internal/services/ske/cluster/resource_test.go
+++ b/stackit/internal/services/ske/cluster/resource_test.go
@@ -198,7 +198,7 @@ func TestMapFields(t *testing.T) {
 							types.StringValue("cidr1"),
 						}),
 					}),
-					"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+					"argus": types.ObjectValueMust(argusTypes, map[string]attr.Value{
 						"enabled":           types.BoolValue(true),
 						"argus_instance_id": types.StringValue("aid"),
 					}),
@@ -237,7 +237,7 @@ func TestMapFields(t *testing.T) {
 						"enabled":       types.BoolValue(true),
 						"allowed_cidrs": types.ListNull(types.StringType),
 					}),
-					"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+					"argus": types.ObjectValueMust(argusTypes, map[string]attr.Value{
 						"enabled":           types.BoolValue(true),
 						"argus_instance_id": types.StringNull(),
 					}),
@@ -253,7 +253,7 @@ func TestMapFields(t *testing.T) {
 					"enabled":       types.BoolValue(false),
 					"allowed_cidrs": types.ListNull(types.StringType),
 				}),
-				"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+				"argus": types.ObjectValueMust(argusTypes, map[string]attr.Value{
 					"enabled":           types.BoolValue(false),
 					"argus_instance_id": types.StringNull(),
 				}),
@@ -276,7 +276,7 @@ func TestMapFields(t *testing.T) {
 						"enabled":       types.BoolValue(false),
 						"allowed_cidrs": types.ListNull(types.StringType),
 					}),
-					"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+					"argus": types.ObjectValueMust(argusTypes, map[string]attr.Value{
 						"enabled":           types.BoolValue(false),
 						"argus_instance_id": types.StringNull(),
 					}),
@@ -294,9 +294,9 @@ func TestMapFields(t *testing.T) {
 						types.StringValue("cidr1"),
 					}),
 				}),
-				"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+				"argus": types.ObjectValueMust(argusTypes, map[string]attr.Value{
 					"enabled":           types.BoolValue(false),
-					"argus_instance_id": types.StringNull(),
+					"argus_instance_id": types.StringValue("id"),
 				}),
 			}),
 			&ske.ClusterResponse{
@@ -304,10 +304,6 @@ func TestMapFields(t *testing.T) {
 					Acl: &ske.ACL{
 						AllowedCidrs: &[]string{"cidr1"},
 						Enabled:      utils.Ptr(true),
-					},
-					Argus: &ske.Argus{
-						ArgusInstanceId: nil,
-						Enabled:         utils.Ptr(false),
 					},
 				},
 				Name: utils.Ptr("name"),
@@ -328,9 +324,9 @@ func TestMapFields(t *testing.T) {
 							types.StringValue("cidr1"),
 						}),
 					}),
-					"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+					"argus": types.ObjectValueMust(argusTypes, map[string]attr.Value{
 						"enabled":           types.BoolValue(false),
-						"argus_instance_id": types.StringNull(),
+						"argus_instance_id": types.StringValue("id"),
 					}),
 				}),
 				KubeConfig: types.StringNull(),

--- a/stackit/internal/services/ske/cluster/resource_test.go
+++ b/stackit/internal/services/ske/cluster/resource_test.go
@@ -286,6 +286,58 @@ func TestMapFields(t *testing.T) {
 			true,
 		},
 		{
+			"extensions_only_argus_disabled",
+			types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
+				"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
+					"enabled": types.BoolValue(true),
+					"allowed_cidrs": types.ListValueMust(types.StringType, []attr.Value{
+						types.StringValue("cidr1"),
+					}),
+				}),
+				"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+					"enabled":           types.BoolValue(false),
+					"argus_instance_id": types.StringNull(),
+				}),
+			}),
+			&ske.ClusterResponse{
+				Extensions: &ske.Extension{
+					Acl: &ske.ACL{
+						AllowedCidrs: &[]string{"cidr1"},
+						Enabled:      utils.Ptr(true),
+					},
+					Argus: &ske.Argus{
+						ArgusInstanceId: nil,
+						Enabled:         utils.Ptr(false),
+					},
+				},
+				Name: utils.Ptr("name"),
+			},
+			Cluster{
+				Id:                        types.StringValue("pid,name"),
+				ProjectId:                 types.StringValue("pid"),
+				Name:                      types.StringValue("name"),
+				KubernetesVersion:         types.StringNull(),
+				AllowPrivilegedContainers: types.BoolNull(),
+				NodePools:                 types.ListNull(types.ObjectType{AttrTypes: nodePoolTypes}),
+				Maintenance:               types.ObjectNull(maintenanceTypes),
+				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
+				Extensions: types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
+					"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
+						"enabled": types.BoolValue(true),
+						"allowed_cidrs": types.ListValueMust(types.StringType, []attr.Value{
+							types.StringValue("cidr1"),
+						}),
+					}),
+					"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+						"enabled":           types.BoolValue(false),
+						"argus_instance_id": types.StringNull(),
+					}),
+				}),
+				KubeConfig: types.StringNull(),
+			},
+			true,
+		},
+		{
 			"extensions_not_set",
 			types.ObjectNull(extensionsTypes),
 			&ske.ClusterResponse{

--- a/stackit/internal/services/ske/cluster/resource_test.go
+++ b/stackit/internal/services/ske/cluster/resource_test.go
@@ -15,13 +15,15 @@ import (
 func TestMapFields(t *testing.T) {
 	cs := ske.ClusterStatusState("OK")
 	tests := []struct {
-		description string
-		input       *ske.ClusterResponse
-		expected    Cluster
-		isValid     bool
+		description     string
+		stateExtensions types.Object
+		input           *ske.ClusterResponse
+		expected        Cluster
+		isValid         bool
 	}{
 		{
 			"default_values",
+			types.ObjectNull(extensionsTypes),
 			&ske.ClusterResponse{
 				Name: utils.Ptr("name"),
 			},
@@ -41,6 +43,7 @@ func TestMapFields(t *testing.T) {
 		},
 		{
 			"simple_values",
+			types.ObjectNull(extensionsTypes),
 			&ske.ClusterResponse{
 				Extensions: &ske.Extension{
 					Acl: &ske.ACL{
@@ -205,13 +208,114 @@ func TestMapFields(t *testing.T) {
 			true,
 		},
 		{
+			"extensions_mixed_values",
+			types.ObjectNull(extensionsTypes),
+			&ske.ClusterResponse{
+				Extensions: &ske.Extension{
+					Acl: &ske.ACL{
+						AllowedCidrs: nil,
+						Enabled:      utils.Ptr(true),
+					},
+					Argus: &ske.Argus{
+						ArgusInstanceId: nil,
+						Enabled:         utils.Ptr(true),
+					},
+				},
+				Name: utils.Ptr("name"),
+			},
+			Cluster{
+				Id:                        types.StringValue("pid,name"),
+				ProjectId:                 types.StringValue("pid"),
+				Name:                      types.StringValue("name"),
+				KubernetesVersion:         types.StringNull(),
+				AllowPrivilegedContainers: types.BoolNull(),
+				NodePools:                 types.ListNull(types.ObjectType{AttrTypes: nodePoolTypes}),
+				Maintenance:               types.ObjectNull(maintenanceTypes),
+				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
+				Extensions: types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
+					"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
+						"enabled":       types.BoolValue(true),
+						"allowed_cidrs": types.ListNull(types.StringType),
+					}),
+					"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+						"enabled":           types.BoolValue(true),
+						"argus_instance_id": types.StringNull(),
+					}),
+				}),
+				KubeConfig: types.StringNull(),
+			},
+			true,
+		},
+		{
+			"extensions_disabled",
+			types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
+				"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
+					"enabled":       types.BoolValue(false),
+					"allowed_cidrs": types.ListNull(types.StringType),
+				}),
+				"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+					"enabled":           types.BoolValue(false),
+					"argus_instance_id": types.StringNull(),
+				}),
+			}),
+			&ske.ClusterResponse{
+				Extensions: &ske.Extension{},
+				Name:       utils.Ptr("name"),
+			},
+			Cluster{
+				Id:                        types.StringValue("pid,name"),
+				ProjectId:                 types.StringValue("pid"),
+				Name:                      types.StringValue("name"),
+				KubernetesVersion:         types.StringNull(),
+				AllowPrivilegedContainers: types.BoolNull(),
+				NodePools:                 types.ListNull(types.ObjectType{AttrTypes: nodePoolTypes}),
+				Maintenance:               types.ObjectNull(maintenanceTypes),
+				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
+				Extensions: types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
+					"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
+						"enabled":       types.BoolValue(false),
+						"allowed_cidrs": types.ListNull(types.StringType),
+					}),
+					"argus": types.ObjectValueMust(argusExtensionTypes, map[string]attr.Value{
+						"enabled":           types.BoolValue(false),
+						"argus_instance_id": types.StringNull(),
+					}),
+				}),
+				KubeConfig: types.StringNull(),
+			},
+			true,
+		},
+		{
+			"extensions_not_set",
+			types.ObjectNull(extensionsTypes),
+			&ske.ClusterResponse{
+				Extensions: &ske.Extension{},
+				Name:       utils.Ptr("name"),
+			},
+			Cluster{
+				Id:                        types.StringValue("pid,name"),
+				ProjectId:                 types.StringValue("pid"),
+				Name:                      types.StringValue("name"),
+				KubernetesVersion:         types.StringNull(),
+				AllowPrivilegedContainers: types.BoolNull(),
+				NodePools:                 types.ListNull(types.ObjectType{AttrTypes: nodePoolTypes}),
+				Maintenance:               types.ObjectNull(maintenanceTypes),
+				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
+				Extensions:                types.ObjectNull(extensionsTypes),
+				KubeConfig:                types.StringNull(),
+			},
+			true,
+		},
+		{
 			"nil_response",
+			types.ObjectNull(extensionsTypes),
 			nil,
 			Cluster{},
 			false,
 		},
 		{
 			"no_resource_id",
+			types.ObjectNull(extensionsTypes),
 			&ske.ClusterResponse{},
 			Cluster{},
 			false,
@@ -220,7 +324,8 @@ func TestMapFields(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			state := &Cluster{
-				ProjectId: tt.expected.ProjectId,
+				ProjectId:  tt.expected.ProjectId,
+				Extensions: tt.stateExtensions,
 			}
 			err := mapFields(context.Background(), tt.input, state)
 			if !tt.isValid && err == nil {

--- a/stackit/internal/services/ske/ske_acc_test.go
+++ b/stackit/internal/services/ske/ske_acc_test.go
@@ -146,7 +146,12 @@ func getConfig(version string, apc *bool, maintenanceEnd *string) string {
 				max_surge = "%s"
 				availability_zones = ["%s"]
 			}]
-			extensions = {}
+			maintenance = {
+				enable_kubernetes_version_updates = %s
+				enable_machine_image_version_updates = %s
+				start = "%s"
+				end = "%s"
+			}
 		}
 		`,
 		testutil.SKEProviderConfig(),
@@ -193,6 +198,10 @@ func getConfig(version string, apc *bool, maintenanceEnd *string) string {
 		clusterResource["nodepool_maximum"],
 		clusterResource["nodepool_max_surge"],
 		clusterResource["nodepool_zone"],
+		clusterResource["maintenance_enable_kubernetes_version_updates"],
+		clusterResource["maintenance_enable_machine_image_version_updates"],
+		clusterResource["maintenance_start"],
+		maintenanceEndTF,
 	)
 }
 

--- a/stackit/internal/services/ske/ske_acc_test.go
+++ b/stackit/internal/services/ske/ske_acc_test.go
@@ -146,12 +146,7 @@ func getConfig(version string, apc *bool, maintenanceEnd *string) string {
 				max_surge = "%s"
 				availability_zones = ["%s"]
 			}]
-			maintenance = {
-				enable_kubernetes_version_updates = %s
-				enable_machine_image_version_updates = %s
-				start = "%s"
-				end = "%s"
-			}
+			extensions = {}
 		}
 		`,
 		testutil.SKEProviderConfig(),
@@ -198,10 +193,6 @@ func getConfig(version string, apc *bool, maintenanceEnd *string) string {
 		clusterResource["nodepool_maximum"],
 		clusterResource["nodepool_max_surge"],
 		clusterResource["nodepool_zone"],
-		clusterResource["maintenance_enable_kubernetes_version_updates"],
-		clusterResource["maintenance_enable_machine_image_version_updates"],
-		clusterResource["maintenance_start"],
-		maintenanceEndTF,
 	)
 }
 


### PR DESCRIPTION
- Fixes #134 
- Fix disabled extensions conversion
- Fix empty hibernations conversion
- Make `extensions.acl.cidrs` field optional