### PR TITLE
Remove deleted resources and datasources from Terraform state on Read (all remaining services)

### DIFF
--- a/stackit/internal/services/dns/recordset/resource.go
+++ b/stackit/internal/services/dns/recordset/resource.go
@@ -282,6 +282,10 @@ func (r *recordSetResource) Read(ctx context.Context, req resource.ReadRequest, 
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading record set", fmt.Sprintf("Calling API: %v", err))
 		return
 	}
+	if recordSetResp != nil && recordSetResp.Rrset.State != nil && *recordSetResp.Rrset.State == wait.DeleteSuccess {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// Map response body to schema
 	err = mapFields(ctx, recordSetResp, &model)

--- a/stackit/internal/services/dns/zone/datasource.go
+++ b/stackit/internal/services/dns/zone/datasource.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
+	"github.com/stackitcloud/stackit-sdk-go/services/dns/wait"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 )
@@ -191,6 +192,11 @@ func (d *zoneDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	zoneResp, err := d.client.GetZone(ctx, projectId, zoneId).Execute()
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading zone", fmt.Sprintf("Calling API: %v", err))
+		return
+	}
+	if zoneResp != nil && zoneResp.Zone.State != nil && *zoneResp.Zone.State == wait.DeleteSuccess {
+		resp.State.RemoveResource(ctx)
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading zone", "Zone was deleted successfully")
 		return
 	}
 

--- a/stackit/internal/services/dns/zone/resource.go
+++ b/stackit/internal/services/dns/zone/resource.go
@@ -361,6 +361,10 @@ func (r *zoneResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading zone", fmt.Sprintf("Calling API: %v", err))
 		return
 	}
+	if zoneResp != nil && zoneResp.Zone.State != nil && *zoneResp.Zone.State == wait.DeleteSuccess {
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	// Map response body to schema
 	err = mapFields(ctx, zoneResp, &model)

--- a/stackit/internal/services/mongodbflex/instance/datasource.go
+++ b/stackit/internal/services/mongodbflex/instance/datasource.go
@@ -3,6 +3,7 @@ package mongodbflex
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 )
 
@@ -184,6 +186,10 @@ func (r *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 	ctx = tflog.SetField(ctx, "instance_id", instanceId)
 	instanceResp, err := r.client.GetInstance(ctx, projectId, instanceId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", fmt.Sprintf("Calling API: %v", err))
 		return
 	}

--- a/stackit/internal/services/mongodbflex/instance/resource.go
+++ b/stackit/internal/services/mongodbflex/instance/resource.go
@@ -3,6 +3,7 @@ package mongodbflex
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/wait"
 )
@@ -384,6 +386,11 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	instanceResp, err := r.client.GetInstance(ctx, projectId, instanceId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", err.Error())
 		return
 	}

--- a/stackit/internal/services/mongodbflex/user/datasource.go
+++ b/stackit/internal/services/mongodbflex/user/datasource.go
@@ -3,6 +3,7 @@ package mongodbflex
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 )
 
@@ -163,6 +165,10 @@ func (r *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	recordSetResp, err := r.client.GetUser(ctx, projectId, instanceId, userId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading user", fmt.Sprintf("Calling API: %v", err))
 		return
 	}

--- a/stackit/internal/services/mongodbflex/user/resource.go
+++ b/stackit/internal/services/mongodbflex/user/resource.go
@@ -3,6 +3,7 @@ package mongodbflex
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
@@ -21,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 )
 
@@ -261,6 +263,11 @@ func (r *userResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	recordSetResp, err := r.client.GetUser(ctx, projectId, instanceId, userId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading user", fmt.Sprintf("Calling API: %v", err))
 		return
 	}

--- a/stackit/internal/services/objectstorage/credential/datasource.go
+++ b/stackit/internal/services/objectstorage/credential/datasource.go
@@ -131,9 +131,14 @@ func (r *credentialDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	ctx = tflog.SetField(ctx, "credentials_group_id", credentialsGroupId)
 	ctx = tflog.SetField(ctx, "credential_id", credentialId)
 
-	err := readCredentials(ctx, &model, r.client)
+	found, err := readCredentials(ctx, &model, r.client)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading credential", fmt.Sprintf("Finding credential: %v", err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading credential", "Credential not found")
 		return
 	}
 

