### PR TITLE
fix: Make SKE cluster hibernations timezone field Computed

### DIFF
--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -564,6 +564,10 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 						"timezone": schema.StringAttribute{
 							Description: "Timezone name corresponding to a file in the IANA Time Zone database. i.e. `Europe/Berlin`.",
 							Optional:    true,
+							Computed:    true,
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
- Fixes an issue where the field is returned in the API response even if not configured in Terraform, which was causing an inconsistent result after apply
- This makes it Computed also (besides Optional), so the field will be `(known after apply)` on creation