### PR TITLE
Fix SKE cluster maintenance updated outside TF causing error

### DIFF
--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -1512,6 +1512,7 @@ func getMaintenanceTimes(ctx context.Context, cl *ske.Cluster, m *Model) (startT
 		return "", "", fmt.Errorf("parsing end time '%s' from API response as RFC3339 datetime: %w", *cl.Maintenance.TimeWindow.End, err)
 	}
 
+	// return startTimeAPI.Format("15:04:05Z07:00"), endTimeAPI.Format("15:04:05Z07:00"), nil
 	if m.Maintenance.IsNull() || m.Maintenance.IsUnknown() {
 		return startTimeAPI.Format("15:04:05Z07:00"), endTimeAPI.Format("15:04:05Z07:00"), nil
 	}
@@ -1530,9 +1531,10 @@ func getMaintenanceTimes(ctx context.Context, cl *ske.Cluster, m *Model) (startT
 			return "", "", fmt.Errorf("parsing start time '%s' from TF config as RFC time: %w", maintenance.Start.ValueString(), err)
 		}
 		if startTimeAPI.Format("15:04:05Z07:00") != startTimeTF.Format("15:04:05Z07:00") {
-			return "", "", fmt.Errorf("start time '%v' from API response doesn't match start time '%v' from TF config", *cl.Maintenance.TimeWindow.Start, maintenance.Start.ValueString())
+			startTime = startTimeAPI.Format("15:04:05Z07:00")
+		} else {
+			startTime = maintenance.Start.ValueString()
 		}
-		startTime = maintenance.Start.ValueString()
 	}
 
 	if maintenance.End.IsNull() || maintenance.End.IsUnknown() {
@@ -1543,9 +1545,10 @@ func getMaintenanceTimes(ctx context.Context, cl *ske.Cluster, m *Model) (startT
 			return "", "", fmt.Errorf("parsing end time '%s' from TF config as RFC time: %w", maintenance.End.ValueString(), err)
 		}
 		if endTimeAPI.Format("15:04:05Z07:00") != endTimeTF.Format("15:04:05Z07:00") {
-			return "", "", fmt.Errorf("end time '%v' from API response doesn't match end time '%v' from TF config", *cl.Maintenance.TimeWindow.End, maintenance.End.ValueString())
+			endTime = endTimeAPI.Format("15:04:05Z07:00")
+		} else {
+			endTime = maintenance.End.ValueString()
 		}
-		endTime = maintenance.End.ValueString()
 	}
 
 	return startTime, endTime, nil

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -1512,7 +1512,6 @@ func getMaintenanceTimes(ctx context.Context, cl *ske.Cluster, m *Model) (startT
 		return "", "", fmt.Errorf("parsing end time '%s' from API response as RFC3339 datetime: %w", *cl.Maintenance.TimeWindow.End, err)
 	}
 
-	// return startTimeAPI.Format("15:04:05Z07:00"), endTimeAPI.Format("15:04:05Z07:00"), nil
 	if m.Maintenance.IsNull() || m.Maintenance.IsUnknown() {
 		return startTimeAPI.Format("15:04:05Z07:00"), endTimeAPI.Format("15:04:05Z07:00"), nil
 	}
