### PR TITLE
Improve beta resources documentation

### DIFF
--- a/docs/data-sources/server_backup_schedule.md
+++ b/docs/data-sources/server_backup_schedule.md
@@ -4,14 +4,14 @@ page_title: "stackit_server_backup_schedule Data Source - stackit"
 subcategory: ""
 description: |-
   Server backup schedule datasource schema. Must have a region specified in the provider configuration.
-  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_backup_schedule (Data Source)
 
 Server backup schedule datasource schema. Must have a `region` specified in the provider configuration.
 
-~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 
 ## Example Usage
 

--- a/docs/data-sources/server_backup_schedule.md
+++ b/docs/data-sources/server_backup_schedule.md
@@ -4,14 +4,14 @@ page_title: "stackit_server_backup_schedule Data Source - stackit"
 subcategory: ""
 description: |-
   Server backup schedule datasource schema. Must have a region specified in the provider configuration.
-  !> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
 ---
 
 # stackit_server_backup_schedule (Data Source)
 
 Server backup schedule datasource schema. Must have a `region` specified in the provider configuration.
 
-!> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
 
 ## Example Usage
 

--- a/docs/data-sources/server_backup_schedules.md
+++ b/docs/data-sources/server_backup_schedules.md
@@ -4,14 +4,14 @@ page_title: "stackit_server_backup_schedules Data Source - stackit"
 subcategory: ""
 description: |-
   Server backup schedules datasource schema. Must have a region specified in the provider configuration.
-  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_backup_schedules (Data Source)
 
 Server backup schedules datasource schema. Must have a `region` specified in the provider configuration.
 
-~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 
 ## Example Usage
 

--- a/docs/data-sources/server_backup_schedules.md
+++ b/docs/data-sources/server_backup_schedules.md
@@ -4,14 +4,14 @@ page_title: "stackit_server_backup_schedules Data Source - stackit"
 subcategory: ""
 description: |-
   Server backup schedules datasource schema. Must have a region specified in the provider configuration.
-  !> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
 ---
 
 # stackit_server_backup_schedules (Data Source)
 
 Server backup schedules datasource schema. Must have a `region` specified in the provider configuration.
 
-!> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
 
 ## Example Usage
 

--- a/docs/guides/opting_into_beta_resources.md
+++ b/docs/guides/opting_into_beta_resources.md
@@ -36,9 +36,9 @@ export STACKIT_TF_ENABLE_BETA_RESOURCES=true
 
 ## Listing Beta Resources
 
-- `stackit_server_backup_schedule`
+- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/server_backup_schedule)
 
 ## Listing Beta Data Sources
 
-- `stackit_server_backup_schedule`
-- `stackit_server_backup_schedules`
+- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedule)
+- [`stackit_server_backup_schedules`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedules)

--- a/docs/resources/server_backup_schedule.md
+++ b/docs/resources/server_backup_schedule.md
@@ -4,14 +4,14 @@ page_title: "stackit_server_backup_schedule Resource - stackit"
 subcategory: ""
 description: |-
   Server backup schedule resource schema. Must have a region specified in the provider configuration.
-  !> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
 ---
 
 # stackit_server_backup_schedule (Resource)
 
 Server backup schedule resource schema. Must have a `region` specified in the provider configuration.
 
-!> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
 
 ## Example Usage
 

--- a/docs/resources/server_backup_schedule.md
+++ b/docs/resources/server_backup_schedule.md
@@ -4,14 +4,14 @@ page_title: "stackit_server_backup_schedule Resource - stackit"
 subcategory: ""
 description: |-
   Server backup schedule resource schema. Must have a region specified in the provider configuration.
-  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_backup_schedule (Resource)
 
 Server backup schedule resource schema. Must have a `region` specified in the provider configuration.
 
-~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.
+~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 
 ## Example Usage
 

--- a/stackit/internal/features/beta.go
+++ b/stackit/internal/features/beta.go
@@ -49,5 +49,9 @@ func CheckBetaResourcesEnabled(ctx context.Context, data *core.ProviderData, dia
 
 func AddBetaDescription(description string) string {
 	// Callout block: https://developer.hashicorp.com/terraform/registry/providers/docs#callouts
-	return fmt.Sprintf("%s\n\n~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.", description)
+	return fmt.Sprintf("%s\n\n~> %s %s",
+		description,
+		"This resource is in beta and may be subject to breaking changes in the future. Use with caution.",
+		"See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.",
+	)
 }

--- a/stackit/internal/features/beta.go
+++ b/stackit/internal/features/beta.go
@@ -49,5 +49,5 @@ func CheckBetaResourcesEnabled(ctx context.Context, data *core.ProviderData, dia
 
 func AddBetaDescription(description string) string {
 	// Callout block: https://developer.hashicorp.com/terraform/registry/providers/docs#callouts
-	return fmt.Sprintf("%s\n\n!> This resource is in beta and may be subject to breaking changes in the future. Use with caution.", description)
+	return fmt.Sprintf("%s\n\n~> This resource is in beta and may be subject to breaking changes in the future. Use with caution.", description)
 }

--- a/templates/guides/opting_into_beta_resources.md.tmpl
+++ b/templates/guides/opting_into_beta_resources.md.tmpl
@@ -36,9 +36,9 @@ export STACKIT_TF_ENABLE_BETA_RESOURCES=true
 
 ## Listing Beta Resources
 
-- `stackit_server_backup_schedule`
+- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/server_backup_schedule)
 
 ## Listing Beta Data Sources
 
-- `stackit_server_backup_schedule`
-- `stackit_server_backup_schedules`
+- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedule)
+- [`stackit_server_backup_schedules`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedules)


### PR DESCRIPTION
- Adjust note to be 
![image](https://github.com/stackitcloud/terraform-provider-stackit/assets/28832884/1aee9794-8e81-4a96-848c-b38261942144)
instead of
![image](https://github.com/stackitcloud/terraform-provider-stackit/assets/28832884/81291974-acdb-49b0-a6d7-77e21e720aad)

- Add links to resources from the opting into to beta resources guide