### PR TITLE
fix(network-interface): Response returns name "" if not set

### DIFF
--- a/stackit/internal/services/iaas/networkinterface/resource.go
+++ b/stackit/internal/services/iaas/networkinterface/resource.go
@@ -532,8 +532,13 @@ func mapFields(ctx context.Context, networkInterfaceResp *iaas.NIC, model *Model
 		labels = types.MapNull(types.StringType)
 	}
 
+	networkInterfaceName := types.StringNull()
+	if networkInterfaceResp.Name != nil && *networkInterfaceResp.Name != "" {
+		networkInterfaceName = types.StringPointerValue(networkInterfaceResp.Name)
+	}
+
 	model.NetworkInterfaceId = types.StringValue(networkInterfaceId)
-	model.Name = types.StringPointerValue(networkInterfaceResp.Name)
+	model.Name = networkInterfaceName
 	model.IPv4 = types.StringPointerValue(networkInterfaceResp.Ipv4)
 	model.Security = types.BoolPointerValue(networkInterfaceResp.NicSecurity)
 	model.Device = types.StringPointerValue(networkInterfaceResp.Device)


### PR DESCRIPTION
This has to be set to a nil value otherwise a name "" is sent via the next request which results in a failing validator

fixes #704