### PR TITLE
Embed tzdata for rrule validation for alpine like env

### DIFF
--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"


### PR DESCRIPTION
The `rrule` validation requires `tzdata`. On environments like `alpine` (docker containers, Azure pipelines, etc.) the `tzdata` may be missing. 

This commit suggests embedding the `time/tzdata` into the terraform-provider validation, so the backup-schedule functionality (and any other future rrule validation) runs without problems on such environments. Otherwise the users will need to do lenghty debugging to be able to finally `apk add tzdata`.

This will add about ~400Kb to the size of the terraform provider.

Testing Done:
* ran linters, automated tests. Not sure how to add a test case for this.
* ran the following (it fails without embedding the `time/tzdata`)
```
[~/code/test-tzdata] cat Dockerfile
FROM alpine:latest
WORKDIR /app
COPY . .
RUN ./main
[~/code/test-tzdata] cat main.go
package main

import (
        "github.com/teambition/rrule-go"
        "log"
        "strings"
        _ "time/tzdata"
)

func main() {
        value := "DTSTART;TZID=America/New_York:19970902T090000 RRULE:FREQ=DAILY;COUNT=10"
        value = strings.ReplaceAll(value, " ", "\n")
        if _, err := rrule.StrToRRuleSet(value); err != nil {
                log.Fatal(err)
        }
    value = strings.ReplaceAll(value, "\n", " ")
        log.Println("Passed: ", value)
}
[~/code/test-tzdata] podman build .
STEP 1/4: FROM alpine:latest
STEP 2/4: WORKDIR /app
--> Using cache d019caf47f6acfdeec26cab54748bfd16462673312110b330e225407d117b6d6
--> d019caf47f6
STEP 3/4: COPY . .
--> 7be5c339d4b
STEP 4/4: RUN ./main
2024/08/06 13:48:18 Passed:  DTSTART;TZID=America/New_York:19970902T090000 RRULE:FREQ=DAILY;COUNT=10
COMMIT
--> aaf3216ab4b
aaf3216ab4bb7db4ce1081f22037b560cdf726a0531649395126ff4725727e75
```