### PR TITLE
fix(acceptance-tests): Postgresql use force delete

### DIFF
--- a/.github/workflows/tf-acc-test.yaml
+++ b/.github/workflows/tf-acc-test.yaml
@@ -17,7 +17,7 @@ jobs:
         run: make project-tools
       - name: Run tests
         run: |
-          make test-acceptance-tf TF_ACC_PROJECT_ID=$${{ secrets.TF_ACC_PROJECT_ID }} TF_ACC_ORGANIZATION_ID=$${{ secrets.TF_ACC_ORGANIZATION_ID }}
+          make test-acceptance-tf TF_ACC_PROJECT_ID=$${{ secrets.TF_ACC_PROJECT_ID }} TF_ACC_ORGANIZATION_ID=$${{ secrets.TF_ACC_ORGANIZATION_ID }} TF_ACC_REGION="eu01"
         env:
           STACKIT_SERVICE_ACCOUNT_TOKEN: ${{ secrets.TF_ACC_SERVICE_ACCOUNT_TOKEN }}
           TF_ACC_TEST_PROJECT_SERVICE_ACCOUNT_EMAIL: ${{ secrets.TF_ACC_TEST_PROJECT_SERVICE_ACCOUNT_EMAIL }}

--- a/stackit/internal/services/serverupdate/serverupdate_acc_test.go
+++ b/stackit/internal/services/serverupdate/serverupdate_acc_test.go
@@ -59,7 +59,6 @@ func TestAccServerUpdateScheduleResource(t *testing.T) {
 		fmt.Println("TF_ACC_SERVER_ID not set, skipping test")
 		return
 	}
-	testRegion := utils.Ptr("eu01")
 	var invalidMaintenanceWindow int64 = 0
 	var validMaintenanceWindow int64 = 15
 	var updatedMaintenanceWindow int64 = 8
@@ -69,12 +68,12 @@ func TestAccServerUpdateScheduleResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Creation fail
 			{
-				Config:      resourceConfig(invalidMaintenanceWindow, testRegion),
+				Config:      resourceConfig(invalidMaintenanceWindow, &testutil.Region),
 				ExpectError: regexp.MustCompile(`.*maintenance_window value must be at least 1*`),
 			},
 			// Creation
 			{
-				Config: resourceConfig(validMaintenanceWindow, testRegion),
+				Config: resourceConfig(validMaintenanceWindow, &testutil.Region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Update schedule data
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", serverUpdateScheduleResource["project_id"]),
@@ -84,7 +83,7 @@ func TestAccServerUpdateScheduleResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", serverUpdateScheduleResource["name"]),
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", serverUpdateScheduleResource["rrule"]),
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", *testRegion),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
 				),
 			},
 			// data source
@@ -102,7 +101,7 @@ func TestAccServerUpdateScheduleResource(t *testing.T) {
 						server_id  = stackit_server_update_schedule.test_schedule.server_id
                         update_schedule_id = stackit_server_update_schedule.test_schedule.update_schedule_id
 					}`,
-					resourceConfig(validMaintenanceWindow, testRegion),
+					resourceConfig(validMaintenanceWindow, &testutil.Region),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server update schedule data

--- a/stackit/internal/services/ske/ske_acc_test.go
+++ b/stackit/internal/services/ske/ske_acc_test.go
@@ -206,7 +206,6 @@ func getConfig(kubernetesVersion, nodePoolMachineOSVersion string, maintenanceEn
 }
 
 func TestAccSKE(t *testing.T) {
-	testRegion := utils.Ptr("eu01")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSKEDestroy,
@@ -215,7 +214,7 @@ func TestAccSKE(t *testing.T) {
 			// 1) Creation
 			{
 
-				Config: getConfig(clusterResource["kubernetes_version_min"], clusterResource["nodepool_os_version_min"], nil, testRegion),
+				Config: getConfig(clusterResource["kubernetes_version_min"], clusterResource["nodepool_os_version_min"], nil, &testutil.Region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// cluster data
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "name", clusterResource["name"]),
@@ -257,7 +256,7 @@ func TestAccSKE(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "maintenance.enable_machine_image_version_updates", clusterResource["maintenance_enable_machine_image_version_updates"]),
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "maintenance.start", clusterResource["maintenance_start"]),
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "maintenance.end", clusterResource["maintenance_end"]),
-					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "region", *testRegion),
+					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "region", testutil.Region),
 
 					// Kubeconfig
 
@@ -285,7 +284,7 @@ func TestAccSKE(t *testing.T) {
 						}
 
 							`,
