### PR TITLE
fix(observability): Observability example retention was in wrong order

### DIFF
--- a/docs/resources/observability_instance.md
+++ b/docs/resources/observability_instance.md
@@ -18,9 +18,9 @@ resource "stackit_observability_instance" "example" {
   name                                   = "example-instance"
   plan_name                              = "Observability-Monitoring-Medium-EU01"
   acl                                    = ["1.1.1.1/32", "2.2.2.2/32"]
-  metrics_retention_days                 = 7
-  metrics_retention_days_5m_downsampling = 30
-  metrics_retention_days_1h_downsampling = 365
+  metrics_retention_days                 = 30
+  metrics_retention_days_5m_downsampling = 10
+  metrics_retention_days_1h_downsampling = 5
 }
 ```
 

--- a/examples/resources/stackit_observability_instance/resource.tf
+++ b/examples/resources/stackit_observability_instance/resource.tf
@@ -3,7 +3,7 @@ resource "stackit_observability_instance" "example" {
   name                                   = "example-instance"
   plan_name                              = "Observability-Monitoring-Medium-EU01"
   acl                                    = ["1.1.1.1/32", "2.2.2.2/32"]
-  metrics_retention_days                 = 7
-  metrics_retention_days_5m_downsampling = 30
-  metrics_retention_days_1h_downsampling = 365
+  metrics_retention_days                 = 30
+  metrics_retention_days_5m_downsampling = 10
+  metrics_retention_days_1h_downsampling = 5
 }


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
