### PR TITLE
Remove initial networking field from server

### DIFF
--- a/stackit/internal/services/iaas/iaas_acc_test.go
+++ b/stackit/internal/services/iaas/iaas_acc_test.go
@@ -179,9 +179,6 @@ func serverResourceConfig(name, machineType string) string {
 						source_type = "%s"
 						source_id = "%s"
 					}
-					initial_networking = {
-						network_id = stackit_network.network.network_id
-					}
 					labels = {
 						"label1" = "%s"
 					}
@@ -623,7 +620,7 @@ func TestAccServer(t *testing.T) {
 				},
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"initial_networking", "boot_volume", "user_data"}, // Field is not mapped as it is only relevant on creation
+				ImportStateVerifyIgnore: []string{"boot_volume", "user_data"}, // Field is not mapped as it is only relevant on creation
 			},
 			{
 				ResourceName: "stackit_network_interface.network_interface",

--- a/stackit/internal/services/iaas/server/datasource.go
+++ b/stackit/internal/services/iaas/server/datasource.go
@@ -121,26 +121,6 @@ func (r *serverDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				MarkdownDescription: "Name of the type of the machine for the server. Possible values are documented in [Virtual machine flavors](https://docs.stackit.cloud/stackit/en/virtual-machine-flavors-75137231.html)",
 				Computed:            true,
 			},
-			"initial_networking": schema.SingleNestedAttribute{
-				Description: "The initial networking setup for the server. A network ID or a list of network interfaces IDs can be provided",
-				Computed:    true,
-				Attributes: map[string]schema.Attribute{
-					"network_id": schema.StringAttribute{
-						Description: "The network ID",
-						Computed:    true,
-					},
-					"network_interface_ids": schema.ListAttribute{
-						ElementType: types.StringType,
-						Description: "List of network interface IDs",
-						Computed:    true,
-					},
-					"security_group_ids": schema.ListAttribute{
-						ElementType: types.StringType,
-						Description: "List of security groups the server is associated to",
-						Computed:    true,
-					},
-				},
-			},
 			"availability_zone": schema.StringAttribute{
 				Description: "The availability zone of the server.",
 				Computed:    true,

--- a/stackit/internal/services/iaas/server/resource.go
+++ b/stackit/internal/services/iaas/server/resource.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
-	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -19,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -53,36 +50,21 @@ var (
 )
 
 type Model struct {
-	Id                types.String `tfsdk:"id"` // needed by TF
-	ProjectId         types.String `tfsdk:"project_id"`
-	ServerId          types.String `tfsdk:"server_id"`
-	MachineType       types.String `tfsdk:"machine_type"`
-	Name              types.String `tfsdk:"name"`
-	InitialNetworking types.Object `tfsdk:"initial_networking"`
-	AvailabilityZone  types.String `tfsdk:"availability_zone"`
-	BootVolume        types.Object `tfsdk:"boot_volume"`
-	ImageId           types.String `tfsdk:"image_id"`
-	KeypairName       types.String `tfsdk:"keypair_name"`
-	Labels            types.Map    `tfsdk:"labels"`
-	ServerGroup       types.String `tfsdk:"server_group"`
-	UserData          types.String `tfsdk:"user_data"`
-	CreatedAt         types.String `tfsdk:"created_at"`
-	LaunchedAt        types.String `tfsdk:"launched_at"`
-	UpdatedAt         types.String `tfsdk:"updated_at"`
-}
-
-// Struct corresponding to Model.InitialNetwork
-type initialNetworkModel struct {
-	NetworkId           types.String `tfsdk:"network_id"`
-	NetworkInterfaceIds types.List   `tfsdk:"network_interface_ids"`
-	SecurityGroupIds    types.List   `tfsdk:"security_group_ids"`
-}
-
-// Types corresponding to initialNetworkModel
-var initialNetworkTypes = map[string]attr.Type{
-	"network_id":            basetypes.StringType{},
-	"network_interface_ids": basetypes.ListType{ElemType: types.StringType},
-	"security_group_ids":    basetypes.ListType{ElemType: types.StringType},
+	Id               types.String `tfsdk:"id"` // needed by TF
+	ProjectId        types.String `tfsdk:"project_id"`
+	ServerId         types.String `tfsdk:"server_id"`
+	MachineType      types.String `tfsdk:"machine_type"`
+	Name             types.String `tfsdk:"name"`
+	AvailabilityZone types.String `tfsdk:"availability_zone"`
+	BootVolume       types.Object `tfsdk:"boot_volume"`
+	ImageId          types.String `tfsdk:"image_id"`
+	KeypairName      types.String `tfsdk:"keypair_name"`
+	Labels           types.Map    `tfsdk:"labels"`
+	ServerGroup      types.String `tfsdk:"server_group"`
+	UserData         types.String `tfsdk:"user_data"`
+	CreatedAt        types.String `tfsdk:"created_at"`
+	LaunchedAt       types.String `tfsdk:"launched_at"`
+	UpdatedAt        types.String `tfsdk:"updated_at"`
 }
 
 // Struct corresponding to Model.BootVolume
@@ -230,73 +212,6 @@ func (r *serverResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(`^[A-Za-z0-9]+((-|_|\s|\.)[A-Za-z0-9]+)*$`),
 						"must match expression"),
-				},
-			},
-			"initial_networking": schema.SingleNestedAttribute{
-				Description: "The initial networking setup for the server. A network ID or a list of network interfaces IDs can be provided",
-				Optional:    true,
-				PlanModifiers: []planmodifier.Object{
-					objectplanmodifier.RequiresReplace(),
-				},
-				Attributes: map[string]schema.Attribute{
-					"network_id": schema.StringAttribute{
-						Description: "The network ID",
-						Optional:    true,
-						PlanModifiers: []planmodifier.String{
-							stringplanmodifier.RequiresReplace(),
-						},
-						Validators: []validator.String{
-							stringvalidator.ConflictsWith(
-								path.MatchRoot("initial_networking").AtName("network_interface_ids"),
-							),
-							validate.UUID(),
-						},
-					},
-					"security_group_ids": schema.ListAttribute{
-						ElementType: types.StringType,
-						Description: "List of security groups the initial network is assigned to",
-						Optional:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.RequiresReplace(),
-						},
-						Validators: []validator.List{
-							listvalidator.ValueStringsAre(
-								stringvalidator.LengthAtLeast(1),
-								stringvalidator.LengthAtMost(63),
-								stringvalidator.RegexMatches(
-									regexp.MustCompile(`^[A-Za-z0-9]+((-|_|\s|\.)[A-Za-z0-9]+)*$`),
-									"must match expression"),
-							),
-							listvalidator.ConflictsWith(
-								path.MatchRoot("initial_networking").AtName("network_interface_ids"),
-							),
-							listvalidator.AlsoRequires(
-								path.MatchRoot("initial_networking").AtName("network_id"),
-							),
-						},
-					},
-					"network_interface_ids": schema.ListAttribute{
-						ElementType: types.StringType,
-						Description: "List of network interface IDs",
-						Optional:    true,
-						PlanModifiers: []planmodifier.List{
-							listplanmodifier.RequiresReplace(),
-						},
-						Validators: []validator.List{
-							listvalidator.ConflictsWith(
-								path.MatchRoot("initial_networking").AtName("network_id"),
-							),
-							listvalidator.ValueStringsAre(
-								validate.UUID(),
-							),
-						},
-					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.AtLeastOneOf(
-						path.MatchRoot("initial_networking").AtName("network_id"),
-						path.MatchRoot("initial_networking").AtName("network_interface_ids"),
-					),
 				},
 			},
 			"availability_zone": schema.StringAttribute{
@@ -715,14 +630,6 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaasalpha.CreateServer
 		}
 	}
 
