### PR TITLE
fix(network): ipv4 prefix must be computed

### DIFF
--- a/stackit/internal/services/iaas/network/resource.go
+++ b/stackit/internal/services/iaas/network/resource.go
@@ -213,6 +213,7 @@ func (r *networkResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"ipv4_prefix": schema.StringAttribute{
 				Description: "The IPv4 prefix of the network (CIDR).",
 				Optional:    true,
+				Computed:    true,
 				Validators: []validator.String{
 					validate.CIDR(),
 				},
@@ -222,6 +223,7 @@ func (r *networkResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"ipv4_prefix_length": schema.Int64Attribute{
 				Description: "The IPv4 prefix length of the network.",
+				Computed:    true,
 				Optional:    true,
 			},
 			"prefixes": schema.ListAttribute{


### PR DESCRIPTION
## Description
Applying the following terraform configuration

resource "stackit_network" "network" {
  project_id         = var.project_id
  name               = "example-network"
  ipv4_nameservers   = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
  ipv4_prefix_length = 24
}
causes an error

╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to stackit_network.network, provider
│ "provider[\"registry.terraform.io/stackitcloud/stackit\"]" produced an unexpected new value:
│ .ipv4_prefix: was null, but now cty.StringVal("10.0.1.0/24").
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
 

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
