### PR TITLE
Fix SKE example and remove cluster name regex validation

### DIFF
--- a/docs/resources/ske_cluster.md
+++ b/docs/resources/ske_cluster.md
@@ -15,13 +15,13 @@ SKE Cluster Resource schema. Must have a `region` specified in the provider conf
 ```terraform
 resource "stackit_ske_cluster" "example" {
   project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  name               = "example-name"
+  name               = "example"
   kubernetes_version = "1.25"
   node_pools = [
     {
       name               = "np-example"
-      machine_type       = "b1.2"
-      os_version         = "3510.2.5"
+      machine_type       = "x.x"
+      os_version         = "x.x.x"
       minimum            = "2"
       maximum            = "3"
       availability_zones = ["eu01-3"]

--- a/examples/resources/stackit_ske_cluster/resource.tf
+++ b/examples/resources/stackit_ske_cluster/resource.tf
@@ -1,12 +1,12 @@
 resource "stackit_ske_cluster" "example" {
   project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  name               = "example-name"
+  name               = "example"
   kubernetes_version = "1.25"
   node_pools = [
     {
       name               = "np-example"
-      machine_type       = "b1.2"
-      os_version         = "3510.2.5"
+      machine_type       = "x.x"
+      os_version         = "x.x.x"
       minimum            = "2"
       maximum            = "3"
       availability_zones = ["eu01-3"]

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -261,10 +261,6 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description: "The cluster name.",
 				Required:    true,
 				Validators: []validator.String{
-					stringvalidator.RegexMatches(
-						regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,10}$`),
-						"must start with a letter, must have lower case letters, numbers or hyphens, no hyphen at the end and less than 11 characters.",
-					),
 					validate.NoSeparator(),
 				},
 			},


### PR DESCRIPTION
Related to #202 

Removed cluster name regex validation for maintainability reasons. The API error message indicates what is a valid name, including the regex.

Replaced the `os_version` field in the ske cluster example with a placeholder for maintainability reasons.