@@ -1530,10 +1529,11 @@ func getMaintenanceTimes(ctx context.Context, cl *ske.Cluster, m *Model) (startT
 		if err != nil {
 			return "", "", fmt.Errorf("parsing start time '%s' from TF config as RFC time: %w", maintenance.Start.ValueString(), err)
 		}
-		if startTimeAPI.Format("15:04:05Z07:00") != startTimeTF.Format("15:04:05Z07:00") {
-			startTime = startTimeAPI.Format("15:04:05Z07:00")
-		} else {
+		// If the start time from the API just differs in time format, we keep the current model value
+		if startTimeAPI.Format("15:04:05Z07:00") == startTimeTF.Format("15:04:05Z07:00") {
 			startTime = maintenance.Start.ValueString()
+		} else {
+			startTime = startTimeAPI.Format("15:04:05Z07:00")
 		}
 	}
 
@@ -1544,10 +1544,11 @@ func getMaintenanceTimes(ctx context.Context, cl *ske.Cluster, m *Model) (startT
 		if err != nil {
 			return "", "", fmt.Errorf("parsing end time '%s' from TF config as RFC time: %w", maintenance.End.ValueString(), err)
 		}
-		if endTimeAPI.Format("15:04:05Z07:00") != endTimeTF.Format("15:04:05Z07:00") {
-			endTime = endTimeAPI.Format("15:04:05Z07:00")
-		} else {
+		// If the start time from the API just differs in time format, we keep the current model value
+		if endTimeAPI.Format("15:04:05Z07:00") == endTimeTF.Format("15:04:05Z07:00") {
 			endTime = maintenance.End.ValueString()
+		} else {
+			endTime = endTimeAPI.Format("15:04:05Z07:00")
 		}
 	}
 

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -1522,33 +1522,27 @@ func getMaintenanceTimes(ctx context.Context, cl *ske.Cluster, m *Model) (startT
 		return "", "", fmt.Errorf("converting maintenance object %w", core.DiagsToError(diags.Errors()))
 	}
 
-	if maintenance.Start.IsNull() || maintenance.Start.IsUnknown() {
-		startTime = startTimeAPI.Format("15:04:05Z07:00")
-	} else {
+	startTime = startTimeAPI.Format("15:04:05Z07:00")
+	if !(maintenance.Start.IsNull() || maintenance.Start.IsUnknown()) {
 		startTimeTF, err := time.Parse("15:04:05Z07:00", maintenance.Start.ValueString())
 		if err != nil {
 			return "", "", fmt.Errorf("parsing start time '%s' from TF config as RFC time: %w", maintenance.Start.ValueString(), err)
 		}
-		// If the start time from the API just differs in time format, we keep the current model value
+		// If the start times from the API and the TF model just differ in format, we keep the current TF model value
 		if startTimeAPI.Format("15:04:05Z07:00") == startTimeTF.Format("15:04:05Z07:00") {
 			startTime = maintenance.Start.ValueString()
-		} else {
-			startTime = startTimeAPI.Format("15:04:05Z07:00")
 		}
 	}
 
-	if maintenance.End.IsNull() || maintenance.End.IsUnknown() {
-		endTime = endTimeAPI.Format("15:04:05Z07:00")
-	} else {
+	endTime = endTimeAPI.Format("15:04:05Z07:00")
+	if !(maintenance.End.IsNull() || maintenance.End.IsUnknown()) {
 		endTimeTF, err := time.Parse("15:04:05Z07:00", maintenance.End.ValueString())
 		if err != nil {
 			return "", "", fmt.Errorf("parsing end time '%s' from TF config as RFC time: %w", maintenance.End.ValueString(), err)
 		}
-		// If the start time from the API just differs in time format, we keep the current model value
+		// If the end times from the API and the TF model just differ in format, we keep the current TF model value
 		if endTimeAPI.Format("15:04:05Z07:00") == endTimeTF.Format("15:04:05Z07:00") {
 			endTime = maintenance.End.ValueString()
-		} else {
-			endTime = endTimeAPI.Format("15:04:05Z07:00")
 		}
 	}
 

--- a/stackit/internal/services/ske/cluster/resource_test.go
+++ b/stackit/internal/services/ske/cluster/resource_test.go
@@ -1461,36 +1461,44 @@ func TestGetMaintenanceTimes(t *testing.T) {
 			endExpected:   "14:15:16Z",
 		},
 		{
-			description: "tf_state_doesnt_match_1",
-			startAPI:    "0001-02-03T04:05:06+07:08",
-			startTF:     utils.Ptr("00:00:00+07:08"),
-			endAPI:      "0011-12-13T14:15:16+17:18",
-			endTF:       utils.Ptr("14:15:16+17:18"),
-			isValid:     false,
+			description:   "api_takes_precedence_if_different_1",
+			startAPI:      "0001-02-03T04:05:06+07:08",
+			startTF:       utils.Ptr("00:00:00+07:08"),
+			endAPI:        "0011-12-13T14:15:16+17:18",
+			endTF:         utils.Ptr("14:15:16+17:18"),
+			isValid:       true,
+			startExpected: "04:05:06+07:08",
+			endExpected:   "14:15:16+17:18",
 		},
 		{
-			description: "tf_state_doesnt_match_2",
-			startAPI:    "0001-02-03T04:05:06+07:08",
-			startTF:     utils.Ptr("04:05:06+07:08"),
-			endAPI:      "0011-12-13T14:15:16+17:18",
-			endTF:       utils.Ptr("00:00:00+17:18"),
-			isValid:     false,
+			description:   "api_takes_precedence_if_different_2",
+			startAPI:      "0001-02-03T04:05:06+07:08",
+			startTF:       utils.Ptr("04:05:06+07:08"),
+			endAPI:        "0011-12-13T14:15:16+17:18",
+			endTF:         utils.Ptr("00:00:00+17:18"),
+			isValid:       true,
+			startExpected: "04:05:06+07:08",
+			endExpected:   "14:15:16+17:18",
 		},
 		{
-			description: "tf_state_doesnt_match_3",
-			startAPI:    "0001-02-03T04:05:06+07:08",
-			startTF:     utils.Ptr("04:05:06Z"),
-			endAPI:      "0011-12-13T14:15:16+17:18",
-			endTF:       utils.Ptr("14:15:16+17:18"),
-			isValid:     false,
+			description:   "api_takes_precedence_if_different_3",
+			startAPI:      "0001-02-03T04:05:06+07:08",
+			startTF:       utils.Ptr("04:05:06Z"),
+			endAPI:        "0011-12-13T14:15:16+17:18",
+			endTF:         utils.Ptr("14:15:16+17:18"),
+			isValid:       true,
+			startExpected: "04:05:06+07:08",
+			endExpected:   "14:15:16+17:18",
 		},
 		{
-			description: "tf_state_doesnt_match_4",
-			startAPI:    "0001-02-03T04:05:06+07:08",
-			startTF:     utils.Ptr("04:05:06+07:08"),
-			endAPI:      "0011-12-13T14:15:16+17:18",
-			endTF:       utils.Ptr("14:15:16Z"),
-			isValid:     false,
+			description:   "api_takes_precedence_if_different_3",
+			startAPI:      "0001-02-03T04:05:06+07:08",
+			startTF:       utils.Ptr("04:05:06+07:08"),
+			endAPI:        "0011-12-13T14:15:16+17:18",
+			endTF:         utils.Ptr("14:15:16Z"),
+			isValid:       true,
+			startExpected: "04:05:06+07:08",
+			endExpected:   "14:15:16+17:18",
 		},
 	}
 	for _, tt := range tests {
@@ -1530,10 +1538,10 @@ func TestGetMaintenanceTimes(t *testing.T) {
 				t.Fatalf("getMaintenanceTimes didn't fail on invalid input")
 			}
 			if tt.startExpected != start {
-				t.Errorf("extected start '%s', got '%s'", tt.startExpected, start)
+				t.Errorf("expected start '%s', got '%s'", tt.startExpected, start)
 			}
 			if tt.endExpected != end {
-				t.Errorf("extected end '%s', got '%s'", tt.endExpected, end)
+				t.Errorf("expected end '%s', got '%s'", tt.endExpected, end)
 			}
 		})
 	}


### PR DESCRIPTION
- The API response always contains a mock date part in front of the time, so in case these are the same we just keep the current value in state (this part hasn't changed)
- What I changed was that now if the API response is different (not only in format but also in the actual time), this takes precedent over the state value as usual (instead of erroring)