### PR TITLE
fix(mongodb): store partial state

### DIFF
--- a/stackit/internal/services/mongodbflex/instance/resource.go
+++ b/stackit/internal/services/mongodbflex/instance/resource.go
@@ -33,10 +33,6 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex/wait"
 )
 
-const (
-	DefaultBackupSchedule = "0 0/6 * * *"
-)
-
 // Ensure the implementation satisfies the expected interfaces.
 var (
 	_ resource.Resource                = &instanceResource{}
@@ -392,6 +388,16 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 	}
 	instanceId := *createResp.Id
 	ctx = tflog.SetField(ctx, "instance_id", instanceId)
+	diags = resp.State.SetAttribute(ctx, path.Root("project_id"), projectId)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = resp.State.SetAttribute(ctx, path.Root("instance_id"), instanceId)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	waitResp, err := wait.CreateInstanceWaitHandler(ctx, r.client, projectId, instanceId).WaitWithContext(ctx)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating instance", fmt.Sprintf("Instance creation waiting: %v", err))
@@ -402,6 +408,12 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 	err = mapFields(ctx, waitResp, &model, flavor, storage, options)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating instance", fmt.Sprintf("Processing API payload: %v", err))
+		return
+	}
+
+	diags = resp.State.Set(ctx, model)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 


### PR DESCRIPTION
this fix avoids that an instance is created but doesn't get stored in terraform when an error occurred