### PR TITLE
fix: add error message that key pair doesn't exists

### DIFF
--- a/stackit/internal/services/iaas/keypair/datasource.go
+++ b/stackit/internal/services/iaas/keypair/datasource.go
@@ -2,6 +2,7 @@ package keypair
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -130,7 +131,8 @@ func (r *keyPairDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	keypairResp, err := r.client.GetKeyPair(ctx, name).Execute()
 	if err != nil {
-		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		var oapiErr *oapierror.GenericOpenAPIError
+		ok := errors.As(err, &oapiErr)
 		if ok && oapiErr.StatusCode == http.StatusNotFound {
 			summary := fmt.Sprintf("Key Pair with name %q does not exists", name)
 			description := fmt.Sprintf("Key Pair with name %q cannot be found. A key pair can be added with the resource \"stackit_key_pair\"", name)

--- a/stackit/internal/services/iaas/keypair/datasource.go
+++ b/stackit/internal/services/iaas/keypair/datasource.go
@@ -132,6 +132,11 @@ func (r *keyPairDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if err != nil {
 		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
 		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			summary := fmt.Sprintf("Key Pair with name %q does not exists", name)
+			description := fmt.Sprintf("Key Pair with name %q cannot be found. A key pair can be added with the resource \"stackit_key_pair\"", name)
+			diags.AddError(summary, description)
+			resp.Diagnostics.Append(diags...)
+
 			resp.State.RemoveResource(ctx)
 			return
 		}


### PR DESCRIPTION
The provider response with a generic error when the key pair cannot be found (see #645). With this PR a more clear error message will be shown