### PR TITLE
fix: Updating values of "stackit_server" leads to an inconsistent result

### DIFF
--- a/stackit/internal/services/iaas/server/resource.go
+++ b/stackit/internal/services/iaas/server/resource.go
@@ -694,11 +694,10 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error retrieving server state", fmt.Sprintf("Getting server state: %v", err))
 	}
 
-	var updatedServer *iaas.Server
 	if model.DesiredStatus.ValueString() == modelStateDeallocated {
 		// if the target state is "deallocated", we have to perform the server update first
 		// and then shelve it afterwards. A shelved server cannot be updated
-		updatedServer, err = r.updateServerAttributes(ctx, &model, &stateModel)
+		_, err = r.updateServerAttributes(ctx, &model, &stateModel)
 		if err != nil {
 			core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating server", err.Error())
 			return
@@ -715,7 +714,7 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 			return
 		}
 
-		updatedServer, err = r.updateServerAttributes(ctx, &model, &stateModel)
+		_, err = r.updateServerAttributes(ctx, &model, &stateModel)
 		if err != nil {
 			core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating server", err.Error())
 			return
@@ -725,7 +724,7 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 	// Re-fetch the server data, to get the details values.
 	serverReq := r.client.GetServer(ctx, projectId, serverId)
 	serverReq = serverReq.Details(true)
-	updatedServer, err = serverReq.Execute()
+	updatedServer, err := serverReq.Execute()
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating server", fmt.Sprintf("Calling API: %v", err))
 		return

--- a/stackit/internal/services/iaas/server/resource.go
+++ b/stackit/internal/services/iaas/server/resource.go
@@ -722,6 +722,15 @@ func (r *serverResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
+	// Re-fetch the server data, to get the details values.
+	serverReq := r.client.GetServer(ctx, projectId, serverId)
+	serverReq = serverReq.Details(true)
+	updatedServer, err = serverReq.Execute()
+	if err != nil {
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating server", fmt.Sprintf("Calling API: %v", err))
+		return
+	}
+
 	err = mapFields(ctx, updatedServer, &model)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating server", fmt.Sprintf("Processing API payload: %v", err))


### PR DESCRIPTION
If you set "network_interfaces" in "stackit_server" and then apply an update to the server (e.g. if the name has changed), you will get an inconsistent result.