### PR TITLE
Deprecate service_account_email config

### DIFF
--- a/stackit/internal/core/core.go
+++ b/stackit/internal/core/core.go
@@ -15,7 +15,7 @@ const Separator = ","
 
 type ProviderData struct {
 	RoundTripper                    http.RoundTripper
-	ServiceAccountEmail             string
+	ServiceAccountEmail             string // Deprecated: ServiceAccountEmail is not required and will be removed after 12th July 2025.
 	Region                          string
 	ArgusCustomEndpoint             string
 	AuthorizationCustomEndpoint     string

--- a/stackit/internal/services/resourcemanager/project/datasource.go
+++ b/stackit/internal/services/resourcemanager/project/datasource.go
@@ -62,13 +62,11 @@ func (d *projectDataSource) Configure(ctx context.Context, req datasource.Config
 	if providerData.ResourceManagerCustomEndpoint != "" {
 		rmClient, err = resourcemanager.NewAPIClient(
 			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithServiceAccountEmail(providerData.ServiceAccountEmail),
 			config.WithEndpoint(providerData.ResourceManagerCustomEndpoint),
 		)
 	} else {
 		rmClient, err = resourcemanager.NewAPIClient(
 			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithServiceAccountEmail(providerData.ServiceAccountEmail),
 		)
 	}
 	if err != nil {

--- a/stackit/internal/services/resourcemanager/project/resource.go
+++ b/stackit/internal/services/resourcemanager/project/resource.go
@@ -107,13 +107,11 @@ func (r *projectResource) Configure(ctx context.Context, req resource.ConfigureR
 		ctx = tflog.SetField(ctx, "resourcemanager_custom_endpoint", providerData.ResourceManagerCustomEndpoint)
 		rmClient, err = resourcemanager.NewAPIClient(
 			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithServiceAccountEmail(providerData.ServiceAccountEmail),
 			config.WithEndpoint(providerData.ResourceManagerCustomEndpoint),
 		)
 	} else {
 		rmClient, err = resourcemanager.NewAPIClient(
 			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithServiceAccountEmail(providerData.ServiceAccountEmail),
 		)
 	}
 
@@ -277,12 +275,6 @@ func (r *projectResource) Create(ctx context.Context, req resource.CreateRequest
 
 	containerId := model.ContainerId.ValueString()
 	ctx = tflog.SetField(ctx, "project_container_id", containerId)
-
-	serviceAccountEmail := r.resourceManagerClient.GetConfig().ServiceAccountEmail
-	if serviceAccountEmail == "" {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating project", "The service account e-mail cannot be empty: set it in the provider configuration or through the STACKIT_SERVICE_ACCOUNT_EMAIL or in your credentials file (default filepath is ~/.stackit/credentials.json)")
-		return
-	}
 
 	// Generate API request body from model
 	payload, err := toCreatePayload(ctx, &model)

--- a/stackit/provider.go
+++ b/stackit/provider.go
@@ -94,7 +94,7 @@ func (p *Provider) Metadata(_ context.Context, _ provider.MetadataRequest, resp 
 
 type providerModel struct {
 	CredentialsFilePath             types.String `tfsdk:"credentials_path"`
-	ServiceAccountEmail             types.String `tfsdk:"service_account_email"`
+	ServiceAccountEmail             types.String `tfsdk:"service_account_email"` // Deprecated: ServiceAccountEmail is not required and will be removed after 12th July 2025
 	ServiceAccountKey               types.String `tfsdk:"service_account_key"`
 	ServiceAccountKeyPath           types.String `tfsdk:"service_account_key_path"`
 	PrivateKey                      types.String `tfsdk:"private_key"`
@@ -167,8 +167,9 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 				Description: descriptions["credentials_path"],
 			},
 			"service_account_email": schema.StringAttribute{
-				Optional:    true,
-				Description: descriptions["service_account_email"],
+				Optional:           true,
+				Description:        descriptions["service_account_email"],
+				DeprecationMessage: "service_account_email has been deprecated because it is not required. Will be removed after July 12th 2025.",
 			},
 			"service_account_token": schema.StringAttribute{
 				Optional:    true,
@@ -302,10 +303,6 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	var providerData core.ProviderData
 	if !(providerConfig.CredentialsFilePath.IsUnknown() || providerConfig.CredentialsFilePath.IsNull()) {
 		sdkConfig.CredentialsFilePath = providerConfig.CredentialsFilePath.ValueString()
-	}
-	if !(providerConfig.ServiceAccountEmail.IsUnknown() || providerConfig.ServiceAccountEmail.IsNull()) {
-		providerData.ServiceAccountEmail = providerConfig.ServiceAccountEmail.ValueString()
-		sdkConfig.ServiceAccountEmail = providerConfig.ServiceAccountEmail.ValueString()
 	}
 	if !(providerConfig.ServiceAccountKey.IsUnknown() || providerConfig.ServiceAccountKey.IsNull()) {
 		sdkConfig.ServiceAccountKey = providerConfig.ServiceAccountKey.ValueString()


### PR DESCRIPTION
Deprecated service_account_email config, because it is not required and could be also extracted from the JWT if needed