### PR TITLE
Preserve order of project members even if API re-orders them

### DIFF
--- a/docs/data-sources/resourcemanager_project.md
+++ b/docs/data-sources/resourcemanager_project.md
@@ -43,5 +43,5 @@ data "stackit_resourcemanager_project" "example" {
 
 Read-Only:
 
-- `role` (String) The role of the member in the project. At least one user must have the `owner` role. Legacy roles (`project.admin`, `project.auditor`, `project.member`, `project.owner`) are not supported.
+- `role` (String) The role of the member in the project. Legacy roles (`project.admin`, `project.auditor`, `project.member`, `project.owner`) are not supported.
 - `subject` (String) Unique identifier of the user, service account or client. This is usually the email address for users or service accounts, and the name in case of clients.

--- a/docs/resources/resourcemanager_project.md
+++ b/docs/resources/resourcemanager_project.md
@@ -50,5 +50,5 @@ resource "stackit_resourcemanager_project" "example" {
 
 Required:
 
-- `role` (String) The role of the member in the project. Possible values include, but are not limited to: `owner`, `editor`, `reader`. At least one user must have the `owner` role. Legacy roles (`project.admin`, `project.auditor`, `project.member`, `project.owner`) are not supported.
+- `role` (String) The role of the member in the project. Possible values include, but are not limited to: `owner`, `editor`, `reader`. Legacy roles (`project.admin`, `project.auditor`, `project.member`, `project.owner`) are not supported.
 - `subject` (String) Unique identifier of the user, service account or client. This is usually the email address for users or service accounts, and the name in case of clients.

--- a/stackit/internal/services/resourcemanager/project/datasource.go
+++ b/stackit/internal/services/resourcemanager/project/datasource.go
@@ -246,7 +246,7 @@ func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return
 	}
 
-	err = mapMembersFields(membersResp.Members, &model)
+	err = mapMembersFields(ctx, membersResp.Members, &model)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading project", fmt.Sprintf("Processing API response: %v", err))
 		return

--- a/stackit/internal/services/resourcemanager/project/datasource.go
+++ b/stackit/internal/services/resourcemanager/project/datasource.go
@@ -112,7 +112,7 @@ func (d *projectDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 		"owner_email":                     "Email address of the owner of the project. This value is only considered during creation. Changing it afterwards will have no effect.",
 		"owner_email_deprecation_message": "The \"owner_email\" field has been deprecated in favor of the \"members\" field. Please use the \"members\" field to assign the owner role to a user, by setting the \"role\" field to `owner`.",
 		"members":                         "The members assigned to the project. At least one subject needs to be a user, and not a client or service account.",
-		"members.role":                    fmt.Sprintf("The role of the member in the project. At least one user must have the `owner` role. Legacy roles (%s) are not supported.", strings.Join(utils.QuoteValues(utils.LegacyProjectRoles), ", ")),
+		"members.role":                    fmt.Sprintf("The role of the member in the project. Legacy roles (%s) are not supported.", strings.Join(utils.QuoteValues(utils.LegacyProjectRoles), ", ")),
 		"members.subject":                 "Unique identifier of the user, service account or client. This is usually the email address for users or service accounts, and the name in case of clients.",
 	}
 

--- a/stackit/internal/services/resourcemanager/project/resource.go
+++ b/stackit/internal/services/resourcemanager/project/resource.go
@@ -157,7 +157,7 @@ func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 		"owner_email":                     "Email address of the owner of the project. This value is only considered during creation. Changing it afterwards will have no effect.",
 		"owner_email_deprecation_message": "The \"owner_email\" field has been deprecated in favor of the \"members\" field. Please use the \"members\" field to assign the owner role to a user, by setting the \"role\" field to `owner`.",
 		"members":                         "The members assigned to the project. At least one subject needs to be a user, and not a client or service account.",
-		"members.role":                    fmt.Sprintf("The role of the member in the project. Possible values include, but are not limited to: `owner`, `editor`, `reader`. At least one user must have the `owner` role. Legacy roles (%s) are not supported.", strings.Join(utils.QuoteValues(utils.LegacyProjectRoles), ", ")),
+		"members.role":                    fmt.Sprintf("The role of the member in the project. Possible values include, but are not limited to: `owner`, `editor`, `reader`. Legacy roles (%s) are not supported.", strings.Join(utils.QuoteValues(utils.LegacyProjectRoles), ", ")),
 		"members.subject":                 "Unique identifier of the user, service account or client. This is usually the email address for users or service accounts, and the name in case of clients.",
 	}
 

--- a/stackit/internal/services/resourcemanager/project/resource_test.go
+++ b/stackit/internal/services/resourcemanager/project/resource_test.go
@@ -339,18 +339,6 @@ func TestToCreatePayload(t *testing.T) {
 		isValid     bool
 	}{
 		{
-			"default_ok",
-			&Model{},
-			nil,
-			&resourcemanager.CreateProjectPayload{
-				ContainerParentId: nil,
-				Labels:            nil,
-				Members:           nil,
-				Name:              nil,
-			},
-			true,
-		},
-		{
 			"mapping_with_conversions_single_member",
 			&Model{
 				ContainerParentId: types.StringValue("pid"),
@@ -466,6 +454,43 @@ func TestToCreatePayload(t *testing.T) {
 				Name: utils.Ptr("name"),
 			},
 			true,
+		},
+		{
+			"deprecated owner_email field still works",
+			&Model{
+				ContainerParentId: types.StringValue("pid"),
+				Name:              types.StringValue("name"),
+				OwnerEmail:        types.StringValue("some_email_deprecated"),
+			},
+			&map[string]string{
+				"label1": "1",
+				"label2": "2",
+			},
+			&resourcemanager.CreateProjectPayload{
+				ContainerParentId: utils.Ptr("pid"),
+				Labels: &map[string]string{
+					"label1": "1",
+					"label2": "2",
+				},
+				Members: &[]resourcemanager.Member{
+					{
+						Subject: utils.Ptr("some_email_deprecated"),
+						Role:    utils.Ptr("owner"),
+					},
+				},
+				Name: utils.Ptr("name"),
+			},
+			true,
+		},
+		{
+			"no members pr owner_email fails",
+			&Model{
+				ContainerParentId: types.StringValue("pid"),
+				Name:              types.StringValue("name"),
+			},
+			&map[string]string{},
+			nil,
+			false,
 		},
 		{
 			"nil_model",

--- a/stackit/internal/services/resourcemanager/project/resource_test.go
+++ b/stackit/internal/services/resourcemanager/project/resource_test.go
@@ -483,7 +483,7 @@ func TestToCreatePayload(t *testing.T) {
 			true,
 		},
 		{
-			"no members pr owner_email fails",
+			"no members or owner_email fails",
 			&Model{
 				ContainerParentId: types.StringValue("pid"),
 				Name:              types.StringValue("name"),


### PR DESCRIPTION
- Also adjusts `role` field description to match API behaviour
- Fixes backwards compatibility of deprecated `owner_email` field