### PR TITLE
Fix inconsistent result after apply in SKE cluster node pool taint value

### DIFF
--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -485,6 +485,7 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 									"value": schema.StringAttribute{
 										Description: "Taint value corresponding to the taint key.",
 										Optional:    true,
+										Computed:    true,
 									},
 								},
 							},

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -486,6 +486,9 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 										Description: "Taint value corresponding to the taint key.",
 										Optional:    true,
 										Computed:    true,
+										PlanModifiers: []planmodifier.String{
+											stringplanmodifier.UseStateForUnknown(),
+										},
 									},
 								},
 							},


### PR DESCRIPTION
- Fixes an inconsistent result after apply in SKE cluster node pool taint value
- Error occured when a `stackit_ske_cluster.nodepool[x].taints[x].value` was left empty in the config, since the API returns `""` in this case (instead of not providing the field in the response)
- Making the field Computed is enough to fix the issue