### PR TITLE
Fix public IP update always removing NIC association

### DIFF
--- a/stackit/internal/services/iaas/publicip/resource.go
+++ b/stackit/internal/services/iaas/publicip/resource.go
@@ -447,7 +447,5 @@ func toUpdatePayload(ctx context.Context, model *Model, currentLabels types.Map)
 		payload.NetworkInterface = iaas.NewNullableString(nil)
 	}
 
-	tflog.Warn(ctx, fmt.Sprintf("payload.NetworkInterface: %v", payload.NetworkInterface))
-
 	return payload, nil
 }


### PR DESCRIPTION
- Fixes an issue where `terraform apply`s detect drifts in the `stackit_public_ip` resource and removes existing network interface association when the user did not specify a `network_interface_id` in the config
- This makes the field `Computed` (besides `Optional`), and changes the update behaviour to not override an existing value if the field is Unknown, which makes it so that if the user does not specify the `network_interface_id` field in the config, Terraform would consider it a Computed field and would not attempt to update it