### PR TITLE
fix(guide): typo in cdn guide

### DIFF
--- a/docs/guides/stackit_cdn_with_custom_domain.md
+++ b/docs/guides/stackit_cdn_with_custom_domain.md
@@ -53,7 +53,7 @@ This guide outlines the process of creating a STACKIT CDN distribution and confi
     resource "stackit_cdn_custom_domain" "example" {
       project_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       distribution_id = stackit_cdn_distribution.example_distribution.distribution_id
-      name            = "${stackit_dns_record_set.example.name}.${stackit_dns_zone.dns_name}"
+      name            = "${stackit_dns_record_set.example.name}.${stackit_dns_zone.example_zone.dns_name}"
     }
     ```
     

--- a/templates/guides/stackit_cdn_with_custom_domain.md.tmpl
+++ b/templates/guides/stackit_cdn_with_custom_domain.md.tmpl
@@ -53,7 +53,7 @@ This guide outlines the process of creating a STACKIT CDN distribution and confi
     resource "stackit_cdn_custom_domain" "example" {
       project_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       distribution_id = stackit_cdn_distribution.example_distribution.distribution_id
-      name            = "${stackit_dns_record_set.example.name}.${stackit_dns_zone.dns_name}"
+      name            = "${stackit_dns_record_set.example.name}.${stackit_dns_zone.example_zone.dns_name}"
     }
     ```
     


### PR DESCRIPTION
## Description

fixes small typo in cdn guide

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
