### PR TITLE
chore(docs): use new 'default_region' provider attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To use beta resources in the STACKIT Terraform provider, follow these steps:
 
    ```hcl
    provider "stackit" {
-     region                = "eu01"
+     default_region                = "eu01"
      enable_beta_resources = true
    }
    ```
@@ -180,7 +180,7 @@ To enable experiments set the experiments field in the provider definition:
 
 ```hcl
 provider "stackit" {
-  region                = "eu01"
+  default_region                = "eu01"
   experiments           = ["iam"]
 }
 ```

--- a/docs/guides/aws_provider_s3_stackit.md
+++ b/docs/guides/aws_provider_s3_stackit.md
@@ -15,7 +15,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
 
       ```hcl
       provider "stackit" {
-         region = "eu01"
+         default_region = "eu01"
       }
       ```
 

--- a/docs/guides/kubernetes_provider_ske.md
+++ b/docs/guides/kubernetes_provider_ske.md
@@ -15,7 +15,7 @@ This guide outlines the process of utilizing the [HashiCorp Kubernetes provider]
 
     ```hcl
     provider "stackit" {
-      region = "eu01"
+      default_region = "eu01"
     }
     ```
 

--- a/docs/guides/opting_into_beta_resources.md
+++ b/docs/guides/opting_into_beta_resources.md
@@ -19,7 +19,7 @@ Set the `enable_beta_resources` option in the provider configuration. This is a 
 
 ```hcl
 provider "stackit" {
-  region                = "eu01"
+  default_region        = "eu01"
   enable_beta_resources = true
 }
 ```

