### PR TITLE
Feat: add egress_address_ranges attribute to ske resource

### DIFF
--- a/docs/data-sources/ske_cluster.md
+++ b/docs/data-sources/ske_cluster.md
@@ -32,6 +32,7 @@ data "stackit_ske_cluster" "example" {
 - `allow_privileged_containers` (Boolean, Deprecated) DEPRECATED as of Kubernetes 1.25+
  Flag to specify if privileged mode for containers is enabled or not.
 This should be used with care since it also disables a couple of other features like the use of some volume type (e.g. PVCs).
+- `egress_address_ranges` (List of String) The outgoing network ranges (in CIDR notation) of traffic originating from workload on the cluster.
 - `extensions` (Attributes) A single extensions block as defined below (see [below for nested schema](#nestedatt--extensions))
 - `hibernations` (Attributes List) One or more hibernation block as defined below. (see [below for nested schema](#nestedatt--hibernations))
 - `id` (String) Terraform's internal data source. ID. It is structured as "`project_id`,`name`".

--- a/docs/resources/ske_cluster.md
+++ b/docs/resources/ske_cluster.md
@@ -62,6 +62,7 @@ Deprecated as of Kubernetes 1.25 and later
 
 ### Read-Only
 
+- `egress_address_ranges` (List of String) The outgoing network ranges (in CIDR notation) of traffic originating from workload on the cluster.
 - `id` (String) Terraform's internal resource ID. It is structured as "`project_id`,`name`".
 - `kubernetes_version_used` (String) Full Kubernetes version used. For example, if 1.22 was set in `kubernetes_version_min`, this value may result to 1.22.15. SKE automatically updates the cluster Kubernetes version if you have set `maintenance.enable_kubernetes_version_updates` to true or if there is a mandatory update, as described in [Updates for Kubernetes versions and Operating System versions in SKE](https://docs.stackit.cloud/stackit/en/version-updates-in-ske-10125631.html).
 

--- a/stackit/internal/services/ske/cluster/datasource.go
+++ b/stackit/internal/services/ske/cluster/datasource.go
@@ -110,7 +110,12 @@ func (r *clusterDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				DeprecationMessage: "Please remove this flag from your configuration when using Kubernetes version 1.25+.",
 				Computed:           true,
 			},
-
+			"egress_address_ranges": schema.ListAttribute{
+				Description: "The outgoing network ranges (in CIDR notation) of traffic originating from workload on the cluster.",
+				Computed:    true,
+				Optional:    true,
+				ElementType: types.StringType,
+			},
 			"node_pools": schema.ListNestedAttribute{
 				Description: "One or more `node_pool` block as defined below.",
 				Computed:    true,

--- a/stackit/internal/services/ske/cluster/datasource.go
+++ b/stackit/internal/services/ske/cluster/datasource.go
@@ -113,7 +113,6 @@ func (r *clusterDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			"egress_address_ranges": schema.ListAttribute{
 				Description: "The outgoing network ranges (in CIDR notation) of traffic originating from workload on the cluster.",
 				Computed:    true,
-				Optional:    true,
 				ElementType: types.StringType,
 			},
 			"node_pools": schema.ListNestedAttribute{

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -378,7 +378,6 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"egress_address_ranges": schema.ListAttribute{
 				Description: "The outgoing network ranges (in CIDR notation) of traffic originating from workload on the cluster.",
 				Computed:    true,
-				Optional:    true,
 				ElementType: types.StringType,
 			},
 			"node_pools": schema.ListNestedAttribute{

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -77,6 +77,7 @@ type Model struct {
 	Network                   types.Object `tfsdk:"network"`
 	Hibernations              types.List   `tfsdk:"hibernations"`
 	Extensions                types.Object `tfsdk:"extensions"`
+	EgressAddressRanges       types.List   `tfsdk:"egress_address_ranges"`
 }
 
 // Struct corresponding to Model.NodePools[i]
@@ -373,6 +374,12 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"allow_privileged_containers": schema.BoolAttribute{
 				Description: "Flag to specify if privileged mode for containers is enabled or not.\nThis should be used with care since it also disables a couple of other features like the use of some volume type (e.g. PVCs).\nDeprecated as of Kubernetes 1.25 and later",
 				Optional:    true,
+			},
+			"egress_address_ranges": schema.ListAttribute{
+				Description: "The outgoing network ranges (in CIDR notation) of traffic originating from workload on the cluster.",
+				Computed:    true,
+				Optional:    true,
+				ElementType: types.StringType,
 			},
 			"node_pools": schema.ListNestedAttribute{
 				Description: "One or more `node_pool` block as defined below.",
@@ -1318,6 +1325,15 @@ func mapFields(ctx context.Context, cl *ske.Cluster, m *Model) error {
 	if cl.Kubernetes != nil {
 		m.KubernetesVersionUsed = types.StringPointerValue(cl.Kubernetes.Version)
 		m.AllowPrivilegedContainers = types.BoolPointerValue(cl.Kubernetes.AllowPrivilegedContainers)
+	}
+
+	m.EgressAddressRanges = types.ListNull(types.StringType)
+	if cl.Status != nil {
+		var diags diag.Diagnostics
+		m.EgressAddressRanges, diags = types.ListValueFrom(ctx, types.StringType, cl.Status.EgressAddressRanges)
+		if diags.HasError() {
+			return fmt.Errorf("map egressAddressRanges: %w", core.DiagsToError(diags))
+		}
 	}
 
 	err := mapNodePools(ctx, cl, m)

--- a/stackit/internal/services/ske/cluster/resource_test.go
+++ b/stackit/internal/services/ske/cluster/resource_test.go
@@ -57,6 +57,7 @@ func TestMapFields(t *testing.T) {
 				Network:                   types.ObjectNull(networkTypes),
 				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
 				Extensions:                types.ObjectNull(extensionsTypes),
+				EgressAddressRanges:       types.ListNull(types.StringType),
 			},
 			true,
 		},
@@ -140,9 +141,10 @@ func TestMapFields(t *testing.T) {
 					},
 				},
 				Status: &ske.ClusterStatus{
-					Aggregated: &cs,
-					Error:      nil,
-					Hibernated: nil,
+					Aggregated:          &cs,
+					Error:               nil,
+					Hibernated:          nil,
+					EgressAddressRanges: &[]string{"0.0.0.0/32", "1.1.1.1/32"},
 				},
 			},
 			Model{
@@ -152,7 +154,13 @@ func TestMapFields(t *testing.T) {
 				KubernetesVersion:         types.StringNull(),
 				KubernetesVersionUsed:     types.StringValue("1.2.3"),
 				AllowPrivilegedContainers: types.BoolValue(true),
-
+				EgressAddressRanges: types.ListValueMust(
+					types.StringType,
+					[]attr.Value{
+						types.StringValue("0.0.0.0/32"),
+						types.StringValue("1.1.1.1/32"),
+					},
+				),
 				NodePools: types.ListValueMust(
 					types.ObjectType{AttrTypes: nodePoolTypes},
 					[]attr.Value{
@@ -265,6 +273,7 @@ func TestMapFields(t *testing.T) {
 				Network:                   types.ObjectNull(networkTypes),
 				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
 				Extensions:                types.ObjectNull(extensionsTypes),
+				EgressAddressRanges:       types.ListNull(types.StringType),
 			},
 			true,
 		},
@@ -298,6 +307,7 @@ func TestMapFields(t *testing.T) {
 				NodePools:                 types.ListNull(types.ObjectType{AttrTypes: nodePoolTypes}),
 				Maintenance:               types.ObjectNull(maintenanceTypes),
 				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
+				EgressAddressRanges:       types.ListNull(types.StringType),
 				Extensions: types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
 					"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
 						"enabled":       types.BoolValue(true),
@@ -345,6 +355,7 @@ func TestMapFields(t *testing.T) {
 				NodePools:                 types.ListNull(types.ObjectType{AttrTypes: nodePoolTypes}),
 				Maintenance:               types.ObjectNull(maintenanceTypes),
 				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
+				EgressAddressRanges:       types.ListNull(types.StringType),
 				Extensions: types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
 					"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
 						"enabled":       types.BoolValue(false),
@@ -403,6 +414,7 @@ func TestMapFields(t *testing.T) {
 				NodePools:                 types.ListNull(types.ObjectType{AttrTypes: nodePoolTypes}),
 				Maintenance:               types.ObjectNull(maintenanceTypes),
 				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
+				EgressAddressRanges:       types.ListNull(types.StringType),
 				Extensions: types.ObjectValueMust(extensionsTypes, map[string]attr.Value{
 					"acl": types.ObjectValueMust(aclTypes, map[string]attr.Value{
 						"enabled": types.BoolValue(true),
@@ -440,6 +452,7 @@ func TestMapFields(t *testing.T) {
 				Maintenance:               types.ObjectNull(maintenanceTypes),
 				Hibernations:              types.ListNull(types.ObjectType{AttrTypes: hibernationTypes}),
 				Extensions:                types.ObjectNull(extensionsTypes),
+				EgressAddressRanges:       types.ListNull(types.StringType),
 			},
 			true,
 		},
@@ -565,6 +578,7 @@ func TestMapFields(t *testing.T) {
 				KubernetesVersion:         types.StringNull(),
 				KubernetesVersionUsed:     types.StringValue("1.2.3"),
 				AllowPrivilegedContainers: types.BoolValue(true),
+				EgressAddressRanges:       types.ListNull(types.StringType),
 				NodePools: types.ListValueMust(
 					types.ObjectType{AttrTypes: nodePoolTypes},
 					[]attr.Value{


### PR DESCRIPTION
Added the new attribute `egress_address_ranges` from the ske api to the terraform provider ressource.

I've adjusted the tests and run the commands:
make fmt
make test

I've also manually tested the changes by building the go binary and creating a new ske cluster. I've also checked that a user is able to downgrade/upgrade tf provider versions (back and forth from v.0.40 to this version and checked the state manually).


Thank you :-)