--- a/stackit/internal/services/objectstorage/credential/resource.go
+++ b/stackit/internal/services/objectstorage/credential/resource.go
@@ -240,9 +240,13 @@ func (r *credentialResource) Read(ctx context.Context, req resource.ReadRequest,
 	ctx = tflog.SetField(ctx, "credentials_group_id", credentialsGroupId)
 	ctx = tflog.SetField(ctx, "credential_id", credentialId)
 
-	err := readCredentials(ctx, &model, r.client)
+	found, err := readCredentials(ctx, &model, r.client)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading credential", fmt.Sprintf("Finding credential: %v", err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
 		return
 	}
 
@@ -389,17 +393,17 @@ func mapFields(credentialResp *objectstorage.CreateAccessKeyResponse, model *Mod
 // readCredentials gets all the existing credentials for the specified credentials group,
 // finds the credential that is being read and updates the state.
 // If the credential cannot be found, it throws an error
-func readCredentials(ctx context.Context, model *Model, client *objectstorage.APIClient) error {
+func readCredentials(ctx context.Context, model *Model, client *objectstorage.APIClient) (bool, error) {
 	projectId := model.ProjectId.ValueString()
 	credentialsGroupId := model.CredentialsGroupId.ValueString()
 	credentialId := model.CredentialId.ValueString()
 
 	credentialsGroupResp, err := client.ListAccessKeys(ctx, projectId).CredentialsGroup(credentialsGroupId).Execute()
 	if err != nil {
-		return fmt.Errorf("getting credentials groups: %w", err)
+		return false, fmt.Errorf("getting credentials groups: %w", err)
 	}
 	if credentialsGroupResp == nil {
-		return fmt.Errorf("getting credentials groups: nil response")
+		return false, fmt.Errorf("getting credentials groups: nil response")
 	}
 
 	foundCredential := false
@@ -427,15 +431,15 @@ func readCredentials(ctx context.Context, model *Model, client *objectstorage.AP
 			// Eg. "2027-01-02T03:04:05.000Z" = "2027-01-02T03:04:05Z"
 			expirationTimestamp, err := time.Parse(time.RFC3339, *credential.Expires)
 			if err != nil {
-				return fmt.Errorf("unable to parse payload expiration timestamp '%v': %w", *credential.Expires, err)
+				return foundCredential, fmt.Errorf("unable to parse payload expiration timestamp '%v': %w", *credential.Expires, err)
 			}
 			model.ExpirationTimestamp = types.StringValue(expirationTimestamp.Format(time.RFC3339))
 		}
 		break
 	}
 	if !foundCredential {
-		return fmt.Errorf("credential could not be found")
+		return foundCredential, nil
 	}
 
-	return nil
+	return foundCredential, nil
 }

--- a/stackit/internal/services/objectstorage/credential/resource.go
+++ b/stackit/internal/services/objectstorage/credential/resource.go
@@ -437,9 +437,6 @@ func readCredentials(ctx context.Context, model *Model, client *objectstorage.AP
 		}
 		break
 	}
-	if !foundCredential {
-		return foundCredential, nil
-	}
 
 	return foundCredential, nil
 }

