### PR TITLE
Docs: add docs to use aws s3 provider for stackit s3

### DIFF
--- a/docs/guides/aws_provider_s3_stackit.md
+++ b/docs/guides/aws_provider_s3_stackit.md
@@ -39,7 +39,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
       credentials_group_id = stackit_objectstorage_credentials_group.example.credentials_group_id
       expiration_timestamp = "2027-01-02T03:04:05Z"
    }
-    ```
+   ```
 
 3. **Configure AWS Provider**
 
@@ -59,33 +59,33 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
          s3 = "https://object.storage.eu01.onstackit.cloud"
       }
    }
-    ```
+   ```
 
 4. **Use the provider to manage objects or policies**
 
     ```hcl
-      resource "aws_s3_object" "test_file" {
-         bucket = stackit_objectstorage_bucket.example.name
-         key    = "hello_world.txt"
-         source = "files/hello_world.txt"
-         content_type = "text/plain"
-         etag = filemd5("files/hello_world.txt")
-      }
+    resource "aws_s3_object" "test_file" {
+     bucket = stackit_objectstorage_bucket.example.name
+     key    = "hello_world.txt"
+     source = "files/hello_world.txt"
+     content_type = "text/plain"
+     etag = filemd5("files/hello_world.txt")
+    }
 
-      resource "aws_s3_bucket_policy" "allow_public_read_access" {
-         bucket = stackit_objectstorage_bucket.test20.name
-         policy = <<EOF
-         {
-            "Statement":[
-               {
-               "Sid": "Public GET",
-               "Effect":"Allow",
-               "Principal":"*",
-               "Action":"s3:GetObject",
-               "Resource":"urn:sgws:s3:::example/*"
-               }
-            ]
-         }
-         EOF
-      }
+    resource "aws_s3_bucket_policy" "allow_public_read_access" {
+     bucket = stackit_objectstorage_bucket.test20.name
+     policy = <<EOF
+     {
+        "Statement":[
+           {
+           "Sid": "Public GET",
+           "Effect":"Allow",
+           "Principal":"*",
+           "Action":"s3:GetObject",
+           "Resource":"urn:sgws:s3:::example/*"
+           }
+        ]
+     }
+     EOF
+    }
     ```

--- a/docs/guides/aws_provider_s3_stackit.md
+++ b/docs/guides/aws_provider_s3_stackit.md
@@ -1,0 +1,91 @@
+---
+page_title: "Using AWS Provider for STACKIT S3"
+---
+# Using AWS Provider for STACKIT S3
+
+## Overview
+
+This guide outlines the process of utilizing the [AWS Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) alongside the STACKIT provider to create and manage STACKIT S3 ressources.
+
+## Steps
+
+1. **Configure STACKIT Provider**
+
+    First, configure the STACKIT provider to connect to the STACKIT services.
+
+    ```hcl
+    provider "stackit" {
+      region = "eu01"
+    }
+    ```
+
+2. **Define STACKIT S3 Bucket**
+
+    Create a STACKIT S3 Bucket and obtain credentials for the AWS provider.
+
+    ```hcl
+    resource "stackit_objectstorage_bucket" "example" {
+      project_id = ""
+      name       = "example"
+    }
+
+    resource "stackit_objectstorage_credentials_group" "example" {
+      project_id = ""
+      name       = "example-credentials-group"
+   }
+
+   resource "stackit_objectstorage_credential" "example" {
+      project_id           = ""
+      credentials_group_id = stackit_objectstorage_credentials_group.example.credentials_group_id
+      expiration_timestamp = "2027-01-02T03:04:05Z"
+   }
+    ```
+
+3. **Configure AWS Provider**
+
+   Configure the AWS Provider to connect to the STACKIT S3 bucket.
+
+    ```hcl
+    provider "aws" {
+      region                      = "eu01"
+      skip_credentials_validation = true
+      skip_region_validation      = true
+      skip_requesting_account_id  = true
+
+      access_key                  = stackit_objectstorage_credential.example.access_key
+      secret_key                  = stackit_objectstorage_credential.example.secret_access_key
+
+      endpoints {
+         s3 = "https://object.storage.eu01.onstackit.cloud"
+      }
+   }
+    ```
+
+4. **Use the provider to manage objects or policies**
+
+    ```hcl
+      resource "aws_s3_object" "test_file" {
+         bucket = stackit_objectstorage_bucket.example.name
+         key    = "hello_world.txt"
+         source = "files/hello_world.txt"
+         content_type = "text/plain"
+         etag = filemd5("files/hello_world.txt")
+      }
+
+      resource "aws_s3_bucket_policy" "allow_public_read_access" {
+         bucket = stackit_objectstorage_bucket.test20.name
+         policy = <<EOF
+         {
+            "Statement":[
+               {
+               "Sid": "Public GET",
+               "Effect":"Allow",
+               "Principal":"*",
+               "Action":"s3:GetObject",
+               "Resource":"urn:sgws:s3:::example/*"
+               }
+            ]
+         }
+         EOF
+      }
+    ```

