### PR TITLE
fix: Fix network interface handling of allowed addresses and security…

### DIFF
--- a/stackit/internal/services/iaas/networkinterface/resource.go
+++ b/stackit/internal/services/iaas/networkinterface/resource.go
@@ -562,20 +562,18 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaas.CreateNICPayload,
 		}
 	}
 
-	var allowedAddressesPayload *[]iaas.AllowedAddressesInner
+	allowedAddressesPayload := &[]iaas.AllowedAddressesInner{}
 	if !(model.AllowedAddresses.IsNull() || model.AllowedAddresses.IsUnknown()) {
-		allowedAddresses := []iaas.AllowedAddressesInner{}
 		for _, allowedAddressModel := range model.AllowedAddresses.Elements() {
 			allowedAddressString, ok := allowedAddressModel.(types.String)
 			if !ok {
 				return nil, fmt.Errorf("type assertion failed")
 			}
 
-			allowedAddresses = append(allowedAddresses, iaas.AllowedAddressesInner{
+			*allowedAddressesPayload = append(*allowedAddressesPayload, iaas.AllowedAddressesInner{
 				String: conversion.StringValueToPointer(allowedAddressString),
 			})
 		}
-		allowedAddressesPayload = &allowedAddresses
 	} else {
 		allowedAddressesPayload = nil
 	}

--- a/stackit/internal/services/iaas/networkinterface/resource.go
+++ b/stackit/internal/services/iaas/networkinterface/resource.go
@@ -469,7 +469,16 @@ func mapFields(ctx context.Context, networkInterfaceResp *iaas.NIC, model *Model
 	respAllowedAddresses := []string{}
 	var diags diag.Diagnostics
 	if networkInterfaceResp.AllowedAddresses == nil {
-		model.AllowedAddresses = types.ListNull(types.StringType)
+		// If we send an empty list, the API will send null in the response
+		// We should handle this case and set the value to an empty list
+		if !model.AllowedAddresses.IsNull() {
+			model.AllowedAddresses, diags = types.ListValueFrom(ctx, types.StringType, []string{})
+			if diags.HasError() {
+				return fmt.Errorf("map network interface allowed addresses: %w", core.DiagsToError(diags))
+			}
+		} else {
+			model.AllowedAddresses = types.ListNull(types.StringType)
+		}
 	} else {
 		for _, n := range *networkInterfaceResp.AllowedAddresses {
 			respAllowedAddresses = append(respAllowedAddresses, *n.String)
@@ -553,19 +562,22 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaas.CreateNICPayload,
 		}
 	}
 
-	allowedAddressesPayload := []iaas.AllowedAddressesInner{}
-
+	var allowedAddressesPayload *[]iaas.AllowedAddressesInner
 	if !(model.AllowedAddresses.IsNull() || model.AllowedAddresses.IsUnknown()) {
+		allowedAddresses := []iaas.AllowedAddressesInner{}
 		for _, allowedAddressModel := range model.AllowedAddresses.Elements() {
 			allowedAddressString, ok := allowedAddressModel.(types.String)
 			if !ok {
 				return nil, fmt.Errorf("type assertion failed")
 			}
 
-			allowedAddressesPayload = append(allowedAddressesPayload, iaas.AllowedAddressesInner{
+			allowedAddresses = append(allowedAddresses, iaas.AllowedAddressesInner{
 				String: conversion.StringValueToPointer(allowedAddressString),
 			})
 		}
+		allowedAddressesPayload = &allowedAddresses
+	} else {
+		allowedAddressesPayload = nil
 	}
 
 	if !model.Labels.IsNull() && !model.Labels.IsUnknown() {
@@ -577,7 +589,7 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaas.CreateNICPayload,
 	}
 
 	return &iaas.CreateNICPayload{
-		AllowedAddresses: &allowedAddressesPayload,
+		AllowedAddresses: allowedAddressesPayload,
 		SecurityGroups:   &modelSecurityGroups,
 		Labels:           labelPayload,
 		Name:             conversion.StringValueToPointer(model.Name),
@@ -585,6 +597,7 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaas.CreateNICPayload,
 		Ipv4:             conversion.StringValueToPointer(model.IPv4),
 		Mac:              conversion.StringValueToPointer(model.Mac),
 		Type:             conversion.StringValueToPointer(model.Type),
+		NicSecurity:      conversion.BoolValueToPointer(model.Security),
 	}, nil
 }
 
@@ -604,8 +617,7 @@ func toUpdatePayload(ctx context.Context, model *Model, currentLabels types.Map)
 		modelSecurityGroups = append(modelSecurityGroups, securityGroupString.ValueString())
 	}
 
-	allowedAddressesPayload := []iaas.AllowedAddressesInner{}
-
+	allowedAddressesPayload := []iaas.AllowedAddressesInner{} // Even if null in the model, we need to send an empty list to the API since it's a PATCH endpoint
 	if !(model.AllowedAddresses.IsNull() || model.AllowedAddresses.IsUnknown()) {
 		for _, allowedAddressModel := range model.AllowedAddresses.Elements() {
 			allowedAddressString, ok := allowedAddressModel.(types.String)
@@ -632,5 +644,6 @@ func toUpdatePayload(ctx context.Context, model *Model, currentLabels types.Map)
 		SecurityGroups:   &modelSecurityGroups,
 		Labels:           labelPayload,
 		Name:             conversion.StringValueToPointer(model.Name),
+		NicSecurity:      conversion.BoolValueToPointer(model.Security),
 	}, nil
 }

--- a/stackit/internal/services/iaas/networkinterface/resource_test.go
+++ b/stackit/internal/services/iaas/networkinterface/resource_test.go
@@ -131,6 +131,30 @@ func TestMapFields(t *testing.T) {
 			true,
 		},
 		{
+			"empty_list_allowed_addresses",
+			Model{
+				ProjectId:          types.StringValue("pid"),
+				NetworkId:          types.StringValue("nid"),
+				NetworkInterfaceId: types.StringValue("nicid"),
+				AllowedAddresses:   types.ListValueMust(types.StringType, []attr.Value{}),
+			},
+			&iaas.NIC{
+				Id:               utils.Ptr("nicid"),
+				AllowedAddresses: nil,
+			},
+			Model{
+				Id:                 types.StringValue("pid,nid,nicid"),
+				ProjectId:          types.StringValue("pid"),
+				NetworkId:          types.StringValue("nid"),
+				NetworkInterfaceId: types.StringValue("nicid"),
+				Name:               types.StringNull(),
+				SecurityGroupIds:   types.ListNull(types.StringType),
+				AllowedAddresses:   types.ListValueMust(types.StringType, []attr.Value{}),
+				Labels:             types.MapNull(types.StringType),
+			},
+			true,
+		},
+		{
 			"response_nil_fail",
 			Model{},
 			nil,
@@ -184,6 +208,7 @@ func TestToCreatePayload(t *testing.T) {
 				AllowedAddresses: types.ListValueMust(types.StringType, []attr.Value{
 					types.StringValue("aa1"),
 				}),
+				Security: types.BoolValue(true),
 			},
 			&iaas.CreateNICPayload{
 				Name: utils.Ptr("name"),
@@ -196,6 +221,28 @@ func TestToCreatePayload(t *testing.T) {
 						String: utils.Ptr("aa1"),
 					},
 				},
+				NicSecurity: utils.Ptr(true),
+			},
+			true,
+		},
+		{
+			"empty_allowed_addresses",
+			&Model{
+				Name: types.StringValue("name"),
+				SecurityGroupIds: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("sg1"),
+					types.StringValue("sg2"),
+				}),
+
+				AllowedAddresses: types.ListNull(types.StringType),
+			},
+			&iaas.CreateNICPayload{
+				Name: utils.Ptr("name"),
+				SecurityGroups: &[]string{
+					"sg1",
+					"sg2",
+				},
+				AllowedAddresses: nil,
 			},
 			true,
 		},
