### PR TITLE
Add UseStateForUnknown to prevent unnecessary replacement

### DIFF
--- a/stackit/internal/services/dns/zone/resource.go
+++ b/stackit/internal/services/dns/zone/resource.go
@@ -231,6 +231,7 @@ func (r *zoneResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				ElementType: types.StringType,
 				PlanModifiers: []planmodifier.List{
 					listplanmodifier.RequiresReplace(),
+					listplanmodifier.UseStateForUnknown(),
 				},
 				Validators: []validator.List{
 					listvalidator.SizeAtMost(10),

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -271,6 +271,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 							Computed:    true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
 							},
 						},
 						"port": schema.Int64Attribute{
@@ -279,6 +280,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 							Computed:    true,
 							PlanModifiers: []planmodifier.Int64{
 								int64planmodifier.RequiresReplace(),
+								int64planmodifier.UseStateForUnknown(),
 							},
 						},
 						"protocol": schema.StringAttribute{
@@ -287,6 +289,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 							Computed:    true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
 							},
 							Validators: []validator.String{
 								stringvalidator.OneOf("PROTOCOL_UNSPECIFIED", "PROTOCOL_TCP", "PROTOCOL_UDP", "PROTOCOL_TCP_PROXY"),
@@ -298,6 +301,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 							Computed:    true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
 							},
 						},
 					},
@@ -343,6 +347,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 							Computed:    true,
 							PlanModifiers: []planmodifier.String{
 								stringplanmodifier.RequiresReplace(),
+								stringplanmodifier.UseStateForUnknown(),
 							},
 							Validators: []validator.String{
 								stringvalidator.OneOf("ROLE_UNSPECIFIED", "ROLE_LISTENERS_AND_TARGETS", "ROLE_LISTENERS", "ROLE_TARGETS"),
@@ -357,6 +362,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 				Computed:    true,
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplace(),
+					objectplanmodifier.UseStateForUnknown(),
 				},
 				Attributes: map[string]schema.Attribute{
 					"acl": schema.SetAttribute{
@@ -366,6 +372,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 						Computed:    true,
 						PlanModifiers: []planmodifier.Set{
 							setplanmodifier.RequiresReplace(),
+							setplanmodifier.UseStateForUnknown(),
 						},
 						Validators: []validator.Set{
 							setvalidator.ValueStringsAre(
@@ -379,6 +386,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 						Computed:    true,
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.RequiresReplace(),
+							boolplanmodifier.UseStateForUnknown(),
 						},
 					},
 				},

--- a/stackit/internal/services/mongodbflex/user/resource.go
+++ b/stackit/internal/services/mongodbflex/user/resource.go
@@ -155,6 +155,7 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"roles": schema.SetAttribute{


### PR DESCRIPTION
- If a field is Computed and RequiresReplacement, an update to any field will cause a force replacement. To fix this, we add UseStateForUnknown