--- a/docs/guides/aws_provider_s3_stackit.md
+++ b/docs/guides/aws_provider_s3_stackit.md
@@ -1,11 +1,11 @@
 ---
-page_title: "Using AWS Provider for STACKIT S3"
+page_title: "Using AWS Provider for STACKIT Object Storage (S3 compatible)"
 ---
-# Using AWS Provider for STACKIT S3
+# Using AWS Provider for STACKIT Object Storage (S3 compatible)
 
 ## Overview
 
-This guide outlines the process of utilizing the [AWS Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) alongside the STACKIT provider to create and manage STACKIT S3 ressources.
+This guide outlines the process of utilizing the [AWS Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) alongside the STACKIT provider to create and manage STACKIT Object Storage (S3 compatible) ressources.
 
 ## Steps
 
@@ -19,23 +19,23 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
     }
     ```
 
-2. **Define STACKIT S3 Bucket**
+2. **Define STACKIT Object Storage Bucket**
 
-    Create a STACKIT S3 Bucket and obtain credentials for the AWS provider.
+    Create a STACKIT Object Storage Bucket and obtain credentials for the AWS provider.
 
     ```hcl
     resource "stackit_objectstorage_bucket" "example" {
-      project_id = ""
+      project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       name       = "example"
     }
 
     resource "stackit_objectstorage_credentials_group" "example" {
-      project_id = ""
+      project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       name       = "example-credentials-group"
    }
 
    resource "stackit_objectstorage_credential" "example" {
-      project_id           = ""
+      project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       credentials_group_id = stackit_objectstorage_credentials_group.example.credentials_group_id
       expiration_timestamp = "2027-01-02T03:04:05Z"
    }
@@ -43,7 +43,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
 
 3. **Configure AWS Provider**
 
-   Configure the AWS Provider to connect to the STACKIT S3 bucket.
+   Configure the AWS Provider to connect to the STACKIT Object Storage bucket.
 
     ```hcl
     provider "aws" {

--- a/templates/guides/aws_provider_s3_stackit.md.tmpl
+++ b/templates/guides/aws_provider_s3_stackit.md.tmpl
@@ -39,7 +39,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
       credentials_group_id = stackit_objectstorage_credentials_group.example.credentials_group_id
       expiration_timestamp = "2027-01-02T03:04:05Z"
    }
-    ```
+   ```
 
 3. **Configure AWS Provider**
 
@@ -59,33 +59,33 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
          s3 = "https://object.storage.eu01.onstackit.cloud"
       }
    }
-    ```
+   ```
 
 4. **Use the provider to manage objects or policies**
 
     ```hcl
-      resource "aws_s3_object" "test_file" {
-         bucket = stackit_objectstorage_bucket.example.name
-         key    = "hello_world.txt"
-         source = "files/hello_world.txt"
-         content_type = "text/plain"
-         etag = filemd5("files/hello_world.txt")
-      }
+    resource "aws_s3_object" "test_file" {
+     bucket = stackit_objectstorage_bucket.example.name
+     key    = "hello_world.txt"
+     source = "files/hello_world.txt"
+     content_type = "text/plain"
+     etag = filemd5("files/hello_world.txt")
+    }
 
