### PR TITLE
docs(typo): fix cdn regions

### DIFF
--- a/docs/resources/cdn_distribution.md
+++ b/docs/resources/cdn_distribution.md
@@ -24,7 +24,7 @@ resource "stackit_cdn_distribution" "example_distribution" {
       type       = "http"
       origin_url = "mybackend.onstackit.cloud"
     }
-    regions = ["EN", "US", "ASIA", "AF", "SA"]
+    regions = ["EU", "US", "ASIA", "AF", "SA"]
   }
 }
 ```

--- a/examples/resources/stackit_cdn_distribution/resource.tf
+++ b/examples/resources/stackit_cdn_distribution/resource.tf
@@ -6,6 +6,6 @@ resource "stackit_cdn_distribution" "example_distribution" {
       type       = "http"
       origin_url = "mybackend.onstackit.cloud"
     }
-    regions = ["EN", "US", "ASIA", "AF", "SA"]
+    regions = ["EU", "US", "ASIA", "AF", "SA"]
   }
 }


### PR DESCRIPTION
## Description

Region EN does not exist. It should be EU

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