-					getConfig(clusterResource["kubernetes_version_min"], clusterResource["nodepool_os_version_min"], nil, testRegion),
+					getConfig(clusterResource["kubernetes_version_min"], clusterResource["nodepool_os_version_min"], nil, &testutil.Region),
 					clusterResource["project_id"],
 					clusterResource["name"],
 				),
@@ -294,7 +293,7 @@ func TestAccSKE(t *testing.T) {
 					// cluster data
 					resource.TestCheckResourceAttr("data.stackit_ske_cluster.cluster", "id", fmt.Sprintf("%s,%s,%s",
 						clusterResource["project_id"],
-						*testRegion,
+						testutil.Region,
 						clusterResource["name"],
 					)),
 					resource.TestCheckResourceAttr("data.stackit_ske_cluster.cluster", "project_id", clusterResource["project_id"]),
@@ -357,7 +356,7 @@ func TestAccSKE(t *testing.T) {
 			},
 			// 4) Update kubernetes version, OS version and maintenance end
 			{
-				Config: getConfig(clusterResource["kubernetes_version_min_new"], clusterResource["nodepool_os_version_min_new"], utils.Ptr(clusterResource["maintenance_end_new"]), testRegion),
+				Config: getConfig(clusterResource["kubernetes_version_min_new"], clusterResource["nodepool_os_version_min_new"], utils.Ptr(clusterResource["maintenance_end_new"]), &testutil.Region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// cluster data
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "project_id", clusterResource["project_id"]),
@@ -399,12 +398,12 @@ func TestAccSKE(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "maintenance.enable_machine_image_version_updates", clusterResource["maintenance_enable_machine_image_version_updates"]),
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "maintenance.start", clusterResource["maintenance_start"]),
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "maintenance.end", clusterResource["maintenance_end_new"]),
-					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "region", *testRegion),
+					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "region", testutil.Region),
 				),
 			},
 			// 5) Downgrade kubernetes and nodepool machine OS version
 			{
-				Config: getConfig(clusterResource["kubernetes_version_min"], clusterResource["nodepool_os_version_min"], utils.Ptr(clusterResource["maintenance_end_new"]), testRegion),
+				Config: getConfig(clusterResource["kubernetes_version_min"], clusterResource["nodepool_os_version_min"], utils.Ptr(clusterResource["maintenance_end_new"]), &testutil.Region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// cluster data
 					resource.TestCheckResourceAttr("stackit_ske_cluster.cluster", "project_id", clusterResource["project_id"]),
@@ -443,7 +442,7 @@ func testAccCheckSKEDestroy(s *terraform.State) error {
 			continue
 		}
 		// cluster terraform ID: = "[project_id],[region],[cluster_name]"
-		clusterName := strings.Split(rs.Primary.ID, core.Separator)[1]
+		clusterName := strings.Split(rs.Primary.ID, core.Separator)[2]
 		clustersToDestroy = append(clustersToDestroy, clusterName)
 	}
 

--- a/stackit/internal/services/sqlserverflex/sqlserverflex_acc_test.go
+++ b/stackit/internal/services/sqlserverflex/sqlserverflex_acc_test.go
@@ -97,14 +97,13 @@ func configResources(backupSchedule string, region *string) string {
 }
 
 func TestAccSQLServerFlexResource(t *testing.T) {
-	testRegion := utils.Ptr("eu01")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccChecksqlserverflexDestroy,
 		Steps: []resource.TestStep{
 			// Creation
 			{
-				Config: configResources(instanceResource["backup_schedule"], testRegion),
+				Config: configResources(instanceResource["backup_schedule"], &testutil.Region),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
 					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", instanceResource["project_id"]),
@@ -122,7 +121,7 @@ func TestAccSQLServerFlexResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "version", instanceResource["version"]),
 					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", instanceResource["options_retention_days"]),
 					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "backup_schedule", instanceResource["backup_schedule"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "region", *testRegion),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "region", testutil.Region),
 					// User
 					resource.TestCheckResourceAttrPair(
 						"stackit_sqlserverflex_user.user", "project_id",
@@ -323,7 +322,7 @@ func testAccChecksqlserverflexDestroy(s *terraform.State) error {
 			continue
 		}
 		// instance terraform ID: = "[project_id],[region],[instance_id]"
-		instanceId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		instanceId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		instancesToDestroy = append(instancesToDestroy, instanceId)
 	}
 


### PR DESCRIPTION
 fix(acceptance-tests): Postgresql use force delete
    - use TF_ACC_REGION in acceptance test


## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->


## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