-      resource "aws_s3_bucket_policy" "allow_public_read_access" {
-         bucket = stackit_objectstorage_bucket.test20.name
-         policy = <<EOF
-         {
-            "Statement":[
-               {
-               "Sid": "Public GET",
-               "Effect":"Allow",
-               "Principal":"*",
-               "Action":"s3:GetObject",
-               "Resource":"urn:sgws:s3:::example/*"
-               }
-            ]
-         }
-         EOF
-      }
+    resource "aws_s3_bucket_policy" "allow_public_read_access" {
+     bucket = stackit_objectstorage_bucket.test20.name
+     policy = <<EOF
+     {
+        "Statement":[
+           {
+           "Sid": "Public GET",
+           "Effect":"Allow",
+           "Principal":"*",
+           "Action":"s3:GetObject",
+           "Resource":"urn:sgws:s3:::example/*"
+           }
+        ]
+     }
+     EOF
+    }
     ```

--- a/templates/guides/aws_provider_s3_stackit.md.tmpl
+++ b/templates/guides/aws_provider_s3_stackit.md.tmpl
@@ -1,0 +1,91 @@
+---
+page_title: "Using AWS Provider for STACKIT S3"
+---
+# Using AWS Provider for STACKIT S3
+
+## Overview
+
+This guide outlines the process of utilizing the [AWS Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) alongside the STACKIT provider to create and manage STACKIT S3 ressources.
+
+## Steps
+
+1. **Configure STACKIT Provider**
+
+    First, configure the STACKIT provider to connect to the STACKIT services.
+
+    ```hcl
+    provider "stackit" {
+      region = "eu01"
+    }
+    ```
+
+2. **Define STACKIT S3 Bucket**
+
+    Create a STACKIT S3 Bucket and obtain credentials for the AWS provider.
+
+    ```hcl
+    resource "stackit_objectstorage_bucket" "example" {
+      project_id = ""
+      name       = "example"
+    }
+
+    resource "stackit_objectstorage_credentials_group" "example" {
+      project_id = ""
+      name       = "example-credentials-group"
+   }
+
+   resource "stackit_objectstorage_credential" "example" {
+      project_id           = ""
+      credentials_group_id = stackit_objectstorage_credentials_group.example.credentials_group_id
+      expiration_timestamp = "2027-01-02T03:04:05Z"
+   }
+    ```
+
+3. **Configure AWS Provider**
+
+   Configure the AWS Provider to connect to the STACKIT S3 bucket.
+
+    ```hcl
+    provider "aws" {
+      region                      = "eu01"
+      skip_credentials_validation = true
+      skip_region_validation      = true
+      skip_requesting_account_id  = true
+
+      access_key                  = stackit_objectstorage_credential.example.access_key
+      secret_key                  = stackit_objectstorage_credential.example.secret_access_key
+
+      endpoints {
+         s3 = "https://object.storage.eu01.onstackit.cloud"
+      }
+   }
+    ```
+
+4. **Use the provider to manage objects or policies**
+
+    ```hcl
+      resource "aws_s3_object" "test_file" {
+         bucket = stackit_objectstorage_bucket.example.name
+         key    = "hello_world.txt"
+         source = "files/hello_world.txt"
+         content_type = "text/plain"
+         etag = filemd5("files/hello_world.txt")
+      }
+
+      resource "aws_s3_bucket_policy" "allow_public_read_access" {
+         bucket = stackit_objectstorage_bucket.test20.name
+         policy = <<EOF
+         {
+            "Statement":[
+               {
+               "Sid": "Public GET",
+               "Effect":"Allow",
+               "Principal":"*",
+               "Action":"s3:GetObject",
+               "Resource":"urn:sgws:s3:::example/*"
+               }
+            ]
+         }
+         EOF
+      }
+    ```

--- a/templates/guides/aws_provider_s3_stackit.md.tmpl
+++ b/templates/guides/aws_provider_s3_stackit.md.tmpl
@@ -1,11 +1,11 @@
 ---
-page_title: "Using AWS Provider for STACKIT S3"
+page_title: "Using AWS Provider for STACKIT Object Storage (S3 compatible)"
 ---
-# Using AWS Provider for STACKIT S3
+# Using AWS Provider for STACKIT Object Storage (S3 compatible)
 
 ## Overview
 
-This guide outlines the process of utilizing the [AWS Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) alongside the STACKIT provider to create and manage STACKIT S3 ressources.
+This guide outlines the process of utilizing the [AWS Terraform Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) alongside the STACKIT provider to create and manage STACKIT Object Storage (S3 compatible) ressources.
 
 ## Steps
 
@@ -19,23 +19,23 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
     }
     ```
 
-2. **Define STACKIT S3 Bucket**
+2. **Define STACKIT Object Storage Bucket**
 
-    Create a STACKIT S3 Bucket and obtain credentials for the AWS provider.
+    Create a STACKIT Object Storage Bucket and obtain credentials for the AWS provider.
 
     ```hcl
     resource "stackit_objectstorage_bucket" "example" {
-      project_id = ""
+      project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       name       = "example"
     }
 
     resource "stackit_objectstorage_credentials_group" "example" {
-      project_id = ""
+      project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       name       = "example-credentials-group"
    }
 
    resource "stackit_objectstorage_credential" "example" {
-      project_id           = ""
+      project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       credentials_group_id = stackit_objectstorage_credentials_group.example.credentials_group_id
       expiration_timestamp = "2027-01-02T03:04:05Z"
    }
@@ -43,7 +43,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
 
 3. **Configure AWS Provider**
 
-   Configure the AWS Provider to connect to the STACKIT S3 bucket.
+   Configure the AWS Provider to connect to the STACKIT Object Storage bucket.
 
     ```hcl
     provider "aws" {


### PR DESCRIPTION
This guide explains how to integrate the official AWS S3 Provider with our custom provider to manage STACKIT S3 Storage.  I used `make generate-docs` to regenerate the Terraform Registry documentation.