--- a/docs/guides/ske_kube_state_metric_alerts.md
+++ b/docs/guides/ske_kube_state_metric_alerts.md
@@ -13,7 +13,7 @@ This guide explains how to configure the STACKIT Observability product to send a
 
    ```hcl
    provider "stackit" {
-     region = "eu01"
+     default_region = "eu01"
    }
 
    provider "kubernetes" {

--- a/docs/guides/vault_secrets_manager.md
+++ b/docs/guides/vault_secrets_manager.md
@@ -13,7 +13,7 @@ This guide outlines the process of utilizing the [HashiCorp Vault provider](http
 
     ```hcl
     provider "stackit" {
-      region = "eu01"
+      default_region = "eu01"
     }
     ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,27 +6,27 @@ The STACKIT Terraform provider is the official Terraform provider to integrate a
 
 ```terraform
 provider "stackit" {
-  region = "eu01"
+  default_region = "eu01"
 }
 
 # Authentication
 
 # Token flow
 provider "stackit" {
-  region                = "eu01"
+  default_region        = "eu01"
   service_account_token = var.service_account_token
 }
 
 # Key flow
 provider "stackit" {
-  region              = "eu01"
+  default_region      = "eu01"
   service_account_key = var.service_account_key
   private_key         = var.private_key
 }
 
 # Key flow (using path)
 provider "stackit" {
-  region                   = "eu01"
+  default_region           = "eu01"
   service_account_key_path = var.service_account_key_path
   private_key_path         = var.private_key_path
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,25 +1,25 @@
 provider "stackit" {
-  region = "eu01"
+  default_region = "eu01"
 }
 
 # Authentication
 
 # Token flow
 provider "stackit" {
-  region                = "eu01"
+  default_region        = "eu01"
   service_account_token = var.service_account_token
 }
 
 # Key flow
 provider "stackit" {
-  region              = "eu01"
+  default_region      = "eu01"
   service_account_key = var.service_account_key
   private_key         = var.private_key
 }
 
 # Key flow (using path)
 provider "stackit" {
-  region                   = "eu01"
+  default_region           = "eu01"
   service_account_key_path = var.service_account_key_path
   private_key_path         = var.private_key_path
 }

--- a/stackit/internal/testutil/testutil.go
+++ b/stackit/internal/testutil/testutil.go
@@ -80,7 +80,7 @@ var (
 func ArgusProviderConfig() string {
 	if ArgusCustomEndpoint == "" {
 		return `provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -96,7 +96,7 @@ func ArgusProviderConfig() string {
 func ObservabilityProviderConfig() string {
 	if ObservabilityCustomEndpoint == "" {
 		return `provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -134,7 +134,7 @@ func IaaSProviderConfig() string {
 	if IaaSCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -149,7 +149,7 @@ func LoadBalancerProviderConfig() string {
 	if LoadBalancerCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 			enable_beta_resources = true
 		}`
 	}
@@ -165,7 +165,7 @@ func LogMeProviderConfig() string {
 	if LogMeCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -180,7 +180,7 @@ func MariaDBProviderConfig() string {
 	if MariaDBCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -195,7 +195,7 @@ func ModelServingProviderConfig() string {
 	if ModelServingCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}
 		`
 	}
@@ -211,7 +211,7 @@ func MongoDBFlexProviderConfig() string {
 	if MongoDBFlexCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -226,7 +226,7 @@ func ObjectStorageProviderConfig() string {
 	if ObjectStorageCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -241,7 +241,7 @@ func OpenSearchProviderConfig() string {
 	if OpenSearchCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -256,7 +256,7 @@ func PostgresFlexProviderConfig() string {
 	if PostgresFlexCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -271,7 +271,7 @@ func RabbitMQProviderConfig() string {
 	if RabbitMQCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -286,7 +286,7 @@ func RedisProviderConfig() string {
 	if RedisCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -327,7 +327,7 @@ func SecretsManagerProviderConfig() string {
 	if SecretsManagerCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -342,7 +342,7 @@ func SQLServerFlexProviderConfig() string {
 	if SQLServerFlexCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -357,7 +357,7 @@ func ServerBackupProviderConfig() string {
 	if ServerBackupCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -388,7 +388,7 @@ func SKEProviderConfig() string {
 	if SKECustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 		}`
 	}
 	return fmt.Sprintf(`
@@ -403,7 +403,7 @@ func AuthorizationProviderConfig() string {
 	if AuthorizationCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 			experiments = ["iam"]
 		}`
 	}
@@ -420,7 +420,7 @@ func ServiceAccountProviderConfig() string {
 	if ServiceAccountCustomEndpoint == "" {
 		return `
 		provider "stackit" {
-			region = "eu01"
+			default_region = "eu01"
 			enable_beta_resources = true
 		}`
 	}

--- a/templates/guides/aws_provider_s3_stackit.md.tmpl
+++ b/templates/guides/aws_provider_s3_stackit.md.tmpl
@@ -15,7 +15,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
 
       ```hcl
       provider "stackit" {
-         region = "eu01"
+         default_region = "eu01"
       }
       ```
 

--- a/templates/guides/kubernetes_provider_ske.md.tmpl
+++ b/templates/guides/kubernetes_provider_ske.md.tmpl
@@ -15,7 +15,7 @@ This guide outlines the process of utilizing the [HashiCorp Kubernetes provider]
 
     ```hcl
     provider "stackit" {
-      region = "eu01"
+      default_region = "eu01"
     }
     ```
 

--- a/templates/guides/opting_into_beta_resources.md.tmpl
+++ b/templates/guides/opting_into_beta_resources.md.tmpl
@@ -19,7 +19,7 @@ Set the `enable_beta_resources` option in the provider configuration. This is a 
 
 ```hcl
 provider "stackit" {
-  region                = "eu01"
+  default_region        = "eu01"
   enable_beta_resources = true
 }
 ```

--- a/templates/guides/ske_kube_state_metric_alerts.md.tmpl
+++ b/templates/guides/ske_kube_state_metric_alerts.md.tmpl
@@ -13,7 +13,7 @@ This guide explains how to configure the STACKIT Observability product to send a
 
    ```hcl
    provider "stackit" {
-     region = "eu01"
+     default_region = "eu01"
    }
 
    provider "kubernetes" {

--- a/templates/guides/vault_secrets_manager.md.tmpl
+++ b/templates/guides/vault_secrets_manager.md.tmpl
@@ -13,7 +13,7 @@ This guide outlines the process of utilizing the [HashiCorp Vault provider](http
 
     ```hcl
     provider "stackit" {
-      region = "eu01"
+      default_region = "eu01"
     }
     ```
 


### PR DESCRIPTION
instead of deprecated 'region' attribute

## Checklist

~- [ ] Issue was linked above~
- [x] Code format was applied: `make fmt`
~- [ ] Examples were added / adjusted (see `examples/` directory)~
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
~- [ ] Unit tests got implemented or updated~
~- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))~
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
