### PR TITLE
fix: Use Kubeconfig endpoint to recover temporal kubeconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/redis v0.10.0
 	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.7.6
 	github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.5.5
-	github.com/stackitcloud/stackit-sdk-go/services/ske v0.9.3
+	github.com/stackitcloud/stackit-sdk-go/services/ske v0.10.0
 	golang.org/x/mod v0.14.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.5.5 h1:rTR5/gh
 github.com/stackitcloud/stackit-sdk-go/services/secretsmanager v0.5.5/go.mod h1:VLqiO/yyC65z9fKgocTbjL0Druly9rNK8GeNeSICWAU=
 github.com/stackitcloud/stackit-sdk-go/services/ske v0.9.3 h1:+gQOSaBp2EbKxs+yLbXQPMcfaTm9YUXte0fACUYejMA=
 github.com/stackitcloud/stackit-sdk-go/services/ske v0.9.3/go.mod h1:ZJyE1fG1XtwOsnd6DaayW3LXef7HeFXJxpU70Xll8Kw=
+github.com/stackitcloud/stackit-sdk-go/services/ske v0.10.0 h1:7UgZFANyn0dB0ouNfwLHLfq44y2/90O3lkO2j6N5yu4=
+github.com/stackitcloud/stackit-sdk-go/services/ske v0.10.0/go.mod h1:ZJyE1fG1XtwOsnd6DaayW3LXef7HeFXJxpU70Xll8Kw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/stackit/internal/services/ske/cluster/datasource.go
+++ b/stackit/internal/services/ske/cluster/datasource.go
@@ -9,11 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/ske"
-	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 )
@@ -315,11 +314,10 @@ func (r *clusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 func (r *clusterDataSource) getCredential(ctx context.Context, diags *diag.Diagnostics, model *Model) {
 	c := r.client
-	res, err := c.CreateKubeconfig(ctx, model.ProjectId.ValueString(), model.Name.ValueString()).
-		CreateKubeconfigPayload(ske.CreateKubeconfigPayload{
-			ExpirationSeconds: conversion.StringValueToPointer(basetypes.NewStringValue(DefaultKubeconfigExpiration)),
-		}).
-		Execute()
+	payload := ske.CreateKubeconfigPayload{
+		ExpirationSeconds: utils.Ptr(DefaultKubeconfigExpiration),
+	}
+	res, err := c.CreateKubeconfig(ctx, model.ProjectId.ValueString(), model.Name.ValueString()).CreateKubeconfigPayload(payload).Execute()
 	if err != nil {
 		diags.AddError("failed fetching cluster credentials for data source", err.Error())
 		return

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -37,13 +37,14 @@ import (
 )
 
 const (
-	DefaultOSName                = "flatcar"
-	DefaultCRI                   = "containerd"
-	DefaultVolumeType            = "storage_premium_perf1"
-	DefaultVolumeSizeGB    int64 = 20
-	VersionStateSupported        = "supported"
-	VersionStatePreview          = "preview"
-	VersionStateDeprecated       = "deprecated"
+	DefaultOSName                     = "flatcar"
+	DefaultCRI                        = "containerd"
+	DefaultKubeconfigExpiration       = "3600"
+	DefaultVolumeType                 = "storage_premium_perf1"
+	DefaultVolumeSizeGB         int64 = 20
+	VersionStateSupported             = "supported"
+	VersionStatePreview               = "preview"
+	VersionStateDeprecated            = "deprecated"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -657,7 +658,11 @@ func (r *clusterResource) createOrUpdateCluster(ctx context.Context, diags *diag
 
 func (r *clusterResource) getCredential(ctx context.Context, model *Model) error {
 	c := r.client
-	res, err := c.GetCredentials(ctx, model.ProjectId.ValueString(), model.Name.ValueString()).Execute()
+	res, err := c.CreateKubeconfig(ctx, model.ProjectId.ValueString(), model.Name.ValueString()).
+		CreateKubeconfigPayload(ske.CreateKubeconfigPayload{
+			ExpirationSeconds: conversion.StringValueToPointer(basetypes.NewStringValue(DefaultKubeconfigExpiration)),
+		}).
+		Execute()
 	if err != nil {
 		return fmt.Errorf("fetching cluster credentials: %w", err)
 	}

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -658,11 +658,10 @@ func (r *clusterResource) createOrUpdateCluster(ctx context.Context, diags *diag
 
 func (r *clusterResource) getCredential(ctx context.Context, model *Model) error {
 	c := r.client
-	res, err := c.CreateKubeconfig(ctx, model.ProjectId.ValueString(), model.Name.ValueString()).
-		CreateKubeconfigPayload(ske.CreateKubeconfigPayload{
-			ExpirationSeconds: conversion.StringValueToPointer(basetypes.NewStringValue(DefaultKubeconfigExpiration)),
-		}).
-		Execute()
+	payload := ske.CreateKubeconfigPayload{
+		ExpirationSeconds: utils.Ptr(DefaultKubeconfigExpiration),
+	}
+	res, err := c.CreateKubeconfig(ctx, model.ProjectId.ValueString(), model.Name.ValueString()).CreateKubeconfigPayload(payload).Execute()
 	if err != nil {
 		return fmt.Errorf("fetching cluster credentials: %w", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/stackitcloud/terraform-provider-stackit/issues/244