-	var initialNetwork = &initialNetworkModel{}
-	if !(model.InitialNetworking.IsNull() || model.InitialNetworking.IsUnknown()) {
-		diags := model.InitialNetworking.As(ctx, initialNetwork, basetypes.ObjectAsOptions{})
-		if diags.HasError() {
-			return nil, fmt.Errorf("convert initial network object to struct: %w", core.DiagsToError(diags))
-		}
-	}
-
 	labels, err := conversion.ToStringInterfaceMap(ctx, model.Labels)
 	if err != nil {
 		return nil, fmt.Errorf("converting to Go map: %w", err)
@@ -740,31 +647,6 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaasalpha.CreateServer
 		}
 	}
 
-	var initialNetworkPayload *iaasalpha.CreateServerPayloadNetworking
-	var securityGroups *[]string
-	if !initialNetwork.NetworkId.IsNull() {
-		initialNetworkPayload = &iaasalpha.CreateServerPayloadNetworking{
-			CreateServerNetworking: &iaasalpha.CreateServerNetworking{
-				NetworkId: conversion.StringValueToPointer(initialNetwork.NetworkId),
-			},
-		}
-
-		securityGroups, err = conversion.StringListToPointer(initialNetwork.SecurityGroupIds)
-		if err != nil {
-			return nil, fmt.Errorf("converting list of security groups to string list pointer: %w", err)
-		}
-	} else if !initialNetwork.NetworkInterfaceIds.IsNull() {
-		nicIds, err := conversion.StringListToPointer(initialNetwork.NetworkInterfaceIds)
-		if err != nil {
-			return nil, fmt.Errorf("converting list of network interface IDs to string list pointer: %w", err)
-		}
-		initialNetworkPayload = &iaasalpha.CreateServerPayloadNetworking{
-			CreateServerNetworkingWithNics: &iaasalpha.CreateServerNetworkingWithNics{
-				NicIds: nicIds,
-			},
-		}
-	}
-
 	var userData *string
 	if !model.UserData.IsNull() && !model.UserData.IsUnknown() {
 		encodedUserData := base64.StdEncoding.EncodeToString([]byte(model.UserData.ValueString()))
@@ -776,8 +658,6 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaasalpha.CreateServer
 		BootVolume:       bootVolumePayload,
 		ImageId:          conversion.StringValueToPointer(model.ImageId),
 		KeypairName:      conversion.StringValueToPointer(model.KeypairName),
-		Networking:       initialNetworkPayload,
-		SecurityGroups:   securityGroups,
 		Labels:           &labels,
 		Name:             conversion.StringValueToPointer(model.Name),
 		MachineType:      conversion.StringValueToPointer(model.MachineType),

--- a/stackit/internal/services/iaas/server/resource_test.go
+++ b/stackit/internal/services/iaas/server/resource_test.go
@@ -166,7 +166,7 @@ func TestToCreatePayload(t *testing.T) {
 		isValid     bool
 	}{
 		{
-			"create_with_network",
+			"ok",
 			&Model{
 				Name:             types.StringValue("name"),
 				AvailabilityZone: types.StringValue("zone"),
@@ -179,14 +179,6 @@ func TestToCreatePayload(t *testing.T) {
 					"source_type":       types.StringValue("type"),
 					"source_id":         types.StringValue("id"),
 				}),
-				InitialNetworking: types.ObjectValueMust(initialNetworkTypes, map[string]attr.Value{
-					"network_id": types.StringValue("nid"),
-					"security_group_ids": types.ListValueMust(types.StringType, []attr.Value{
-						types.StringValue("group1"),
-						types.StringValue("group2"),
-					}),
-					"network_interface_ids": types.ListNull(types.StringType),
-				}),
 				ImageId:     types.StringValue("image"),
 				KeypairName: types.StringValue("keypair"),
 				MachineType: types.StringValue("machine_type"),
@@ -198,57 +190,12 @@ func TestToCreatePayload(t *testing.T) {
 				Labels: &map[string]interface{}{
 					"key": "value",
 				},
-				Networking: &iaasalpha.CreateServerPayloadNetworking{
-					CreateServerNetworking: &iaasalpha.CreateServerNetworking{
-						NetworkId: utils.Ptr("nid"),
-					},
-				},
-				SecurityGroups: utils.Ptr([]string{"group1", "group2"}),
 				BootVolume: &iaasalpha.CreateServerPayloadBootVolume{
 					PerformanceClass: utils.Ptr("class"),
 					Size:             utils.Ptr(int64(1)),
 					Source: &iaasalpha.BootVolumeSource{
 						Type: utils.Ptr("type"),
 						Id:   utils.Ptr("id"),
-					},
-				},
-				ImageId:     utils.Ptr("image"),
-				KeypairName: utils.Ptr("keypair"),
-				MachineType: utils.Ptr("machine_type"),
-				UserData:    utils.Ptr(base64EncodedUserData),
-			},
-			true,
-		},
-		{
-			"create_with_network_interface_ids",
-			&Model{
-				Name:             types.StringValue("name"),
-				AvailabilityZone: types.StringValue("zone"),
-				Labels: types.MapValueMust(types.StringType, map[string]attr.Value{
-					"key": types.StringValue("value"),
-				}),
-				InitialNetworking: types.ObjectValueMust(initialNetworkTypes, map[string]attr.Value{
-					"network_id":         types.StringNull(),
-					"security_group_ids": types.ListNull(types.StringType),
-					"network_interface_ids": types.ListValueMust(types.StringType, []attr.Value{
-						types.StringValue("nic1"),
-						types.StringValue("nic2"),
-					}),
-				}),
-				ImageId:     types.StringValue("image"),
-				KeypairName: types.StringValue("keypair"),
-				MachineType: types.StringValue("machine_type"),
-				UserData:    types.StringValue(userData),
-			},
-			&iaasalpha.CreateServerPayload{
-				Name:             utils.Ptr("name"),
-				AvailabilityZone: utils.Ptr("zone"),
-				Labels: &map[string]interface{}{
-					"key": "value",
-				},
-				Networking: &iaasalpha.CreateServerPayloadNetworking{
-					CreateServerNetworkingWithNics: &iaasalpha.CreateServerNetworkingWithNics{
-						NicIds: utils.Ptr([]string{"nic1", "nic2"}),
 					},
 				},
 				ImageId:     utils.Ptr("image"),


### PR DESCRIPTION
- After aligning withe IaaS team, we decide to remove this field to improve user experience and make it very clear and transparent how to setup networking for a server which is going to be done solely by separate network interface attachment resource