### PR TITLE
Small fixes to Object Storage and Resource Manager

### DIFF
--- a/stackit/internal/services/objectstorage/credential/resource.go
+++ b/stackit/internal/services/objectstorage/credential/resource.go
@@ -70,10 +70,10 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 
 	var apiClient *objectstorage.APIClient
 	var err error
-	if providerData.PostgreSQLCustomEndpoint != "" {
+	if providerData.ObjectStorageCustomEndpoint != "" {
 		apiClient, err = objectstorage.NewAPIClient(
 			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithEndpoint(providerData.PostgreSQLCustomEndpoint),
+			config.WithEndpoint(providerData.ObjectStorageCustomEndpoint),
 		)
 	} else {
 		apiClient, err = objectstorage.NewAPIClient(

--- a/stackit/internal/services/resourcemanager/project/resource.go
+++ b/stackit/internal/services/resourcemanager/project/resource.go
@@ -171,7 +171,7 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					),
 					mapvalidator.ValueStringsAre(
 						stringvalidator.RegexMatches(
-							regexp.MustCompile(`[A-ZÄÜÖa-zäüöß0-9_-]{1,64}`),
+							regexp.MustCompile(`^$|[A-ZÄÜÖa-zäüöß0-9_-]{1,64}`),
 							"must match expression"),
 					),
 				},


### PR DESCRIPTION
- Object storage credential custom endpoint was wrong
- Resource manager label value regex validation was wrong