### PR TITLE
Suggestion: remove list of beta resources

### DIFF
--- a/docs/guides/opting_into_beta_resources.md
+++ b/docs/guides/opting_into_beta_resources.md
@@ -33,15 +33,3 @@ export STACKIT_TF_ENABLE_BETA_RESOURCES=true
 ```
 
 -> The environment variable takes precedence over the provider configuration option. This means that if the `STACKIT_TF_ENABLE_BETA_RESOURCES` environment variable is set to a valid value (`"true"` or `"false"`), it will override the `enable_beta_resources` option specified in the provider configuration.
-
-## Listing Beta Resources
-
-- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/server_backup_schedule)
-- [`stackit_network_area`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/network_area)
-- [`stackit_network_area_route`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/network_area_route)
-
-## Listing Beta Data Sources
-
-- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedule)
-- [`stackit_server_backup_schedules`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedules)
-- [`stackit_network_area_route`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/network_area_route)

--- a/templates/guides/opting_into_beta_resources.md.tmpl
+++ b/templates/guides/opting_into_beta_resources.md.tmpl
@@ -33,15 +33,3 @@ export STACKIT_TF_ENABLE_BETA_RESOURCES=true
 ```
 
 -> The environment variable takes precedence over the provider configuration option. This means that if the `STACKIT_TF_ENABLE_BETA_RESOURCES` environment variable is set to a valid value (`"true"` or `"false"`), it will override the `enable_beta_resources` option specified in the provider configuration.
-
-## Listing Beta Resources
-
-- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/server_backup_schedule)
-- [`stackit_network_area`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/network_area)
-- [`stackit_network_area_route`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/network_area_route)
-
-## Listing Beta Data Sources
-
-- [`stackit_server_backup_schedule`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedule)
-- [`stackit_server_backup_schedules`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/server_backup_schedules)
-- [`stackit_network_area_route`](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/data-sources/network_area_route)


### PR DESCRIPTION
Let's remove the list of beta resources in our docs. This list is not up to date and I don't see a good way to automate it. 