--- a/stackit/internal/services/objectstorage/credential/resource.go
+++ b/stackit/internal/services/objectstorage/credential/resource.go
@@ -392,7 +392,7 @@ func mapFields(credentialResp *objectstorage.CreateAccessKeyResponse, model *Mod
 
 // readCredentials gets all the existing credentials for the specified credentials group,
 // finds the credential that is being read and updates the state.
-// If the credential cannot be found, it throws an error
+// Returns True if the credential was found, False otherwise.
 func readCredentials(ctx context.Context, model *Model, client *objectstorage.APIClient) (bool, error) {
 	projectId := model.ProjectId.ValueString()
 	credentialsGroupId := model.CredentialsGroupId.ValueString()

--- a/stackit/internal/services/objectstorage/credentialsgroup/datasource.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/datasource.go
@@ -128,9 +128,14 @@ func (r *credentialsGroupDataSource) Read(ctx context.Context, req datasource.Re
 	ctx = tflog.SetField(ctx, "project_id", projectId)
 	ctx = tflog.SetField(ctx, "credentials_group_id", credentialsGroupId)
 
-	err := readCredentialsGroups(ctx, &model, r.client)
+	found, err := readCredentialsGroups(ctx, &model, r.client)
 	if err != nil {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading credentialsGroup", fmt.Sprintf("getting credential group from list of credentials groups: %v", err))
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading credentials group", fmt.Sprintf("getting credential group from list of credentials groups: %v", err))
+		return
+	}
+	if !found {
+		resp.State.RemoveResource(ctx)
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading credentials group", "Credentials group not found")
 		return
 	}
 

--- a/stackit/internal/services/objectstorage/credentialsgroup/resource.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/resource.go
@@ -322,7 +322,7 @@ func enableProject(ctx context.Context, model *Model, client objectStorageClient
 }
 
 // readCredentialsGroups gets all the existing credentials groups for the specified project,
-// finds the credentials group that is being read and updates the state. 
+// finds the credentials group that is being read and updates the state.
 // Returns True if the credential was found, False otherwise.
 func readCredentialsGroups(ctx context.Context, model *Model, client objectStorageClient) (bool, error) {
 	found := false

--- a/stackit/internal/services/objectstorage/credentialsgroup/resource.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/resource.go
@@ -322,7 +322,8 @@ func enableProject(ctx context.Context, model *Model, client objectStorageClient
 }
 
 // readCredentialsGroups gets all the existing credentials groups for the specified project,
-// finds the credentials group that is being read and updates the state. If the credentials group cannot be found, it throws an error
+// finds the credentials group that is being read and updates the state. 
+// Returns True if the credential was found, False otherwise.
 func readCredentialsGroups(ctx context.Context, model *Model, client objectStorageClient) (bool, error) {
 	found := false
 

--- a/stackit/internal/services/objectstorage/credentialsgroup/resource.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/resource.go
@@ -351,9 +351,5 @@ func readCredentialsGroups(ctx context.Context, model *Model, client objectStora
 		break
 	}
 
-	if !found {
-		return found, nil
-	}
-
 	return found, nil
 }

--- a/stackit/internal/services/objectstorage/credentialsgroup/resource_test.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/resource_test.go
@@ -162,7 +162,8 @@ func TestReadCredentialsGroups(t *testing.T) {
 	tests := []struct {
 		description               string
 		mockedResp                *objectstorage.ListCredentialsGroupsResponse
-		expected                  Model
+		expectedModel             Model
+		expectedFound             bool
 		getCredentialsGroupsFails bool
 		isValid                   bool
 	}{
@@ -185,6 +186,7 @@ func TestReadCredentialsGroups(t *testing.T) {
 				CredentialsGroupId: types.StringValue("cid"),
 				URN:                types.StringNull(),
 			},
+			true,
 			false,
 			true,
 		},
@@ -211,6 +213,7 @@ func TestReadCredentialsGroups(t *testing.T) {
 				CredentialsGroupId: types.StringValue("cid"),
 				URN:                types.StringValue("urn"),
 			},
+			true,
 			false,
 			true,
 		},
@@ -222,6 +225,7 @@ func TestReadCredentialsGroups(t *testing.T) {
 			Model{},
 			false,
 			false,
+			false,
 		},
 		{
 			"nil_credentials_groups",
@@ -231,11 +235,13 @@ func TestReadCredentialsGroups(t *testing.T) {
 			Model{},
 			false,
 			false,
+			false,
 		},
 		{
 			"nil_response",
 			nil,
 			Model{},
+			false,
 			false,
 			false,
 		},
@@ -253,6 +259,7 @@ func TestReadCredentialsGroups(t *testing.T) {
 			Model{},
 			false,
 			false,
+			false,
 		},
 		{
 			"error_response",
@@ -266,6 +273,7 @@ func TestReadCredentialsGroups(t *testing.T) {
 				},
 			},
 			Model{},
+			false,
 			true,
 			false,
 		},
@@ -277,10 +285,10 @@ func TestReadCredentialsGroups(t *testing.T) {
 				listCredentialsGroupsResp: tt.mockedResp,
 			}
 			model := &Model{
-				ProjectId:          tt.expected.ProjectId,
-				CredentialsGroupId: tt.expected.CredentialsGroupId,
+				ProjectId:          tt.expectedModel.ProjectId,
+				CredentialsGroupId: tt.expectedModel.CredentialsGroupId,
 			}
-			err := readCredentialsGroups(context.Background(), model, client)
+			found, err := readCredentialsGroups(context.Background(), model, client)
 			if !tt.isValid && err == nil {
 				t.Fatalf("Should have failed")
 			}
@@ -288,9 +296,13 @@ func TestReadCredentialsGroups(t *testing.T) {
 				t.Fatalf("Should not have failed: %v", err)
 			}
 			if tt.isValid {
-				diff := cmp.Diff(model, &tt.expected)
+				diff := cmp.Diff(model, &tt.expectedModel)
 				if diff != "" {
 					t.Fatalf("Data does not match: %s", diff)
+				}
+
+				if found != tt.expectedFound {
+					t.Fatalf("Found does not match")
 				}
 			}
 		})

--- a/stackit/internal/services/postgresflex/instance/datasource.go
+++ b/stackit/internal/services/postgresflex/instance/datasource.go
@@ -3,6 +3,7 @@ package postgresflex
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -14,7 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
+	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex/wait"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -172,7 +175,16 @@ func (r *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 	ctx = tflog.SetField(ctx, "instance_id", instanceId)
 	instanceResp, err := r.client.GetInstance(ctx, projectId, instanceId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", fmt.Sprintf("Calling API: %v", err))
+		return
+	}
+	if instanceResp != nil && instanceResp.Item != nil && instanceResp.Item.Status != nil && *instanceResp.Item.Status == wait.InstanceStateDeleted {
+		resp.State.RemoveResource(ctx)
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", "Instance was deleted successfully")
 		return
 	}
 

--- a/stackit/internal/services/postgresflex/user/datasource.go
+++ b/stackit/internal/services/postgresflex/user/datasource.go
@@ -3,6 +3,7 @@ package postgresflex
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -15,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
 )
 
@@ -159,6 +161,10 @@ func (r *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	recordSetResp, err := r.client.GetUser(ctx, projectId, instanceId, userId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading user", fmt.Sprintf("Calling API: %v", err))
 		return
 	}

--- a/stackit/internal/services/secretsmanager/instance/datasource.go
+++ b/stackit/internal/services/secretsmanager/instance/datasource.go
@@ -3,6 +3,7 @@ package secretsmanager
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
 )
 
@@ -134,6 +136,10 @@ func (r *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	instanceResp, err := r.client.GetInstance(ctx, projectId, instanceId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", fmt.Sprintf("Calling API: %v", err))
 		return
 	}

--- a/stackit/internal/services/secretsmanager/user/datasource.go
+++ b/stackit/internal/services/secretsmanager/user/datasource.go
@@ -3,6 +3,7 @@ package secretsmanager
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -14,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
 )
 
@@ -160,6 +162,10 @@ func (r *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	userResp, err := r.client.GetUser(ctx, projectId, instanceId, userId).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading user", fmt.Sprintf("Calling API: %v", err))
 		return
 	}

--- a/stackit/internal/services/ske/cluster/datasource.go
+++ b/stackit/internal/services/ske/cluster/datasource.go
@@ -296,6 +296,10 @@ func (r *clusterDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	ctx = tflog.SetField(ctx, "name", name)
 	clusterResp, err := r.client.GetCluster(ctx, projectId, name).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading cluster", fmt.Sprintf("Calling API: %v", err))
 		return
 	}

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -1403,6 +1403,11 @@ func (r *clusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	clResp, err := r.client.GetCluster(ctx, projectId, name).Execute()
 	if err != nil {
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading cluster", fmt.Sprintf("Calling API: %v", err))
 		return
 	}


### PR DESCRIPTION
- Object storage credentials and credentials group
  - Read for credentials groups and credentials is different, we are listing and searching on the list
  - If not found, also removed from state
- PostgreSQL flex instance
  - Did not error because instance stays on state deleted
  - We now check for state after getting instance, and remove from state if deleted
- DNS zone and record set
  - Did not error because instance can still be listed (state becomes deleted but state is not part of the schema)
  - We now check for state after getting instance, and remove from state if deleted
- Argus instance
  - Did not error because instance can still be listed (state becomes deleted but state is not part of the schema)
  - We now check for state after getting instance, and remove from state if deleted
- Resource Manager
  - Deleted project gives a `403`