### PR TITLE
Update STACKIT SDK modules renovate group name

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,7 @@
   "packageRules": [
     {
       "matchSourceUrls": ["https://github.com/stackitcloud/stackit-sdk-go"],
-      "groupName": "SDK"
+      "groupName": "STACKIT SDK modules"
     }
   ],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"]


### PR DESCRIPTION
- So renovate PRs updating the STACKIT SDK modules are titled `Update STACKIT SDK modules` instead of just `Update SDK`