### PR TITLE
Increase maximum Load Balancer target count to 1000 

### DIFF
--- a/docs/data-sources/loadbalancer.md
+++ b/docs/data-sources/loadbalancer.md
@@ -90,7 +90,7 @@ Read-Only:
 - `active_health_check` (Attributes) (see [below for nested schema](#nestedatt--target_pools--active_health_check))
 - `name` (String) Target pool name.
 - `target_port` (Number) Identical port number where each target listens for traffic.
-- `targets` (Attributes List) List of all targets which will be used in the pool. Limited to 250. (see [below for nested schema](#nestedatt--target_pools--targets))
+- `targets` (Attributes List) List of all targets which will be used in the pool. Limited to 1000. (see [below for nested schema](#nestedatt--target_pools--targets))
 
 <a id="nestedatt--target_pools--session_persistence"></a>
 ### Nested Schema for `target_pools.session_persistence`

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -233,7 +233,7 @@ Required:
 
 - `name` (String) Target pool name.
 - `target_port` (Number) Identical port number where each target listens for traffic.
-- `targets` (Attributes List) List of all targets which will be used in the pool. Limited to 250. (see [below for nested schema](#nestedatt--target_pools--targets))
+- `targets` (Attributes List) List of all targets which will be used in the pool. Limited to 1000. (see [below for nested schema](#nestedatt--target_pools--targets))
 
 Optional:
 

--- a/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
@@ -108,7 +108,7 @@ func (r *loadBalancerDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 		"unhealthy_threshold":         "Unhealthy threshold of the health checking.",
 		"target_pools.name":           "Target pool name.",
 		"target_port":                 "Identical port number where each target listens for traffic.",
-		"targets":                     "List of all targets which will be used in the pool. Limited to 250.",
+		"targets":                     "List of all targets which will be used in the pool. Limited to 1000.",
 		"targets.display_name":        "Target display name",
 		"ip":                          "Target IP",
 	}
@@ -284,7 +284,7 @@ func (r *loadBalancerDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 							Description: descriptions["targets"],
 							Computed:    true,
 							Validators: []validator.List{
-								listvalidator.SizeBetween(1, 250),
+								listvalidator.SizeBetween(1, 1000),
 							},
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -252,7 +252,7 @@ func (r *loadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 		"unhealthy_threshold":         "Unhealthy threshold of the health checking.",
 		"target_pools.name":           "Target pool name.",
 		"target_port":                 "Identical port number where each target listens for traffic.",
-		"targets":                     "List of all targets which will be used in the pool. Limited to 250.",
+		"targets":                     "List of all targets which will be used in the pool. Limited to 1000.",
 		"targets.display_name":        "Target display name",
 		"ip":                          "Target IP",
 	}
@@ -267,7 +267,6 @@ func (r *loadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 To automate the creation of load balancers, OpenStack can be used to setup the supporting infrastructure.
 To set up the OpenStack provider, you can create a token through the STACKIT Portal, in your project's Infrastructure API page.
 There, the OpenStack user domain name, username, and password are generated and can be obtained. The provider can then be configured as follows:` + "\n" +
-
 			"```terraform" + `
 terraform {
 	required_providers {
@@ -536,7 +535,7 @@ The example below uses OpenStack to create the network, router, a public IP addr
 							Description: descriptions["targets"],
 							Required:    true,
 							Validators: []validator.List{
-								listvalidator.SizeBetween(1, 250),
+								listvalidator.SizeBetween(1, 1000),
 							},
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
We have increased our maximum target count per pool from 250 to 1000.