### PR TITLE
DNS: Fix rrsetNameLength validation

### DIFF
--- a/stackit/internal/services/dns/recordset/resource.go
+++ b/stackit/internal/services/dns/recordset/resource.go
@@ -149,7 +149,6 @@ func (r *recordSetResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
-					stringvalidator.LengthAtMost(253),
 				},
 			},
 			"fqdn": schema.StringAttribute{

--- a/stackit/internal/services/dns/recordset/resource.go
+++ b/stackit/internal/services/dns/recordset/resource.go
@@ -149,7 +149,7 @@ func (r *recordSetResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Required:    true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
-					stringvalidator.LengthAtMost(63),
+					stringvalidator.LengthAtMost(253),
 				},
 			},
 			"fqdn": schema.StringAttribute{


### PR DESCRIPTION
The valid length of a dns resource record name in the dns-stackit-api is 253 character.  
This was set to 63 character before by accident.

With this PR its also possible to create long rrset names with terraform.