### PR TITLE
Feat: Service Plan support for Load Balancers

### DIFF
--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -72,6 +72,7 @@ resource "stackit_server_network_interface_attach" "nic-attachment" {
 resource "stackit_loadbalancer" "example" {
   project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name       = "example-load-balancer"
+  plan_id    = "p10"
   target_pools = [
     {
       name        = "example-target-pool"
@@ -126,6 +127,7 @@ resource "stackit_loadbalancer" "example" {
 ### Optional
 
 - `external_address` (String) External Load Balancer IP address where this Load Balancer is exposed.
+- `plan_id` (String) The service plan ID. Defaults to p10. See the API docs for a list of available plans.
 - `options` (Attributes) Defines any optional functionality you want to have enabled on your load balancer. (see [below for nested schema](#nestedatt--options))
 
 ### Read-Only

--- a/examples/resources/stackit_loadbalancer/resource.tf
+++ b/examples/resources/stackit_loadbalancer/resource.tf
@@ -53,6 +53,7 @@ resource "stackit_server_network_interface_attach" "nic-attachment" {
 resource "stackit_loadbalancer" "example" {
   project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name       = "example-load-balancer"
+  plan_id    = "p10"
   target_pools = [
     {
       name        = "example-target-pool"

--- a/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
@@ -89,6 +89,7 @@ func (r *loadBalancerDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 		"protocol":                    "Protocol is the highest network protocol we understand to load balance.",
 		"target_pool":                 "Reference target pool by target pool name.",
 		"name":                        "Load balancer name.",
+		"plan_id":                     "The service plan ID. Defaults to p10. See the API docs for a list of available plans.",
 		"networks":                    "List of networks that listeners and targets reside in.",
 		"network_id":                  "Openstack network ID.",
 		"role":                        "The role defines how the load balancer is using the network.",
@@ -129,6 +130,10 @@ func (r *loadBalancerDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 			},
 			"external_address": schema.StringAttribute{
 				Description: descriptions["external_address"],
+				Computed:    true,
+			},
+			"plan_id": schema.StringAttribute{
+				Description: descriptions["plan_id"],
 				Computed:    true,
 			},
 			"listeners": schema.ListNestedAttribute{

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -50,6 +50,7 @@ type Model struct {
 	ExternalAddress types.String `tfsdk:"external_address"`
 	Listeners       types.List   `tfsdk:"listeners"`
 	Name            types.String `tfsdk:"name"`
+	PlanId          types.String `tfsdk:"plan_id"`
 	Networks        types.List   `tfsdk:"networks"`
 	Options         types.Object `tfsdk:"options"`
 	PrivateAddress  types.String `tfsdk:"private_address"`
@@ -233,6 +234,7 @@ func (r *loadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 		"protocol":                    "Protocol is the highest network protocol we understand to load balance. " + utils.SupportedValuesDocumentation(protocolOptions),
 		"target_pool":                 "Reference target pool by target pool name.",
 		"name":                        "Load balancer name.",
+		"plan_id":                     "The service plan ID. Defaults to p10. See the API docs for a list of available plans.",
 		"networks":                    "List of networks that listeners and targets reside in.",
 		"network_id":                  "Openstack network ID.",
 		"role":                        "The role defines how the load balancer is using the network. " + utils.SupportedValuesDocumentation(roleOptions),
@@ -284,6 +286,13 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 			},
 			"external_address": schema.StringAttribute{
 				Description: descriptions["external_address"],
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"plan_id": schema.StringAttribute{
+				Description: descriptions["plan_id"],
 				Optional:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -758,6 +767,7 @@ func toCreatePayload(ctx context.Context, model *Model) (*loadbalancer.CreateLoa
 		ExternalAddress: conversion.StringValueToPointer(model.ExternalAddress),
 		Listeners:       listenersPayload,
 		Name:            conversion.StringValueToPointer(model.Name),
+		PlanId:          conversion.StringValueToPointer(model.PlanId),
 		Networks:        networksPayload,
 		Options:         optionsPayload,
 		TargetPools:     targetPoolsPayload,
@@ -1037,6 +1047,7 @@ func mapFields(ctx context.Context, lb *loadbalancer.LoadBalancer, m *Model) err
 		strings.Join(idParts, core.Separator),
 	)
 
+	m.PlanId = types.StringPointerValue(lb.PlanId)
 	m.ExternalAddress = types.StringPointerValue(lb.ExternalAddress)
 	m.PrivateAddress = types.StringPointerValue(lb.PrivateAddress)
 

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource_test.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource_test.go
@@ -158,6 +158,129 @@ func TestToCreatePayload(t *testing.T) {
 			true,
 		},
 		{
+			"service_plans_ok",
+			&Model{
+				PlanId:          types.StringValue("p250"),
+				ExternalAddress: types.StringValue("external_address"),
+				Listeners: types.ListValueMust(types.ObjectType{AttrTypes: listenerTypes}, []attr.Value{
+					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
+						"display_name": types.StringValue("display_name"),
+						"port":         types.Int64Value(80),
+						"protocol":     types.StringValue("protocol"),
+						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
+							types.ObjectValueMust(
+								serverNameIndicatorTypes,
+								map[string]attr.Value{
+									"name": types.StringValue("domain.com"),
+								},
+							),
+						},
+						),
+						"target_pool": types.StringValue("target_pool"),
+					}),
+				}),
+				Name: types.StringValue("name"),
+				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
+					types.ObjectValueMust(networkTypes, map[string]attr.Value{
+						"network_id": types.StringValue("network_id"),
+						"role":       types.StringValue("role"),
+					}),
+					types.ObjectValueMust(networkTypes, map[string]attr.Value{
+						"network_id": types.StringValue("network_id_2"),
+						"role":       types.StringValue("role_2"),
+					}),
+				}),
+				Options: types.ObjectValueMust(
+					optionsTypes,
+					map[string]attr.Value{
+						"acl": types.SetValueMust(
+							types.StringType,
+							[]attr.Value{types.StringValue("cidr")}),
+						"private_network_only": types.BoolValue(true),
+					},
+				),
+				TargetPools: types.ListValueMust(types.ObjectType{AttrTypes: targetPoolTypes}, []attr.Value{
+					types.ObjectValueMust(targetPoolTypes, map[string]attr.Value{
+						"active_health_check": types.ObjectValueMust(activeHealthCheckTypes, map[string]attr.Value{
+							"healthy_threshold":   types.Int64Value(1),
+							"interval":            types.StringValue("2s"),
+							"interval_jitter":     types.StringValue("3s"),
+							"timeout":             types.StringValue("4s"),
+							"unhealthy_threshold": types.Int64Value(5),
+						}),
+						"name":        types.StringValue("name"),
+						"target_port": types.Int64Value(80),
+						"targets": types.ListValueMust(types.ObjectType{AttrTypes: targetTypes}, []attr.Value{
+							types.ObjectValueMust(targetTypes, map[string]attr.Value{
+								"display_name": types.StringValue("display_name"),
+								"ip":           types.StringValue("ip"),
+							}),
+						}),
+						"session_persistence": types.ObjectValueMust(sessionPersistenceTypes, map[string]attr.Value{
+							"use_source_ip_address": types.BoolValue(true),
+						}),
+					}),
+				}),
+			},
+			&loadbalancer.CreateLoadBalancerPayload{
+				PlanId:          utils.Ptr("p250"),
+				ExternalAddress: utils.Ptr("external_address"),
+				Listeners: &[]loadbalancer.Listener{
+					{
+						DisplayName: utils.Ptr("display_name"),
+						Port:        utils.Ptr(int64(80)),
+						Protocol:    utils.Ptr("protocol"),
+						ServerNameIndicators: &[]loadbalancer.ServerNameIndicator{
+							{
+								Name: utils.Ptr("domain.com"),
+							},
+						},
+						TargetPool: utils.Ptr("target_pool"),
+					},
+				},
+				Name: utils.Ptr("name"),
+				Networks: &[]loadbalancer.Network{
+					{
+						NetworkId: utils.Ptr("network_id"),
+						Role:      utils.Ptr("role"),
+					},
+					{
+						NetworkId: utils.Ptr("network_id_2"),
+						Role:      utils.Ptr("role_2"),
+					},
+				},
+				Options: &loadbalancer.LoadBalancerOptions{
+					AccessControl: &loadbalancer.LoadbalancerOptionAccessControl{
+						AllowedSourceRanges: &[]string{"cidr"},
+					},
+					PrivateNetworkOnly: utils.Ptr(true),
+				},
+				TargetPools: &[]loadbalancer.TargetPool{
+					{
+						ActiveHealthCheck: &loadbalancer.ActiveHealthCheck{
+							HealthyThreshold:   utils.Ptr(int64(1)),
+							Interval:           utils.Ptr("2s"),
+							IntervalJitter:     utils.Ptr("3s"),
+							Timeout:            utils.Ptr("4s"),
+							UnhealthyThreshold: utils.Ptr(int64(5)),
+						},
+						Name:       utils.Ptr("name"),
+						TargetPort: utils.Ptr(int64(80)),
+						Targets: &[]loadbalancer.Target{
+							{
+								DisplayName: utils.Ptr("display_name"),
+								Ip:          utils.Ptr("ip"),
+							},
+						},
+						SessionPersistence: &loadbalancer.SessionPersistence{
+							UseSourceIpAddress: utils.Ptr(true),
+						},
+					},
+				},
+			},
+			true,
+		},
+		{
 			"nil_model",
 			nil,
 			nil,
@@ -365,6 +488,127 @@ func TestMapFields(t *testing.T) {
 				Id:              types.StringValue("pid,name"),
 				ProjectId:       types.StringValue("pid"),
 				ExternalAddress: types.StringValue("external_address"),
+				Listeners: types.ListValueMust(types.ObjectType{AttrTypes: listenerTypes}, []attr.Value{
+					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
+						"display_name": types.StringValue("display_name"),
+						"port":         types.Int64Value(80),
+						"protocol":     types.StringValue("protocol"),
+						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
+							types.ObjectValueMust(
+								serverNameIndicatorTypes,
+								map[string]attr.Value{
+									"name": types.StringValue("domain.com"),
+								},
+							),
+						},
+						),
+						"target_pool": types.StringValue("target_pool"),
+					}),
+				}),
+				Name: types.StringValue("name"),
+				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
+					types.ObjectValueMust(networkTypes, map[string]attr.Value{
+						"network_id": types.StringValue("network_id"),
+						"role":       types.StringValue("role"),
+					}),
+					types.ObjectValueMust(networkTypes, map[string]attr.Value{
+						"network_id": types.StringValue("network_id_2"),
+						"role":       types.StringValue("role_2"),
+					}),
+				}),
+				Options: types.ObjectValueMust(
+					optionsTypes,
+					map[string]attr.Value{
+						"private_network_only": types.BoolValue(true),
+						"acl":                  types.SetNull(types.StringType),
+					},
+				),
+				TargetPools: types.ListValueMust(types.ObjectType{AttrTypes: targetPoolTypes}, []attr.Value{
+					types.ObjectValueMust(targetPoolTypes, map[string]attr.Value{
+						"active_health_check": types.ObjectValueMust(activeHealthCheckTypes, map[string]attr.Value{
+							"healthy_threshold":   types.Int64Value(1),
+							"interval":            types.StringValue("2s"),
+							"interval_jitter":     types.StringValue("3s"),
+							"timeout":             types.StringValue("4s"),
+							"unhealthy_threshold": types.Int64Value(5),
+						}),
+						"name":        types.StringValue("name"),
+						"target_port": types.Int64Value(80),
+						"targets": types.ListValueMust(types.ObjectType{AttrTypes: targetTypes}, []attr.Value{
+							types.ObjectValueMust(targetTypes, map[string]attr.Value{
+								"display_name": types.StringValue("display_name"),
+								"ip":           types.StringValue("ip"),
+							}),
+						}),
+						"session_persistence": types.ObjectValueMust(sessionPersistenceTypes, map[string]attr.Value{
+							"use_source_ip_address": types.BoolValue(true),
+						}),
+					}),
+				}),
+			},
+			true,
+		},
+		{
+			"service_plans_ok",
+			&loadbalancer.LoadBalancer{
+				PlanId:          utils.Ptr("p250"),
+				ExternalAddress: utils.Ptr("external_address"),
+				Listeners: utils.Ptr([]loadbalancer.Listener{
+					{
+						DisplayName: utils.Ptr("display_name"),
+						Port:        utils.Ptr(int64(80)),
+						Protocol:    utils.Ptr("protocol"),
+						ServerNameIndicators: &[]loadbalancer.ServerNameIndicator{
+							{
+								Name: utils.Ptr("domain.com"),
+							},
+						},
+						TargetPool: utils.Ptr("target_pool"),
+					},
+				}),
+				Name: utils.Ptr("name"),
+				Networks: utils.Ptr([]loadbalancer.Network{
+					{
+						NetworkId: utils.Ptr("network_id"),
+						Role:      utils.Ptr("role"),
+					},
+					{
+						NetworkId: utils.Ptr("network_id_2"),
+						Role:      utils.Ptr("role_2"),
+					},
+				}),
+				Options: utils.Ptr(loadbalancer.LoadBalancerOptions{
+					PrivateNetworkOnly: utils.Ptr(true),
+				}),
+				TargetPools: utils.Ptr([]loadbalancer.TargetPool{
+					{
+						ActiveHealthCheck: utils.Ptr(loadbalancer.ActiveHealthCheck{
+							HealthyThreshold:   utils.Ptr(int64(1)),
+							Interval:           utils.Ptr("2s"),
+							IntervalJitter:     utils.Ptr("3s"),
+							Timeout:            utils.Ptr("4s"),
+							UnhealthyThreshold: utils.Ptr(int64(5)),
+						}),
+						Name:       utils.Ptr("name"),
+						TargetPort: utils.Ptr(int64(80)),
+						Targets: utils.Ptr([]loadbalancer.Target{
+							{
+								DisplayName: utils.Ptr("display_name"),
+								Ip:          utils.Ptr("ip"),
+							},
+						}),
+						SessionPersistence: utils.Ptr(loadbalancer.SessionPersistence{
+							UseSourceIpAddress: utils.Ptr(true),
+						}),
+					},
+				}),
+			},
+			nil,
+			&Model{
+				Id:              types.StringValue("pid,name"),
+				ProjectId:       types.StringValue("pid"),
+				ExternalAddress: types.StringValue("external_address"),
+				PlanId:          types.StringValue("p250"),
 				Listeners: types.ListValueMust(types.ObjectType{AttrTypes: listenerTypes}, []attr.Value{
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),


### PR DESCRIPTION
Added support for the plan_id field used to create or change a load balancer's plan to a higher one (e.g. p250, p750, ...). 