### PR TITLE
improve resource documentation for STACKIT LoadBalancer Service

### DIFF
--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -64,7 +64,9 @@ provider "openstack" {
 
 ### Configuring the supporting infrastructure
 
-The example below uses OpenStack to create the network, router, a public IP address and a compute instance.
+The example below uses OpenStack to create the network, router, a public IP address and a compute instance.  
+The STACKIT Loadbalancer Service automatically adjust necessary Security Groups to its targets,  
+to avoid unnecessary changes in the terraform plan utilising the lifecycle function of terraform can be used.
 
 ## Example Usage
 
@@ -115,6 +117,11 @@ resource "openstack_compute_instance_v2" "example" {
 
   network {
     name = openstack_networking_network_v2.example.name
+  }
+  
+  lifecycle {
+    # Security groups are modified by the STACKIT LoadBalancer Service, so terraform should ignore changes here
+    ignore_changes        = [security_groups]
   }
 }
 

--- a/examples/resources/stackit_loadbalancer/resource.tf
+++ b/examples/resources/stackit_loadbalancer/resource.tf
@@ -48,7 +48,7 @@ resource "openstack_compute_instance_v2" "example" {
 
   lifecycle {
     # Security groups are modified by the STACKIT LoadBalancer Service, so terraform should ignore changes here
-    ignore_changes        = [security_groups]
+    ignore_changes = [security_groups]
   }
 }
 

--- a/examples/resources/stackit_loadbalancer/resource.tf
+++ b/examples/resources/stackit_loadbalancer/resource.tf
@@ -45,6 +45,11 @@ resource "openstack_compute_instance_v2" "example" {
   network {
     name = openstack_networking_network_v2.example.name
   }
+
+  lifecycle {
+    # Security groups are modified by the STACKIT LoadBalancer Service, so terraform should ignore changes here
+    ignore_changes        = [security_groups]
+  }
 }
 
 # Create a router and attach it to the public network


### PR DESCRIPTION
Add a hint on the Access LoadBalancer Service behaviour to adjust security groups of its targets automatically. 
Also add a suggestion to circumvent this behaviour to not fight over security group ownership.