### PR TITLE
fix:  validates the record conent based on record type

### DIFF
--- a/stackit/internal/services/dns/recordset/resource.go
+++ b/stackit/internal/services/dns/recordset/resource.go
@@ -158,7 +158,7 @@ func (r *recordSetResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.List{
 					listvalidator.SizeAtLeast(1),
 					listvalidator.UniqueValues(),
-					listvalidator.ValueStringsAre(validate.IP()),
+					listvalidator.ValueStringsAre(validate.RecordSet()),
 				},
 			},
 			"ttl": schema.Int64Attribute{

--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -115,7 +115,6 @@ func RecordSet() *Validator {
 					req.ConfigValue.ValueString(),
 				))
 			}
-
 		},
 	}
 }

--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -108,12 +108,8 @@ func RecordSet() *Validator {
 			case "ALIAS":
 			case "DNAME":
 			case "CAA":
+			case "PTR":
 			default:
-				resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
-					req.Path,
-					"invalid record type",
-					req.ConfigValue.ValueString(),
-				))
 			}
 		},
 	}

--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -108,7 +108,6 @@ func RecordSet() *Validator {
 			case "ALIAS":
 			case "DNAME":
 			case "CAA":
-			case "PTR":
 			default:
 			}
 		},

--- a/stackit/internal/validate/validate_test.go
+++ b/stackit/internal/validate/validate_test.go
@@ -214,10 +214,16 @@ func TestRecordSet(t *testing.T) {
 			true,
 		},
 		{
+			"PTR record",
+			"some-record",
+			"PTR",
+			true,
+		},
+		{
 			"random record",
 			"some-record",
 			"random",
-			false,
+			true,
 		},
 	}
 	for _, tt := range tests {

--- a/stackit/internal/validate/validate_test.go
+++ b/stackit/internal/validate/validate_test.go
@@ -214,12 +214,6 @@ func TestRecordSet(t *testing.T) {
 			true,
 		},
 		{
-			"PTR record",
-			"some-record",
-			"PTR",
-			true,
-		},
-		{
 			"random record",
 			"some-record",
 			"random",


### PR DESCRIPTION
I've added a new validation `RecordSet` which takes into account the type type for validating the record value

Fixes https://github.com/stackitcloud/terraform-provider-stackit/issues/261