### PR TITLE
Fix inconsistent result after updating Argus instance plan

### DIFF
--- a/stackit/internal/services/argus/instance/resource.go
+++ b/stackit/internal/services/argus/instance/resource.go
@@ -164,9 +164,6 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"plan_id": schema.StringAttribute{
 				Description: "The Argus plan ID.",
 				Computed:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 				Validators: []validator.String{
 					validate.UUID(),
 				},


### PR DESCRIPTION
- `UseStateForUnknown` on the Argus instance plan ID field was causing an inconsistent result after applying an update using the plan name