### PR TITLE
CDN distribution: add string validator for backend type

### DIFF
--- a/docs/data-sources/cdn_distribution.md
+++ b/docs/data-sources/cdn_distribution.md
@@ -55,7 +55,7 @@ Read-Only:
 
 - `origin_request_headers` (Map of String) The configured origin request headers for the backend
 - `origin_url` (String) The configured backend type for the distribution
-- `type` (String) The configured backend type
+- `type` (String) The configured backend type. Supported values are: `http`.
 
 
 

--- a/docs/resources/cdn_distribution.md
+++ b/docs/resources/cdn_distribution.md
@@ -61,7 +61,7 @@ Required:
 Required:
 
 - `origin_url` (String) The configured backend type for the distribution
-- `type` (String) The configured backend type
+- `type` (String) The configured backend type. Supported values are: `http`.
 
 Optional:
 

--- a/stackit/internal/services/cdn/distribution/datasource.go
+++ b/stackit/internal/services/cdn/distribution/datasource.go
@@ -73,6 +73,7 @@ func (r *distributionDataSource) Metadata(_ context.Context, req datasource.Meta
 }
 
 func (r *distributionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	backendOptions := []string{"http"}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: features.AddBetaDescription("CDN distribution data source schema."),
 		Description:         "CDN distribution data source schema.",
@@ -147,7 +148,7 @@ func (r *distributionDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed:    true,
-								Description: schemaDescriptions["config_backend_type"],
+								Description: schemaDescriptions["config_backend_type"] + utils.SupportedValuesDocumentation(backendOptions),
 							},
 							"origin_url": schema.StringAttribute{
 								Computed:    true,

--- a/stackit/internal/services/cdn/distribution/resource.go
+++ b/stackit/internal/services/cdn/distribution/resource.go
@@ -146,7 +146,8 @@ func (r *distributionResource) Schema(_ context.Context, _ resource.SchemaReques
 	backendOptions := []string{"http"}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: features.AddBetaDescription("CDN distribution data source schema."),
-		Description:         "CDN distribution data source schema.",
+		MarkdownDescription: features.AddBetaDescription("CDN distribution data source schema. " + utils.SupportedValuesDocumentation(backendOptions)),
+		Description:         "CDN distribution data source schema. " + utils.SupportedValuesDocumentation(backendOptions),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: schemaDescriptions["id"],

--- a/stackit/internal/services/cdn/distribution/resource.go
+++ b/stackit/internal/services/cdn/distribution/resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/cdn/wait"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/features"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 )
 
@@ -47,7 +48,7 @@ var schemaDescriptions = map[string]string{
 	"config":                                "The distribution configuration",
 	"config_backend":                        "The configured backend for the distribution",
 	"config_regions":                        "The configured regions where content will be hosted",
-	"config_backend_type":                   "The configured backend type",
+	"config_backend_type":                   "The configured backend type. ",
 	"config_backend_origin_url":             "The configured backend type for the distribution",
 	"config_backend_origin_request_headers": "The configured origin request headers for the backend",
 	"domain_name":                           "The name of the domain",
@@ -146,8 +147,7 @@ func (r *distributionResource) Schema(_ context.Context, _ resource.SchemaReques
 	backendOptions := []string{"http"}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: features.AddBetaDescription("CDN distribution data source schema."),
-		MarkdownDescription: features.AddBetaDescription("CDN distribution data source schema. " + utils.SupportedValuesDocumentation(backendOptions)),
-		Description:         "CDN distribution data source schema. " + utils.SupportedValuesDocumentation(backendOptions),
+		Description:         "CDN distribution data source schema.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: schemaDescriptions["id"],
@@ -221,7 +221,7 @@ func (r *distributionResource) Schema(_ context.Context, _ resource.SchemaReques
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required:    true,
-								Description: schemaDescriptions["config_backend_type"],
+								Description: schemaDescriptions["config_backend_type"] + utils.SupportedValuesDocumentation(backendOptions),
 								Validators:  []validator.String{stringvalidator.OneOf(backendOptions...)},
 							},
 							"origin_url": schema.StringAttribute{

--- a/stackit/internal/services/cdn/distribution/resource.go
+++ b/stackit/internal/services/cdn/distribution/resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -142,6 +143,7 @@ func (r *distributionResource) Metadata(_ context.Context, req resource.Metadata
 }
 
 func (r *distributionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	backendOptions := []string{"http"}
 	resp.Schema = schema.Schema{
 		MarkdownDescription: features.AddBetaDescription("CDN distribution data source schema."),
 		Description:         "CDN distribution data source schema.",
@@ -219,6 +221,7 @@ func (r *distributionResource) Schema(_ context.Context, _ resource.SchemaReques
 							"type": schema.StringAttribute{
 								Required:    true,
 								Description: schemaDescriptions["config_backend_type"],
+								Validators:  []validator.String{stringvalidator.OneOf(backendOptions...)},
 							},
 							"origin_url": schema.StringAttribute{
 								Required:    true,


### PR DESCRIPTION
## Description

Quick fix for cdn distribution resource that I recently submitted: Currently the only allowed value for backend should be "http", I added a validator to avoid issues. Since other values will be added in the future, I am using the "OneOf" validator

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