@@ -237,6 +284,7 @@ func TestToUpdatePayload(t *testing.T) {
 				AllowedAddresses: types.ListValueMust(types.StringType, []attr.Value{
 					types.StringValue("aa1"),
 				}),
+				Security: types.BoolValue(true),
 			},
 			&iaas.UpdateNICPayload{
 				Name: utils.Ptr("name"),
@@ -249,6 +297,28 @@ func TestToUpdatePayload(t *testing.T) {
 						String: utils.Ptr("aa1"),
 					},
 				},
+				NicSecurity: utils.Ptr(true),
+			},
+			true,
+		},
+		{
+			"empty_allowed_addresses",
+			&Model{
+				Name: types.StringValue("name"),
+				SecurityGroupIds: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("sg1"),
+					types.StringValue("sg2"),
+				}),
+
+				AllowedAddresses: types.ListNull(types.StringType),
+			},
+			&iaas.UpdateNICPayload{
+				Name: utils.Ptr("name"),
+				SecurityGroups: &[]string{
+					"sg1",
+					"sg2",
+				},
+				AllowedAddresses: utils.Ptr([]iaas.AllowedAddressesInner{}),
 			},
 			true,
 		},


### PR DESCRIPTION
… fields


**Fixes 2 issues in `network_interface` resource where:**
- The `security` field was not being mapped to the API payloads
- Mapping `allowed_addressed` from the API response back to the Terraform state sometimes caused an inconsistent result (the API returns `null` if the payload contains an empty list)