### PR TITLE
Feat/stackittpr 189 min max tests

### DIFF
--- a/docs/resources/dns_record_set.md
+++ b/docs/resources/dns_record_set.md
@@ -31,6 +31,7 @@ resource "stackit_dns_record_set" "example" {
 - `name` (String) Name of the record which should be a valid domain according to rfc1035 Section 2.3.4. E.g. `example.com`
 - `project_id` (String) STACKIT project ID to which the dns record set is associated.
 - `records` (List of String) Records.
+- `type` (String) The record set type. E.g. `A` or `CNAME`
 - `zone_id` (String) The zone ID to which is dns record set is associated.
 
 ### Optional
@@ -38,7 +39,6 @@ resource "stackit_dns_record_set" "example" {
 - `active` (Boolean) Specifies if the record set is active or not. Defaults to `true`
 - `comment` (String) Comment.
 - `ttl` (Number) Time to live. E.g. 3600
-- `type` (String) The record set type. E.g. `A` or `CNAME`
 
 ### Read-Only
 

--- a/stackit/internal/services/dns/dns_acc_test.go
+++ b/stackit/internal/services/dns/dns_acc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
 	"maps"
 	"regexp"
 	"strings"
@@ -83,14 +82,6 @@ func configVarsMaxUpdated() config.Variables {
 	return tempConfig
 }
 
-func unwrap(v config.Variable) string {
-	tmp, err := v.MarshalJSON()
-	if err != nil {
-		log.Panicf("cannot marshal variable %v: %v", v, err)
-	}
-	return strings.Trim(string(tmp), `"`)
-}
-
 func TestAccDnsMinResource(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
@@ -117,10 +108,10 @@ func TestAccDnsMinResource(t *testing.T) {
 						"stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMin["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", testutil.ConvertConfigVariable(testConfigVarsMin["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMin["record_record1"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMin["record_type"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", testutil.ConvertConfigVariable(testConfigVarsMin["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", testutil.ConvertConfigVariable(testConfigVarsMin["record_type"])),
 				),
 			},
 			{
@@ -142,10 +133,10 @@ func TestAccDnsMinResource(t *testing.T) {
 						"stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMin["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", testutil.ConvertConfigVariable(testConfigVarsMin["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMin["record_record1"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMin["record_type"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", testutil.ConvertConfigVariable(testConfigVarsMin["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", testutil.ConvertConfigVariable(testConfigVarsMin["record_type"])),
 				),
 			},
 			// Data sources
@@ -174,10 +165,10 @@ func TestAccDnsMinResource(t *testing.T) {
 
 					// Record set data
 					resource.TestCheckResourceAttrSet("data.stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMin["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", testutil.ConvertConfigVariable(testConfigVarsMin["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMin["record_record1"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMin["record_type"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", testutil.ConvertConfigVariable(testConfigVarsMin["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", testutil.ConvertConfigVariable(testConfigVarsMin["record_type"])),
 				),
 			},
 			// Import
@@ -243,10 +234,10 @@ func TestAccDnsMinResource(t *testing.T) {
 						"stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMin["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", testutil.ConvertConfigVariable(testConfigVarsMin["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(configVarsMinUpdated()["record_record1"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMin["record_type"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", testutil.ConvertConfigVariable(configVarsMinUpdated()["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", testutil.ConvertConfigVariable(testConfigVarsMin["record_type"])),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -278,28 +269,28 @@ func TestAccDnsMaxResource(t *testing.T) {
 						"stackit_dns_record_set.record_set", "zone_id",
 						"stackit_dns_zone.zone", "zone_id",
 					),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", unwrap(testConfigVarsMax["acl"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", unwrap(testConfigVarsMax["active"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", unwrap(testConfigVarsMax["contact_email"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", unwrap(testConfigVarsMax["default_ttl"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
-					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", testutil.ConvertConfigVariable(testConfigVarsMax["acl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", testutil.ConvertConfigVariable(testConfigVarsMax["active"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", testutil.ConvertConfigVariable(testConfigVarsMax["contact_email"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", testutil.ConvertConfigVariable(testConfigVarsMax["default_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", testutil.ConvertConfigVariable(testConfigVarsMax["description"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", testutil.ConvertConfigVariable(testConfigVarsMax["expire_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", testutil.ConvertConfigVariable(testConfigVarsMax["is_reverse_zone"])),
+					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", testutil.ConvertConfigVariable(testConfigVarsMax["negative_cache"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", unwrap(testConfigVarsMax["retry_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", unwrap(testConfigVarsMax["type"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", testutil.ConvertConfigVariable(testConfigVarsMax["refresh_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", testutil.ConvertConfigVariable(testConfigVarsMax["retry_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", testutil.ConvertConfigVariable(testConfigVarsMax["type"])),
 
 					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMax["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", testutil.ConvertConfigVariable(testConfigVarsMax["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMax["record_record1"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", unwrap(testConfigVarsMax["record_active"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", unwrap(testConfigVarsMax["record_comment"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", unwrap(testConfigVarsMax["record_ttl"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMax["record_type"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", testutil.ConvertConfigVariable(testConfigVarsMax["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", testutil.ConvertConfigVariable(testConfigVarsMax["record_active"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", testutil.ConvertConfigVariable(testConfigVarsMax["record_comment"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", testutil.ConvertConfigVariable(testConfigVarsMax["record_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", testutil.ConvertConfigVariable(testConfigVarsMax["record_type"])),
 				),
 			},
 			// Data sources
@@ -326,29 +317,29 @@ func TestAccDnsMaxResource(t *testing.T) {
 						"stackit_dns_record_set.record_set", "project_id",
 					),
 
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", unwrap(testConfigVarsMax["acl"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", unwrap(testConfigVarsMax["active"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", unwrap(testConfigVarsMax["contact_email"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", unwrap(testConfigVarsMax["default_ttl"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
-					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", testutil.ConvertConfigVariable(testConfigVarsMax["acl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", testutil.ConvertConfigVariable(testConfigVarsMax["active"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", testutil.ConvertConfigVariable(testConfigVarsMax["contact_email"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", testutil.ConvertConfigVariable(testConfigVarsMax["default_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", testutil.ConvertConfigVariable(testConfigVarsMax["description"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", testutil.ConvertConfigVariable(testConfigVarsMax["expire_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", testutil.ConvertConfigVariable(testConfigVarsMax["is_reverse_zone"])),
+					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", testutil.ConvertConfigVariable(testConfigVarsMax["negative_cache"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", unwrap(testConfigVarsMax["retry_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", unwrap(testConfigVarsMax["type"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", testutil.ConvertConfigVariable(testConfigVarsMax["refresh_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", testutil.ConvertConfigVariable(testConfigVarsMax["retry_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", testutil.ConvertConfigVariable(testConfigVarsMax["type"])),
 
 					// Record set data
 					resource.TestCheckResourceAttrSet("data.stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMax["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", testutil.ConvertConfigVariable(testConfigVarsMax["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMax["record_record1"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", unwrap(testConfigVarsMax["record_active"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", unwrap(testConfigVarsMax["record_comment"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", unwrap(testConfigVarsMax["record_ttl"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMax["record_type"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", testutil.ConvertConfigVariable(testConfigVarsMax["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", testutil.ConvertConfigVariable(testConfigVarsMax["record_active"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", testutil.ConvertConfigVariable(testConfigVarsMax["record_comment"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", testutil.ConvertConfigVariable(testConfigVarsMax["record_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", testutil.ConvertConfigVariable(testConfigVarsMax["record_type"])),
 				),
 			},
 			// Import
@@ -403,19 +394,19 @@ func TestAccDnsMaxResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "zone_id"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "state"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", unwrap(testConfigVarsMax["acl"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", unwrap(testConfigVarsMax["active"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", unwrap(testConfigVarsMax["contact_email"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", unwrap(testConfigVarsMax["default_ttl"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
-					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", testutil.ConvertConfigVariable(testConfigVarsMax["acl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", testutil.ConvertConfigVariable(testConfigVarsMax["active"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", testutil.ConvertConfigVariable(testConfigVarsMax["contact_email"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", testutil.ConvertConfigVariable(testConfigVarsMax["default_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", testutil.ConvertConfigVariable(testConfigVarsMax["description"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", testutil.ConvertConfigVariable(testConfigVarsMax["expire_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", testutil.ConvertConfigVariable(testConfigVarsMax["is_reverse_zone"])),
+					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", testutil.ConvertConfigVariable(testConfigVarsMax["negative_cache"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", unwrap(testConfigVarsMax["retry_time"])),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", unwrap(testConfigVarsMax["type"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", testutil.ConvertConfigVariable(testConfigVarsMax["refresh_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", testutil.ConvertConfigVariable(testConfigVarsMax["retry_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", testutil.ConvertConfigVariable(testConfigVarsMax["type"])),
 
 					// Record set data
 					resource.TestCheckResourceAttrPair(
@@ -427,13 +418,13 @@ func TestAccDnsMaxResource(t *testing.T) {
 						"stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMax["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", testutil.ConvertConfigVariable(testConfigVarsMax["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(configVarsMaxUpdated()["record_record1"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", unwrap(testConfigVarsMax["record_active"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", unwrap(testConfigVarsMax["record_comment"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", unwrap(testConfigVarsMax["record_ttl"])),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMax["record_type"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", testutil.ConvertConfigVariable(configVarsMaxUpdated()["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", testutil.ConvertConfigVariable(testConfigVarsMax["record_active"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", testutil.ConvertConfigVariable(testConfigVarsMax["record_comment"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", testutil.ConvertConfigVariable(testConfigVarsMax["record_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", testutil.ConvertConfigVariable(testConfigVarsMax["record_type"])),
 				),
 			},
 			// Deletion is done by the framework implicitly

--- a/stackit/internal/services/dns/dns_acc_test.go
+++ b/stackit/internal/services/dns/dns_acc_test.go
@@ -2,14 +2,18 @@ package dns_test
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
+	"log"
+	"maps"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	core_config "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/dns"
 	"github.com/stackitcloud/stackit-sdk-go/services/dns/wait"
@@ -17,129 +21,88 @@ import (
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
 
-// Zone resource data
-var zoneResource = map[string]string{
-	"project_id":          testutil.ProjectId,
-	"name":                testutil.ResourceNameWithDateTime("zone"),
-	"dns_name":            fmt.Sprintf("www.%s.com", acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)),
-	"dns_name_min":        fmt.Sprintf("www.%s.com", acctest.RandStringFromCharSet(20, acctest.CharSetAlpha)),
-	"description":         "my description",
-	"description_updated": "my description updated",
-	"acl":                 "192.168.0.0/24",
-	"active":              "true",
-	"contact_email":       "aa@bb.cc",
-	"ttl":                 "120",
-	"ttl_updated":         "4440",
-	"expire_time":         "123456",
-	"is_reverse_zone":     "false",
-	"negative_cache":      "60",
-	"primaries":           "1.2.3.4",
-	"refresh_time":        "500",
-	"retry_time":          "700",
-	"type":                "primary",
+var (
+	//go:embed testdata/resource-min.tf
+	resourceMinConfig string
+
+	//go:embed testdata/resource-max.tf
+	resourceMaxConfig string
+)
+
+var testConfigVarsMin = config.Variables{
+	"project_id":     config.StringVariable(testutil.ProjectId),
+	"name":           config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"dns_name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha) + ".example.home"),
+	"record_name":    config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"record_record1": config.StringVariable("1.2.3.4"),
+	"record_type":    config.StringVariable("A"),
 }
 
-// Record set resource data
-var recordSetResource = map[string]string{
-	"name":            fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)),
-	"name_min":        fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)),
-	"records":         `"1.2.3.4"`,
-	"records_updated": `"5.6.7.8", "9.10.11.12"`,
-	"ttl":             "3700",
-	"type":            "A",
-	"active":          "true",
-	"comment":         "a comment",
+var testConfigVarsMax = config.Variables{
+	"project_id":      config.StringVariable(testutil.ProjectId),
+	"name":            config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"dns_name":        config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha) + ".example.home"),
+	"acl":             config.StringVariable("0.0.0.0/0"),
+	"active":          config.BoolVariable(true),
+	"contact_email":   config.StringVariable("contact@example.com"),
+	"default_ttl":     config.IntegerVariable(3600),
+	"description":     config.StringVariable("a test description"),
+	"expire_time":     config.IntegerVariable(1 * 24 * 60 * 60),
+	"is_reverse_zone": config.BoolVariable(false),
+	"negative_cache":  config.IntegerVariable(128),
+	"primaries":       config.ListVariable(config.StringVariable("1.1.1.1")),
+	"refresh_time":    config.IntegerVariable(3600),
+	"retry_time":      config.IntegerVariable(600),
+	"type":            config.StringVariable("primary"),
+
+	"record_name":    config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"record_record1": config.StringVariable("1.2.3.4"),
+	"record_active":  config.BoolVariable(true),
+	"record_comment": config.StringVariable("a test comment"),
+	"record_ttl":     config.IntegerVariable(3600),
+	"record_type":    config.StringVariable("A"),
 }
 
-func inputConfig(zoneName, description, ttl, records string) string {
-	return fmt.Sprintf(`
-		%s
-
-		resource "stackit_dns_zone" "zone" {
-			project_id = "%s"
-			name    = "%s"
-			dns_name = "%s"
-			description = "%s"
-			acl = "%s"
-			active = %s
-			contact_email = "%s"
-			default_ttl = %s
-			expire_time = %s
-			is_reverse_zone = %s
-			negative_cache = %s
-			primaries = ["%s"]
-			refresh_time = %s
-			retry_time = %s
-			type = "%s"
-		}
-
-		resource "stackit_dns_record_set" "record_set" {
-			project_id = stackit_dns_zone.zone.project_id
-			zone_id    = stackit_dns_zone.zone.zone_id
-			name       = "%s"
-			records    = [%s]
-			type       = "%s"
-			ttl 	   =  %s
-			comment    = "%s"
-			active     =  %s
-
-		}
-		`,
-		testutil.DnsProviderConfig(),
-		zoneResource["project_id"],
-		zoneName,
-		zoneResource["dns_name"],
-		description,
-		zoneResource["acl"],
-		zoneResource["active"],
-		zoneResource["contact_email"],
-		ttl,
-		zoneResource["expire_time"],
-		zoneResource["is_reverse_zone"],
-		zoneResource["negative_cache"],
-		zoneResource["primaries"],
-		zoneResource["refresh_time"],
-		zoneResource["retry_time"],
-		zoneResource["type"],
-		recordSetResource["name"],
-		records,
-		recordSetResource["type"],
-		recordSetResource["ttl"],
-		recordSetResource["comment"],
-		recordSetResource["active"],
-	)
+func configVarsInvalid(vars config.Variables) config.Variables {
+	tempConfig := maps.Clone(vars)
+	tempConfig["dns_name"] = config.StringVariable("foo")
+	return tempConfig
 }
 
-func TestAccDnsResource(t *testing.T) {
+func configVarsMinUpdated() config.Variables {
+	tempConfig := maps.Clone(testConfigVarsMin)
+	tempConfig["record_record1"] = config.StringVariable("1.2.3.5")
+
+	return tempConfig
+}
+
+func configVarsMaxUpdated() config.Variables {
+	tempConfig := maps.Clone(testConfigVarsMax)
+	tempConfig["record_record1"] = config.StringVariable("1.2.3.5")
+	return tempConfig
+}
+
+func unwrap(v config.Variable) string {
+	tmp, err := v.MarshalJSON()
+	if err != nil {
+		log.Panicf("cannot marshal variable %v: %v", v, err)
+	}
+	return strings.Trim(string(tmp), `"`)
+}
+
+func TestAccDnsMinResource(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckDnsDestroy,
 		Steps: []resource.TestStep{
 			// Creation
 			{
-				Config: inputConfig(zoneResource["name"], zoneResource["description"], zoneResource["ttl"], recordSetResource["records"]),
+				Config:          resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Zone data
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", zoneResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "zone_id"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "name", zoneResource["name"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "dns_name", zoneResource["dns_name"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", zoneResource["description"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", zoneResource["acl"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", zoneResource["active"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", zoneResource["contact_email"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", zoneResource["ttl"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", zoneResource["expire_time"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", zoneResource["is_reverse_zone"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", zoneResource["negative_cache"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.0", zoneResource["primaries"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", zoneResource["refresh_time"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", zoneResource["retry_time"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", zoneResource["type"]),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primary_name_server"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "serial_number"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "visibility"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "state"),
 
 					// Record set data
@@ -152,36 +115,19 @@ func TestAccDnsResource(t *testing.T) {
 						"stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", recordSetResource["name"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "fqdn", recordSetResource["name"]+"."+zoneResource["dns_name"]+"."),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMin["record_name"])),
 					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", strings.ReplaceAll(recordSetResource["records"], "\"", "")),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", recordSetResource["type"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", recordSetResource["ttl"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", recordSetResource["comment"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", recordSetResource["active"]),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMin["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMin["record_type"])),
 				),
 			},
 			// Data sources
 			{
-				Config: fmt.Sprintf(`
-					%s
-
-					data "stackit_dns_zone" "zone" {
-						project_id = stackit_dns_zone.zone.project_id
-						zone_id    = stackit_dns_zone.zone.zone_id
-					}
-
-					data "stackit_dns_record_set" "record_set" {
-						project_id = stackit_dns_zone.zone.project_id
-						zone_id    = stackit_dns_zone.zone.zone_id
-						record_set_id = stackit_dns_record_set.record_set.record_set_id
-					}`,
-					inputConfig(zoneResource["name"], zoneResource["description"], zoneResource["ttl"], recordSetResource["records"]),
-				),
+				Config:          resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Zone data
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "project_id", zoneResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrPair(
 						"stackit_dns_zone.zone", "zone_id",
 						"data.stackit_dns_zone.zone", "zone_id",
@@ -198,42 +144,19 @@ func TestAccDnsResource(t *testing.T) {
 						"data.stackit_dns_record_set.record_set", "project_id",
 						"stackit_dns_record_set.record_set", "project_id",
 					),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "name", zoneResource["name"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "default_ttl", zoneResource["ttl"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "dns_name", zoneResource["dns_name"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "description", zoneResource["description"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "acl", zoneResource["acl"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "active", zoneResource["active"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "contact_email", zoneResource["contact_email"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "default_ttl", zoneResource["ttl"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "expire_time", zoneResource["expire_time"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "is_reverse_zone", zoneResource["is_reverse_zone"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "negative_cache", zoneResource["negative_cache"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "primaries.#", "1"),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "primaries.0", zoneResource["primaries"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "refresh_time", zoneResource["refresh_time"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "retry_time", zoneResource["retry_time"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "type", zoneResource["type"]),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone", "primary_name_server"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone", "serial_number"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone", "visibility"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone", "state"),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone", "record_count", "4"),
 
 					// Record set data
 					resource.TestCheckResourceAttrSet("data.stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set", "name", recordSetResource["name"]+"."+zoneResource["dns_name"]+"."),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set", "fqdn", recordSetResource["name"]+"."+zoneResource["dns_name"]+"."),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set", "records.#", "1"),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set", "type", recordSetResource["type"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set", "ttl", recordSetResource["ttl"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set", "comment", recordSetResource["comment"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set", "active", recordSetResource["active"]),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMin["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMin["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMin["record_type"])),
 				),
 			},
 			// Import
 			{
-				ResourceName: "stackit_dns_zone.zone",
+				ConfigVariables: testConfigVarsMin,
+				ResourceName:    "stackit_dns_zone.zone",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_dns_zone.zone"]
 					if !ok {
@@ -250,7 +173,8 @@ func TestAccDnsResource(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName: "stackit_dns_record_set.record_set",
+				ConfigVariables: testConfigVarsMin,
+				ResourceName:    "stackit_dns_record_set.record_set",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_dns_record_set.record_set"]
 					if !ok {
@@ -274,29 +198,12 @@ func TestAccDnsResource(t *testing.T) {
 			},
 			// Update. The zone ttl should not be updated according to the DNS API.
 			{
-				Config: inputConfig(zoneResource["name"], zoneResource["description_updated"], zoneResource["ttl"], recordSetResource["records_updated"]),
+				Config:          resourceMinConfig,
+				ConfigVariables: configVarsMinUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Zone data
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", zoneResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "zone_id"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "name", zoneResource["name"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "dns_name", zoneResource["dns_name"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", zoneResource["description_updated"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", zoneResource["acl"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", zoneResource["active"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", zoneResource["contact_email"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", zoneResource["ttl"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", zoneResource["expire_time"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", zoneResource["is_reverse_zone"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", zoneResource["negative_cache"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.0", zoneResource["primaries"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", zoneResource["refresh_time"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", zoneResource["retry_time"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", zoneResource["type"]),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primary_name_server"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "serial_number"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "visibility"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "state"),
 
 					// Record set data
@@ -309,13 +216,10 @@ func TestAccDnsResource(t *testing.T) {
 						"stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", recordSetResource["name"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "fqdn", recordSetResource["name"]+"."+zoneResource["dns_name"]+"."),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "2"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", recordSetResource["type"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", recordSetResource["ttl"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", recordSetResource["comment"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", recordSetResource["active"]),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMin["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(configVarsMinUpdated()["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMin["record_type"])),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -323,164 +227,111 @@ func TestAccDnsResource(t *testing.T) {
 	})
 }
 
-func inputConfigMinimal() string {
-	return fmt.Sprintf(`
-		%s
-
-		resource "stackit_dns_zone" "zone_min" {
-			project_id = "%s"
-			name    = "%s"
-			dns_name = "%s"
-			contact_email = "%s"
-			type = "%s"
-			acl = "%s"
-		}
-
-		resource "stackit_dns_record_set" "record_set_min" {
-			project_id = stackit_dns_zone.zone_min.project_id
-			zone_id    = stackit_dns_zone.zone_min.zone_id
-			name       = "%s"
-			records    = [%s]
-			type       = "%s"
-		}
-		`,
-		testutil.DnsProviderConfig(),
-		zoneResource["project_id"],
-		zoneResource["name"],
-		zoneResource["dns_name_min"],
-		zoneResource["contact_email"],
-		zoneResource["type"],
-		zoneResource["acl"],
-		recordSetResource["name_min"],
-		recordSetResource["records"],
-		recordSetResource["type"],
-	)
-}
-
-func TestAccDnsMinimalResource(t *testing.T) {
+func TestAccDnsMaxResource(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckDnsDestroy,
 		Steps: []resource.TestStep{
 			// Creation
 			{
-				Config: inputConfigMinimal(),
+				Config:          resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// Zone
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "project_id", zoneResource["project_id"]),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "zone_id"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "name", zoneResource["name"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "dns_name", zoneResource["dns_name_min"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "contact_email", zoneResource["contact_email"]),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "type", zoneResource["type"]),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "acl"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "active", "true"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "default_ttl"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "expire_time"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "is_reverse_zone", "false"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "negative_cache"),
-					resource.TestCheckResourceAttr("stackit_dns_zone.zone_min", "primaries.#", "1"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "refresh_time"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "retry_time"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "primary_name_server"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "serial_number"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "visibility"),
-					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone_min", "state"),
+					// Zone data
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "zone_id"),
+					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "state"),
 
-					// Record set
+					// Record set data
 					resource.TestCheckResourceAttrPair(
-						"stackit_dns_record_set.record_set_min", "project_id",
-						"stackit_dns_zone.zone_min", "project_id",
+						"stackit_dns_record_set.record_set", "project_id",
+						"stackit_dns_zone.zone", "project_id",
 					),
 					resource.TestCheckResourceAttrPair(
-						"stackit_dns_record_set.record_set_min", "zone_id",
-						"stackit_dns_zone.zone_min", "zone_id",
+						"stackit_dns_record_set.record_set", "zone_id",
+						"stackit_dns_zone.zone", "zone_id",
 					),
-					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set_min", "record_set_id"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set_min", "name", recordSetResource["name_min"]),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set_min", "fqdn", recordSetResource["name_min"]+"."+zoneResource["dns_name_min"]+"."),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set_min", "records.#", "1"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set_min", "records.0", strings.ReplaceAll(recordSetResource["records"], "\"", "")),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set_min", "type", recordSetResource["type"]),
-					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set_min", "ttl"),
-					resource.TestCheckNoResourceAttr("stackit_dns_record_set.record_set_min", "comment"),
-					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set_min", "active", "true"),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", unwrap(testConfigVarsMax["acl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", unwrap(testConfigVarsMax["active"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", unwrap(testConfigVarsMax["contact_email"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", unwrap(testConfigVarsMax["default_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
+					//resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
+					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", unwrap(testConfigVarsMax["retry_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", unwrap(testConfigVarsMax["type"])),
+
+					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMax["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMax["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", unwrap(testConfigVarsMax["record_active"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", unwrap(testConfigVarsMax["record_comment"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", unwrap(testConfigVarsMax["record_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMax["record_type"])),
 				),
 			},
 			// Data sources
 			{
-				Config: fmt.Sprintf(`
-					%s
-
-					data "stackit_dns_zone" "zone_min" {
-						project_id = stackit_dns_zone.zone_min.project_id
-						zone_id    = stackit_dns_zone.zone_min.zone_id
-					}
-
-					data "stackit_dns_record_set" "record_set_min" {
-						project_id = stackit_dns_zone.zone_min.project_id
-						zone_id    = stackit_dns_zone.zone_min.zone_id
-						record_set_id = stackit_dns_record_set.record_set_min.record_set_id
-					}`,
-					inputConfigMinimal(),
-				),
+				Config:          resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Zone data
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "project_id", zoneResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrPair(
-						"stackit_dns_zone.zone_min", "zone_id",
-						"data.stackit_dns_zone.zone_min", "zone_id",
+						"stackit_dns_zone.zone", "zone_id",
+						"data.stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrPair(
-						"data.stackit_dns_record_set.record_set_min", "zone_id",
-						"data.stackit_dns_zone.zone_min", "zone_id",
+						"data.stackit_dns_record_set.record_set", "zone_id",
+						"data.stackit_dns_zone.zone", "zone_id",
 					),
 					resource.TestCheckResourceAttrPair(
-						"data.stackit_dns_record_set.record_set_min", "project_id",
-						"data.stackit_dns_zone.zone_min", "project_id",
+						"data.stackit_dns_record_set.record_set", "project_id",
+						"data.stackit_dns_zone.zone", "project_id",
 					),
 					resource.TestCheckResourceAttrPair(
-						"data.stackit_dns_record_set.record_set_min", "project_id",
-						"stackit_dns_record_set.record_set_min", "project_id",
+						"data.stackit_dns_record_set.record_set", "project_id",
+						"stackit_dns_record_set.record_set", "project_id",
 					),
 
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "project_id", zoneResource["project_id"]),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "zone_id"),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "name", zoneResource["name"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "dns_name", zoneResource["dns_name_min"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "contact_email", zoneResource["contact_email"]),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "type", zoneResource["type"]),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "acl"),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "active", "true"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "default_ttl"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "expire_time"),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "is_reverse_zone", "false"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "negative_cache"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "primary_name_server"),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "primaries.#", "1"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "refresh_time"),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_zone.zone_min", "retry_time"),
-					resource.TestCheckResourceAttr("data.stackit_dns_zone.zone_min", "record_count", "4"),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", unwrap(testConfigVarsMax["acl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", unwrap(testConfigVarsMax["active"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", unwrap(testConfigVarsMax["contact_email"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", unwrap(testConfigVarsMax["default_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
+					//resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
+					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", unwrap(testConfigVarsMax["retry_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", unwrap(testConfigVarsMax["type"])),
 
 					// Record set data
-					resource.TestCheckResourceAttrSet("data.stackit_dns_record_set.record_set_min", "record_set_id"),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set_min", "name", recordSetResource["name_min"]+"."+zoneResource["dns_name_min"]+"."),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set_min", "fqdn", recordSetResource["name_min"]+"."+zoneResource["dns_name_min"]+"."),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set_min", "records.#", "1"),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set_min", "records.0", strings.ReplaceAll(recordSetResource["records"], "\"", "")),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set_min", "type", recordSetResource["type"]),
-					resource.TestCheckResourceAttrSet("data.stackit_dns_record_set.record_set_min", "ttl"),
-					resource.TestCheckNoResourceAttr("data.stackit_dns_record_set.record_set_min", "comment"),
-					resource.TestCheckResourceAttr("data.stackit_dns_record_set.record_set_min", "active", "true"),
+					resource.TestCheckResourceAttrSet("data.stackit_dns_record_set.record_set", "record_set_id"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMax["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(testConfigVarsMax["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", unwrap(testConfigVarsMax["record_active"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", unwrap(testConfigVarsMax["record_comment"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", unwrap(testConfigVarsMax["record_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMax["record_type"])),
 				),
 			},
 			// Import
 			{
-				ResourceName: "stackit_dns_zone.zone_min",
+				ConfigVariables: testConfigVarsMax,
+				ResourceName:    "stackit_dns_zone.zone",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					r, ok := s.RootModule().Resources["stackit_dns_zone.zone_min"]
+					r, ok := s.RootModule().Resources["stackit_dns_zone.zone"]
 					if !ok {
-						return "", fmt.Errorf("couldn't find resource stackit_dns_zone.zone_min")
+						return "", fmt.Errorf("couldn't find resource stackit_dns_zone.recozonerd_set")
 					}
 					zoneId, ok := r.Primary.Attributes["zone_id"]
 					if !ok {
@@ -493,11 +344,12 @@ func TestAccDnsMinimalResource(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName: "stackit_dns_record_set.record_set_min",
+				ConfigVariables: testConfigVarsMax,
+				ResourceName:    "stackit_dns_record_set.record_set",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					r, ok := s.RootModule().Resources["stackit_dns_record_set.record_set_min"]
+					r, ok := s.RootModule().Resources["stackit_dns_record_set.record_set"]
 					if !ok {
-						return "", fmt.Errorf("couldn't find resource stackit_dns_record_set.record_set_min")
+						return "", fmt.Errorf("couldn't find resource stackit_dns_record_set.record_set")
 					}
 					zoneId, ok := r.Primary.Attributes["zone_id"]
 					if !ok {
@@ -510,9 +362,52 @@ func TestAccDnsMinimalResource(t *testing.T) {
 
 					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, zoneId, recordSetId), nil
 				},
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// Will be different because of the name vs fqdn problem, but the value is already tested in the datasource acc test
 				ImportStateVerifyIgnore: []string{"name"},
+			},
+			// Update. The zone ttl should not be updated according to the DNS API.
+			{
+				Config:          resourceMaxConfig,
+				ConfigVariables: configVarsMaxUpdated(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Zone data
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "zone_id"),
+					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "state"),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "acl", unwrap(testConfigVarsMax["acl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "active", unwrap(testConfigVarsMax["active"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "contact_email", unwrap(testConfigVarsMax["contact_email"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "default_ttl", unwrap(testConfigVarsMax["default_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
+					//resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
+					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "retry_time", unwrap(testConfigVarsMax["retry_time"])),
+					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "type", unwrap(testConfigVarsMax["type"])),
+
+					// Record set data
+					resource.TestCheckResourceAttrPair(
+						"stackit_dns_record_set.record_set", "project_id",
+						"stackit_dns_zone.zone", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_dns_record_set.record_set", "zone_id",
+						"stackit_dns_zone.zone", "zone_id",
+					),
+					resource.TestCheckResourceAttrSet("stackit_dns_record_set.record_set", "record_set_id"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "name", unwrap(testConfigVarsMax["record_name"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.#", "1"),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "records.0", unwrap(configVarsMaxUpdated()["record_record1"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "active", unwrap(testConfigVarsMax["record_active"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "comment", unwrap(testConfigVarsMax["record_comment"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "ttl", unwrap(testConfigVarsMax["record_ttl"])),
+					resource.TestCheckResourceAttr("stackit_dns_record_set.record_set", "type", unwrap(testConfigVarsMax["record_type"])),
+				),
 			},
 			// Deletion is done by the framework implicitly
 		},
@@ -527,7 +422,7 @@ func testAccCheckDnsDestroy(s *terraform.State) error {
 		client, err = dns.NewAPIClient()
 	} else {
 		client, err = dns.NewAPIClient(
-			config.WithEndpoint(testutil.DnsCustomEndpoint),
+			core_config.WithEndpoint(testutil.DnsCustomEndpoint),
 		)
 	}
 	if err != nil {

--- a/stackit/internal/services/dns/dns_acc_test.go
+++ b/stackit/internal/services/dns/dns_acc_test.go
@@ -100,7 +100,7 @@ func TestAccDnsMinResource(t *testing.T) {
 			{
 				Config:          resourceMinConfig,
 				ConfigVariables: configVarsInvalid(testConfigVarsMin),
-				ExpectError: regexp.MustCompile(`not a valid dns name. Need at least two levels`),
+				ExpectError:     regexp.MustCompile(`not a valid dns name. Need at least two levels`),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Zone data
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "project_id", testutil.ProjectId),
@@ -285,7 +285,7 @@ func TestAccDnsMaxResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
-					//resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
@@ -333,7 +333,7 @@ func TestAccDnsMaxResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
-					//resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),
@@ -410,7 +410,7 @@ func TestAccDnsMaxResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "description", unwrap(testConfigVarsMax["description"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "expire_time", unwrap(testConfigVarsMax["expire_time"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "is_reverse_zone", unwrap(testConfigVarsMax["is_reverse_zone"])),
-					//resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
+					// resource.TestCheckResourceAttr("stackit_dns_zone.zone", "negative_cache", unwrap(testConfigVarsMax["negative_cache"])),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "primaries.#", "1"),
 					resource.TestCheckResourceAttrSet("stackit_dns_zone.zone", "primaries.0"),
 					resource.TestCheckResourceAttr("stackit_dns_zone.zone", "refresh_time", unwrap(testConfigVarsMax["refresh_time"])),

--- a/stackit/internal/services/dns/recordset/resource.go
+++ b/stackit/internal/services/dns/recordset/resource.go
@@ -176,8 +176,7 @@ func (r *recordSetResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"type": schema.StringAttribute{
 				Description: "The record set type. E.g. `A` or `CNAME`",
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 					stringplanmodifier.RequiresReplace(),

--- a/stackit/internal/services/dns/testdata/resource-max.tf
+++ b/stackit/internal/services/dns/testdata/resource-max.tf
@@ -8,7 +8,7 @@ variable "default_ttl" {}
 variable "description" {}
 variable "expire_time" {}
 variable "is_reverse_zone" {}
-variable "negative_cache" {}
+# variable "negative_cache" {}
 variable "primaries" {}
 variable "refresh_time" {}
 variable "retry_time" {}
@@ -35,7 +35,7 @@ resource "stackit_dns_zone" "zone" {
   description     = var.description
   expire_time     = var.expire_time
   is_reverse_zone = var.is_reverse_zone
-//  negative_cache  = var.negative_cache
+  # negative_cache  = var.negative_cache
   primaries       = var.primaries
   refresh_time    = var.refresh_time
   retry_time      = var.retry_time

--- a/stackit/internal/services/dns/testdata/resource-max.tf
+++ b/stackit/internal/services/dns/testdata/resource-max.tf
@@ -1,0 +1,69 @@
+variable "project_id" {}
+variable "name" {}
+variable "dns_name" {}
+variable "acl" {}
+variable "active" {}
+variable "contact_email" {}
+variable "default_ttl" {}
+variable "description" {}
+variable "expire_time" {}
+variable "is_reverse_zone" {}
+variable "negative_cache" {}
+variable "primaries" {}
+variable "refresh_time" {}
+variable "retry_time" {}
+variable "type" {}
+
+variable "record_name" {}
+variable "record_record1" {}
+variable "record_active" {}
+variable "record_comment" {}
+variable "record_ttl" {}
+variable "record_type" {}
+
+
+
+
+resource "stackit_dns_zone" "zone" {
+  project_id      = var.project_id
+  name            = var.name
+  dns_name        = var.dns_name
+  acl             = var.acl
+  active          = var.active
+  contact_email   = var.contact_email
+  default_ttl     = var.default_ttl
+  description     = var.description
+  expire_time     = var.expire_time
+  is_reverse_zone = var.is_reverse_zone
+//  negative_cache  = var.negative_cache
+  primaries       = var.primaries
+  refresh_time    = var.refresh_time
+  retry_time      = var.retry_time
+  type            = var.type
+}
+
+
+resource "stackit_dns_record_set" "record_set" {
+  project_id = var.project_id
+  zone_id    = stackit_dns_zone.zone.zone_id
+  name       = var.record_name
+  records = [
+    var.record_record1
+  ]
+
+  active  = var.record_active
+  comment = var.record_comment
+  ttl     = var.record_ttl
+  type    = var.record_type
+}
+
+data "stackit_dns_zone" "zone" {
+  project_id = var.project_id
+  zone_id    = stackit_dns_zone.zone.zone_id
+}
+
+data "stackit_dns_record_set" "record_set" {
+  project_id    = var.project_id
+  zone_id       = stackit_dns_zone.zone.zone_id
+  record_set_id = stackit_dns_record_set.record_set.record_set_id
+}

--- a/stackit/internal/services/dns/testdata/resource-min.tf
+++ b/stackit/internal/services/dns/testdata/resource-min.tf
@@ -1,0 +1,36 @@
+variable "project_id" {}
+variable "name" {}
+variable "dns_name" {}
+
+variable "record_name" {}
+variable "record_record1" {}
+variable "record_type" {}
+
+
+resource "stackit_dns_zone" "zone" {
+  project_id = var.project_id
+  name       = var.name
+  dns_name   = var.dns_name
+}
+
+
+resource "stackit_dns_record_set" "record_set" {
+  project_id = var.project_id
+  zone_id    = stackit_dns_zone.zone.zone_id
+  name       = var.record_name
+  records = [
+    var.record_record1
+  ]
+  type = var.record_type
+}
+
+data "stackit_dns_zone" "zone" {
+  project_id = var.project_id
+  zone_id    = stackit_dns_zone.zone.zone_id
+}
+
+data "stackit_dns_record_set" "record_set" {
+  project_id    = var.project_id
+  zone_id       = stackit_dns_zone.zone.zone_id
+  record_set_id = stackit_dns_record_set.record_set.record_set_id
+}

--- a/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
+++ b/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
@@ -70,7 +70,7 @@ func TestAccSecretsManagerMin(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Creation fail
 			{
-				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMinConfig,
+				Config:          testutil.SecretsManagerProviderConfig() + "\n" + resourceMinConfig,
 				ConfigVariables: configVarsInvalid(testConfigVarsMin),
 				ExpectError:     regexp.MustCompile(`input variable "instance_name" is not set,`),
 			},
@@ -113,7 +113,7 @@ func TestAccSecretsManagerMin(t *testing.T) {
 						"data.stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMin["instance_name"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "0"),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "acls.#", "0"),
 
 					// User
 					resource.TestCheckResourceAttrPair(
@@ -219,7 +219,7 @@ func TestAccSecretsManagerMax(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Creation fail
 			{
-				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMaxConfig,
+				Config:          testutil.SecretsManagerProviderConfig() + "\n" + resourceMaxConfig,
 				ConfigVariables: configVarsInvalid(testConfigVarsMax),
 				ExpectError:     regexp.MustCompile(`input variable "instance_name" is not set,`),
 			},
@@ -264,9 +264,9 @@ func TestAccSecretsManagerMax(t *testing.T) {
 						"data.stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMax["instance_name"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", testutil.ConvertConfigVariable(testConfigVarsMax["acl1"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", testutil.ConvertConfigVariable(testConfigVarsMax["acl2"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "acls.#", "2"),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "acls.0", testutil.ConvertConfigVariable(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "acls.1", testutil.ConvertConfigVariable(testConfigVarsMax["acl2"])),
 
 					// User
 					resource.TestCheckResourceAttrPair(

--- a/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
+++ b/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
 	"maps"
 	"regexp"
 	"strings"
@@ -28,14 +27,6 @@ var (
 	//go:embed testdata/resource-max.tf
 	resourceMaxConfig string
 )
-
-func unwrap(v config.Variable) string {
-	tmp, err := v.MarshalJSON()
-	if err != nil {
-		log.Panicf("cannot marshal variable %v: %v", v, err)
-	}
-	return strings.Trim(string(tmp), `"`)
-}
 
 var testConfigVarsMin = config.Variables{
 	"project_id":       config.StringVariable(testutil.ProjectId),
@@ -89,9 +80,9 @@ func TestAccSecretsManagerMin(t *testing.T) {
 				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMin["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMin["instance_name"])),
 					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "0"),
 
 					// User
@@ -104,8 +95,8 @@ func TestAccSecretsManagerMin(t *testing.T) {
 						"stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMin["user_description"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMin["write_enabled"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", testutil.ConvertConfigVariable(testConfigVarsMin["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", testutil.ConvertConfigVariable(testConfigVarsMin["write_enabled"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
 				),
@@ -116,12 +107,12 @@ func TestAccSecretsManagerMin(t *testing.T) {
 				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrPair(
 						"stackit_secretsmanager_instance.instance", "instance_id",
 						"data.stackit_secretsmanager_instance.instance", "instance_id",
 					),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMin["instance_name"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMin["instance_name"])),
 					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "0"),
 
 					// User
@@ -137,8 +128,8 @@ func TestAccSecretsManagerMin(t *testing.T) {
 						"stackit_secretsmanager_user.user", "user_id",
 						"data.stackit_secretsmanager_user.user", "user_id",
 					),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMin["user_description"])),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMin["write_enabled"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "description", testutil.ConvertConfigVariable(testConfigVarsMin["user_description"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "write_enabled", testutil.ConvertConfigVariable(testConfigVarsMin["write_enabled"])),
 					resource.TestCheckResourceAttrPair(
 						"stackit_secretsmanager_user.user", "username",
 						"data.stackit_secretsmanager_user.user", "username",
@@ -194,9 +185,9 @@ func TestAccSecretsManagerMin(t *testing.T) {
 				ConfigVariables: configVarsMinUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(configVarsMinUpdated()["project_id"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", testutil.ConvertConfigVariable(configVarsMinUpdated()["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(configVarsMinUpdated()["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(configVarsMinUpdated()["instance_name"])),
 					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "0"),
 
 					// User
@@ -209,8 +200,8 @@ func TestAccSecretsManagerMin(t *testing.T) {
 						"stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(configVarsMinUpdated()["user_description"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(configVarsMinUpdated()["write_enabled"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", testutil.ConvertConfigVariable(configVarsMinUpdated()["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", testutil.ConvertConfigVariable(configVarsMinUpdated()["write_enabled"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
 				),
@@ -238,12 +229,12 @@ func TestAccSecretsManagerMax(t *testing.T) {
 				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMax["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMax["instance_name"])),
 					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", unwrap(testConfigVarsMax["acl1"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", unwrap(testConfigVarsMax["acl2"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", testutil.ConvertConfigVariable(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", testutil.ConvertConfigVariable(testConfigVarsMax["acl2"])),
 
 					// User
 					resource.TestCheckResourceAttrPair(
@@ -255,8 +246,8 @@ func TestAccSecretsManagerMax(t *testing.T) {
 						"stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMax["user_description"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMax["write_enabled"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", testutil.ConvertConfigVariable(testConfigVarsMax["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", testutil.ConvertConfigVariable(testConfigVarsMax["write_enabled"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
 				),
@@ -267,15 +258,15 @@ func TestAccSecretsManagerMax(t *testing.T) {
 				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
 					resource.TestCheckResourceAttrPair(
 						"stackit_secretsmanager_instance.instance", "instance_id",
 						"data.stackit_secretsmanager_instance.instance", "instance_id",
 					),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMax["instance_name"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMax["instance_name"])),
 					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", unwrap(testConfigVarsMax["acl1"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", unwrap(testConfigVarsMax["acl2"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", testutil.ConvertConfigVariable(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", testutil.ConvertConfigVariable(testConfigVarsMax["acl2"])),
 
 					// User
 					resource.TestCheckResourceAttrPair(
@@ -290,8 +281,8 @@ func TestAccSecretsManagerMax(t *testing.T) {
 						"stackit_secretsmanager_user.user", "user_id",
 						"data.stackit_secretsmanager_user.user", "user_id",
 					),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMax["user_description"])),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMax["write_enabled"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "description", testutil.ConvertConfigVariable(testConfigVarsMax["user_description"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "write_enabled", testutil.ConvertConfigVariable(testConfigVarsMax["write_enabled"])),
 					resource.TestCheckResourceAttrPair(
 						"stackit_secretsmanager_user.user", "username",
 						"data.stackit_secretsmanager_user.user", "username",
@@ -347,12 +338,12 @@ func TestAccSecretsManagerMax(t *testing.T) {
 				ConfigVariables: configVarsMaxUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(configVarsMaxUpdated()["project_id"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", testutil.ConvertConfigVariable(configVarsMaxUpdated()["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(configVarsMaxUpdated()["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", testutil.ConvertConfigVariable(configVarsMaxUpdated()["instance_name"])),
 					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", unwrap(configVarsMaxUpdated()["acl1"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", unwrap(configVarsMaxUpdated()["acl2"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", testutil.ConvertConfigVariable(configVarsMaxUpdated()["acl1"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", testutil.ConvertConfigVariable(configVarsMaxUpdated()["acl2"])),
 
 					// User
 					resource.TestCheckResourceAttrPair(
@@ -364,8 +355,8 @@ func TestAccSecretsManagerMax(t *testing.T) {
 						"stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(configVarsMaxUpdated()["user_description"])),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(configVarsMaxUpdated()["write_enabled"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", testutil.ConvertConfigVariable(configVarsMaxUpdated()["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", testutil.ConvertConfigVariable(configVarsMaxUpdated()["write_enabled"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
 				),

--- a/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
+++ b/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
@@ -215,7 +215,7 @@ func TestAccSecretsManagerMin(t *testing.T) {
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
 				),
 			},
-			
+
 			// Deletion is done by the framework implicitly
 		},
 	})

--- a/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
+++ b/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
@@ -2,111 +2,97 @@ package secretsmanager_test
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
+	"log"
+	"maps"
+	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	core_config "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/secretsmanager"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
 
-// Instance resource data
-var instanceResource = map[string]string{
-	"project_id":    testutil.ProjectId,
-	"name":          fmt.Sprintf("acc-test-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-	"acl-0":         "1.2.3.4/5",
-	"acl-1":         "111.222.111.222/11",
-	"acl-1-updated": "111.222.111.222/22",
-}
+var (
+	//go:embed testdata/resource-min.tf
+	resourceMinConfig string
 
-// User resource data
-var userResource = map[string]string{
-	"description":           testutil.ResourceNameWithDateTime("secretsmanager"),
-	"write_enabled":         "false",
-	"write_enabled_updated": "true",
-}
+	//go:embed testdata/resource-max.tf
+	resourceMaxConfig string
+)
 
-func resourceConfig(acls *string, writeEnabled string) string {
-	if acls == nil {
-		return fmt.Sprintf(`
-					%s
-	
-					resource "stackit_secretsmanager_instance" "instance" {
-						project_id = "%s"
-						name       = "%s"
-					}
-
-					resource "stackit_secretsmanager_user" "user" {
-						project_id = stackit_secretsmanager_instance.instance.project_id
-						instance_id = stackit_secretsmanager_instance.instance.instance_id
-						description = "%s"
-						write_enabled = %s
-					}
-					`,
-			testutil.SecretsManagerProviderConfig(),
-			instanceResource["project_id"],
-			instanceResource["name"],
-			userResource["description"],
-			writeEnabled,
-		)
+func unwrap(v config.Variable) string {
+	tmp, err := v.MarshalJSON()
+	if err != nil {
+		log.Panicf("cannot marshal variable %v: %v", v, err)
 	}
-
-	return fmt.Sprintf(`
-				%s
-
-				resource "stackit_secretsmanager_instance" "instance" {
-					project_id = "%s"
-					name       = "%s"
-					acls = %s
-				}
-
-				resource "stackit_secretsmanager_user" "user" {
-					project_id = stackit_secretsmanager_instance.instance.project_id
-					instance_id = stackit_secretsmanager_instance.instance.instance_id
-					description = "%s"
-					write_enabled = %s
-				}
-				`,
-		testutil.SecretsManagerProviderConfig(),
-		instanceResource["project_id"],
-		instanceResource["name"],
-		*acls,
-		userResource["description"],
-		writeEnabled,
-	)
+	return strings.Trim(string(tmp), `"`)
 }
 
-func TestAccSecretsManager(t *testing.T) {
+var testConfigVarsMin = config.Variables{
+	"project_id":       config.StringVariable(testutil.ProjectId),
+	"instance_name":    config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"user_description": config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"write_enabled":    config.BoolVariable(true),
+}
+
+var testConfigVarsMax = config.Variables{
+	"project_id":       config.StringVariable(testutil.ProjectId),
+	"instance_name":    config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"user_description": config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"acl1":             config.StringVariable("10.100.0.0/24"),
+	"acl2":             config.StringVariable("10.100.1.0/24"),
+	"write_enabled":    config.BoolVariable(true),
+}
+
+func configVarsInvalid(vars config.Variables) config.Variables {
+	tempConfig := maps.Clone(vars)
+	delete(tempConfig, "instance_name")
+	return tempConfig
+}
+
+func configVarsMinUpdated() config.Variables {
+	tempConfig := maps.Clone(testConfigVarsMin)
+	tempConfig["write_enabled"] = config.BoolVariable(false)
+	return tempConfig
+}
+
+func configVarsMaxUpdated() config.Variables {
+	tempConfig := maps.Clone(testConfigVarsMax)
+	tempConfig["write_enabled"] = config.BoolVariable(false)
+	tempConfig["acl2"] = config.StringVariable("10.100.2.0/24")
+	return tempConfig
+}
+
+func TestAccSecretsManagerMin(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckSecretsManagerDestroy,
 		Steps: []resource.TestStep{
-
+			// Creation fail
+			{
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMinConfig,
+				ConfigVariables: configVarsInvalid(testConfigVarsMin),
+				ExpectError:     regexp.MustCompile(`input variable "instance_name" is not set,`),
+			},
 			// Creation
 			{
-				Config: resourceConfig(
-					utils.Ptr(fmt.Sprintf(
-						"[%q, %q, %q]",
-						instanceResource["acl-0"],
-						instanceResource["acl-1"],
-						instanceResource["acl-1"],
-					)),
-					userResource["write_enabled"],
-				),
+				Config:          resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", instanceResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", instanceResource["name"]),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", instanceResource["acl-0"]),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", instanceResource["acl-1"]),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMin["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "0"),
 
 					// User
 					resource.TestCheckResourceAttrPair(
@@ -118,46 +104,25 @@ func TestAccSecretsManager(t *testing.T) {
 						"stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", userResource["description"]),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", userResource["write_enabled"]),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMin["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMin["write_enabled"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
 				),
 			},
 			// Data source
 			{
-				Config: fmt.Sprintf(`
-					%s
-
-					data "stackit_secretsmanager_instance" "instance" {
-						project_id  = stackit_secretsmanager_instance.instance.project_id
-						instance_id = stackit_secretsmanager_instance.instance.instance_id
-					}
-
-					data "stackit_secretsmanager_user" "user" {
-						project_id  = stackit_secretsmanager_user.user.project_id
-						instance_id = stackit_secretsmanager_user.user.instance_id
-						user_id = stackit_secretsmanager_user.user.user_id
-					}`,
-					resourceConfig(
-						utils.Ptr(fmt.Sprintf(
-							"[%q, %q]",
-							instanceResource["acl-0"],
-							instanceResource["acl-1"],
-						)),
-						userResource["write_enabled"],
-					),
-				),
+				Config:          resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "project_id", instanceResource["project_id"]),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrPair(
 						"stackit_secretsmanager_instance.instance", "instance_id",
 						"data.stackit_secretsmanager_instance.instance", "instance_id",
 					),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", instanceResource["name"]),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "acls.0", instanceResource["acl-0"]),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "acls.1", instanceResource["acl-1"]),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMin["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "0"),
 
 					// User
 					resource.TestCheckResourceAttrPair(
@@ -172,8 +137,8 @@ func TestAccSecretsManager(t *testing.T) {
 						"stackit_secretsmanager_user.user", "user_id",
 						"data.stackit_secretsmanager_user.user", "user_id",
 					),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "description", userResource["description"]),
-					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "write_enabled", userResource["write_enabled"]),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMin["user_description"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMin["write_enabled"])),
 					resource.TestCheckResourceAttrPair(
 						"stackit_secretsmanager_user.user", "username",
 						"data.stackit_secretsmanager_user.user", "username",
@@ -182,7 +147,8 @@ func TestAccSecretsManager(t *testing.T) {
 			},
 			// Import
 			{
-				ResourceName: "stackit_secretsmanager_instance.instance",
+				ConfigVariables: testConfigVarsMin,
+				ResourceName:    "stackit_secretsmanager_instance.instance",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_secretsmanager_instance.instance"]
 					if !ok {
@@ -198,7 +164,9 @@ func TestAccSecretsManager(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				ResourceName: "stackit_secretsmanager_user.user",
+				Config:          resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
+				ResourceName:    "stackit_secretsmanager_user.user",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_secretsmanager_user.user"]
 					if !ok {
@@ -222,47 +190,13 @@ func TestAccSecretsManager(t *testing.T) {
 			},
 			// Update
 			{
-				Config: resourceConfig(
-					utils.Ptr(fmt.Sprintf(
-						"[%q, %q]",
-						instanceResource["acl-0"],
-						instanceResource["acl-1-updated"],
-					)),
-					userResource["write_enabled_updated"],
-				),
+				Config:          resourceMinConfig,
+				ConfigVariables: configVarsMinUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", instanceResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(configVarsMinUpdated()["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", instanceResource["name"]),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", instanceResource["acl-0"]),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", instanceResource["acl-1-updated"]),
-
-					// User
-					resource.TestCheckResourceAttrPair(
-						"stackit_secretsmanager_user.user", "project_id",
-						"stackit_secretsmanager_instance.instance", "project_id",
-					),
-					resource.TestCheckResourceAttrPair(
-						"stackit_secretsmanager_user.user", "instance_id",
-						"stackit_secretsmanager_instance.instance", "instance_id",
-					),
-					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", userResource["description"]),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", userResource["write_enabled_updated"]),
-					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
-					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
-				),
-			},
-			// Update, no ACLs
-			{
-				Config: resourceConfig(nil, userResource["write_enabled_updated"]),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Instance data
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", instanceResource["project_id"]),
-					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", instanceResource["name"]),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(configVarsMinUpdated()["instance_name"])),
 					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "0"),
 
 					// User
@@ -275,8 +209,163 @@ func TestAccSecretsManager(t *testing.T) {
 						"stackit_secretsmanager_instance.instance", "instance_id",
 					),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", userResource["description"]),
-					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", userResource["write_enabled_updated"]),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(configVarsMinUpdated()["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(configVarsMinUpdated()["write_enabled"])),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
+				),
+			},
+			
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccSecretsManagerMax(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckSecretsManagerDestroy,
+		Steps: []resource.TestStep{
+			// Creation fail
+			{
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMaxConfig,
+				ConfigVariables: configVarsInvalid(testConfigVarsMax),
+				ExpectError:     regexp.MustCompile(`input variable "instance_name" is not set,`),
+			},
+			// Creation
+			{
+				Config:          resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Instance
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMax["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", unwrap(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", unwrap(testConfigVarsMax["acl2"])),
+
+					// User
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "project_id",
+						"stackit_secretsmanager_instance.instance", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "instance_id",
+						"stackit_secretsmanager_instance.instance", "instance_id",
+					),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMax["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMax["write_enabled"])),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
+				),
+			},
+			// Data source
+			{
+				Config:          resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Instance
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_instance.instance", "instance_id",
+						"data.stackit_secretsmanager_instance.instance", "instance_id",
+					),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_instance.instance", "name", unwrap(testConfigVarsMax["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", unwrap(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", unwrap(testConfigVarsMax["acl2"])),
+
+					// User
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "project_id",
+						"data.stackit_secretsmanager_user.user", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "instance_id",
+						"data.stackit_secretsmanager_user.user", "instance_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "user_id",
+						"data.stackit_secretsmanager_user.user", "user_id",
+					),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "description", unwrap(testConfigVarsMax["user_description"])),
+					resource.TestCheckResourceAttr("data.stackit_secretsmanager_user.user", "write_enabled", unwrap(testConfigVarsMax["write_enabled"])),
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "username",
+						"data.stackit_secretsmanager_user.user", "username",
+					),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigVarsMax,
+				ResourceName:    "stackit_secretsmanager_instance.instance",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					r, ok := s.RootModule().Resources["stackit_secretsmanager_instance.instance"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find resource stackit_secretsmanager_instance.instance")
+					}
+					instanceId, ok := r.Primary.Attributes["instance_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute instance_id")
+					}
+					return fmt.Sprintf("%s,%s", testutil.ProjectId, instanceId), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:          resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
+				ResourceName:    "stackit_secretsmanager_user.user",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					r, ok := s.RootModule().Resources["stackit_secretsmanager_user.user"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find resource stackit_secretsmanager_user.user")
+					}
+					instanceId, ok := r.Primary.Attributes["instance_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute instance_id")
+					}
+					userId, ok := r.Primary.Attributes["user_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute user_id")
+					}
+
+					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, instanceId, userId), nil
+				},
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+				Check:                   resource.TestCheckNoResourceAttr("stackit_secretsmanager_user.user", "password"),
+			},
+			// Update
+			{
+				Config:          resourceMaxConfig,
+				ConfigVariables: configVarsMaxUpdated(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Instance
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "project_id", unwrap(configVarsMaxUpdated()["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_instance.instance", "instance_id"),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "name", unwrap(configVarsMaxUpdated()["instance_name"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.#", "2"),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.0", unwrap(configVarsMaxUpdated()["acl1"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_instance.instance", "acls.1", unwrap(configVarsMaxUpdated()["acl2"])),
+
+					// User
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "project_id",
+						"stackit_secretsmanager_instance.instance", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_secretsmanager_user.user", "instance_id",
+						"stackit_secretsmanager_instance.instance", "instance_id",
+					),
+					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "user_id"),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "description", unwrap(configVarsMaxUpdated()["user_description"])),
+					resource.TestCheckResourceAttr("stackit_secretsmanager_user.user", "write_enabled", unwrap(configVarsMaxUpdated()["write_enabled"])),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "username"),
 					resource.TestCheckResourceAttrSet("stackit_secretsmanager_user.user", "password"),
 				),
@@ -292,11 +381,11 @@ func testAccCheckSecretsManagerDestroy(s *terraform.State) error {
 	var err error
 	if testutil.SecretsManagerCustomEndpoint == "" {
 		client, err = secretsmanager.NewAPIClient(
-			config.WithRegion("eu01"),
+			core_config.WithRegion("eu01"),
 		)
 	} else {
 		client, err = secretsmanager.NewAPIClient(
-			config.WithEndpoint(testutil.SecretsManagerCustomEndpoint),
+			core_config.WithEndpoint(testutil.SecretsManagerCustomEndpoint),
 		)
 	}
 	if err != nil {

--- a/stackit/internal/services/secretsmanager/testdata/resource-max.tf
+++ b/stackit/internal/services/secretsmanager/testdata/resource-max.tf
@@ -1,0 +1,34 @@
+variable "project_id" {}
+variable "instance_name" {}
+variable "user_description" {}
+variable "write_enabled" {}
+variable "acl1" {}
+variable "acl2" {}
+
+resource "stackit_secretsmanager_instance" "instance" {
+  project_id = var.project_id
+  name       = var.instance_name
+  acls = [
+    var.acl1,
+    var.acl2,
+  ]
+}
+
+resource "stackit_secretsmanager_user" "user" {
+  project_id    = var.project_id
+  instance_id   = stackit_secretsmanager_instance.instance.instance_id
+  description   = var.user_description
+  write_enabled = var.write_enabled
+}
+
+
+data "stackit_secretsmanager_instance" "instance" {
+  project_id  = var.project_id
+  instance_id = stackit_secretsmanager_instance.instance.instance_id
+}
+
+data "stackit_secretsmanager_user" "user" {
+  project_id  = var.project_id
+  instance_id = stackit_secretsmanager_instance.instance.instance_id
+  user_id     = stackit_secretsmanager_user.user.user_id
+}

--- a/stackit/internal/services/secretsmanager/testdata/resource-min.tf
+++ b/stackit/internal/services/secretsmanager/testdata/resource-min.tf
@@ -1,0 +1,28 @@
+variable "project_id" {}
+variable "instance_name" {}
+variable "user_description" {}
+variable "write_enabled" {}
+
+resource "stackit_secretsmanager_instance" "instance" {
+  project_id = var.project_id
+  name       = var.instance_name
+}
+
+resource "stackit_secretsmanager_user" "user" {
+  project_id    = var.project_id
+  instance_id   = stackit_secretsmanager_instance.instance.instance_id
+  description   = var.user_description
+  write_enabled = var.write_enabled
+}
+
+
+data "stackit_secretsmanager_instance" "instance" {
+  project_id  = var.project_id
+  instance_id = stackit_secretsmanager_instance.instance.instance_id
+}
+
+data "stackit_secretsmanager_user" "user" {
+  project_id  = var.project_id
+  instance_id = stackit_secretsmanager_instance.instance.instance_id
+  user_id     = stackit_secretsmanager_user.user.user_id
+}

--- a/stackit/internal/services/serverbackup/serverbackup_acc_test.go
+++ b/stackit/internal/services/serverbackup/serverbackup_acc_test.go
@@ -82,7 +82,7 @@ func TestAccServerBackupScheduleMinResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Creation fail
 			{
-				Config:          testutil.ServerBackupCustomEndpoint + "\n" + resourceMinConfig,
+				Config:          testutil.ServerBackupProviderConfig() + "\n" + resourceMinConfig,
 				ConfigVariables: configVarsInvalid(testConfigVarsMin),
 				ExpectError:     regexp.MustCompile(`.*backup_properties.retention_period value must be at least 1*`),
 			},
@@ -104,7 +104,7 @@ func TestAccServerBackupScheduleMinResource(t *testing.T) {
 			},
 			// data source
 			{
-				Config:          testutil.ServerBackupCustomEndpoint + "\n" + resourceMinConfig,
+				Config:          testutil.ServerBackupProviderConfig() + "\n" + resourceMinConfig,
 				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server backup schedule data
@@ -143,7 +143,7 @@ func TestAccServerBackupScheduleMinResource(t *testing.T) {
 			},
 			// Update
 			{
-				Config:          testutil.ServerBackupCustomEndpoint + "\n" + resourceMinConfig,
+				Config:          testutil.ServerBackupProviderConfig() + "\n" + resourceMinConfig,
 				ConfigVariables: configVarsMinUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Backup schedule data
@@ -174,7 +174,7 @@ func TestAccServerBackupScheduleMaxResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Creation fail
 			{
-				Config:          testutil.ServerBackupCustomEndpoint + "\n" + resourceMaxConfig,
+				Config:          testutil.ServerBackupProviderConfig() + "\n" + resourceMaxConfig,
 				ConfigVariables: configVarsInvalid(testConfigVarsMax),
 				ExpectError:     regexp.MustCompile(`.*backup_properties.retention_period value must be at least 1*`),
 			},
@@ -196,7 +196,7 @@ func TestAccServerBackupScheduleMaxResource(t *testing.T) {
 			},
 			// data source
 			{
-				Config:          testutil.ServerBackupCustomEndpoint + "\n" + resourceMaxConfig,
+				Config:          testutil.ServerBackupProviderConfig() + "\n" + resourceMaxConfig,
 				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server backup schedule data
@@ -235,7 +235,7 @@ func TestAccServerBackupScheduleMaxResource(t *testing.T) {
 			},
 			// Update
 			{
-				Config:          testutil.ServerBackupCustomEndpoint + "\n" + resourceMaxConfig,
+				Config:          testutil.ServerBackupProviderConfig() + "\n" + resourceMaxConfig,
 				ConfigVariables: configVarsMaxUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Backup schedule data

--- a/stackit/internal/services/serverbackup/serverbackup_acc_test.go
+++ b/stackit/internal/services/serverbackup/serverbackup_acc_test.go
@@ -172,7 +172,6 @@ func TestAccServerBackupScheduleMinResource(t *testing.T) {
 	})
 }
 
-
 func TestAccServerBackupScheduleMaxResource(t *testing.T) {
 	if testutil.ServerId == "" {
 		fmt.Println("TF_ACC_SERVER_ID not set, skipping test")

--- a/stackit/internal/services/serverbackup/serverbackup_acc_test.go
+++ b/stackit/internal/services/serverbackup/serverbackup_acc_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
-	"log"
 	"maps"
 	"regexp"
 	"strconv"
@@ -29,14 +28,6 @@ var (
 	//go:embed testdata/resource-max.tf
 	resourceMaxConfig string
 )
-
-func unwrap(v config.Variable) string {
-	tmp, err := v.MarshalJSON()
-	if err != nil {
-		log.Panicf("cannot marshal variable %v: %v", v, err)
-	}
-	return strings.Trim(string(tmp), `"`)
-}
 
 var testConfigVarsMin = config.Variables{
 	"project_id":       config.StringVariable(testutil.ProjectId),
@@ -101,14 +92,14 @@ func TestAccServerBackupScheduleMinResource(t *testing.T) {
 				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Backup schedule data
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", unwrap(testConfigVarsMin["project_id"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", unwrap(testConfigVarsMin["server_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", testutil.ConvertConfigVariable(testConfigVarsMin["server_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "backup_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", unwrap(testConfigVarsMin["schedule_name"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", unwrap(testConfigVarsMin["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", testutil.ConvertConfigVariable(testConfigVarsMin["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(testConfigVarsMin["rrule"])),
 					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", unwrap(testConfigVarsMin["backup_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", testutil.ConvertConfigVariable(testConfigVarsMin["backup_name"])),
 				),
 			},
 			// data source
@@ -117,18 +108,18 @@ func TestAccServerBackupScheduleMinResource(t *testing.T) {
 				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server backup schedule data
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "project_id", unwrap(testConfigVarsMin["project_id"])),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "server_id", unwrap(testConfigVarsMin["server_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "server_id", testutil.ConvertConfigVariable(testConfigVarsMin["server_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_backup_schedule.schedule_data_test", "backup_schedule_id"),
 					resource.TestCheckResourceAttrSet("data.stackit_server_backup_schedule.schedule_data_test", "id"),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "name", unwrap(testConfigVarsMin["schedule_name"])),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "rrule", unwrap(testConfigVarsMin["rrule"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "name", testutil.ConvertConfigVariable(testConfigVarsMin["schedule_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "rrule", testutil.ConvertConfigVariable(testConfigVarsMin["rrule"])),
 					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "backup_properties.name", unwrap(testConfigVarsMin["backup_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "backup_properties.name", testutil.ConvertConfigVariable(testConfigVarsMin["backup_name"])),
 
 					// Server backup schedules data
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "project_id", unwrap(testConfigVarsMin["project_id"])),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "server_id", unwrap(testConfigVarsMin["server_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "server_id", testutil.ConvertConfigVariable(testConfigVarsMin["server_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_backup_schedules.schedules_data_test", "id"),
 				),
 			},
@@ -156,15 +147,15 @@ func TestAccServerBackupScheduleMinResource(t *testing.T) {
 				ConfigVariables: configVarsMinUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Backup schedule data
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", unwrap(configVarsMinUpdated()["project_id"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", unwrap(configVarsMinUpdated()["server_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(configVarsMinUpdated()["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", testutil.ConvertConfigVariable(configVarsMinUpdated()["server_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "backup_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", unwrap(configVarsMinUpdated()["schedule_name"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", unwrap(configVarsMinUpdated()["rrule"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "enabled", unwrap(configVarsMinUpdated()["enabled"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.retention_period", unwrap(configVarsMinUpdated()["retention_period"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", unwrap(configVarsMinUpdated()["backup_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", testutil.ConvertConfigVariable(configVarsMinUpdated()["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(configVarsMinUpdated()["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(configVarsMinUpdated()["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.retention_period", testutil.ConvertConfigVariable(configVarsMinUpdated()["retention_period"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", testutil.ConvertConfigVariable(configVarsMinUpdated()["backup_name"])),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -193,14 +184,14 @@ func TestAccServerBackupScheduleMaxResource(t *testing.T) {
 				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Backup schedule data
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", unwrap(testConfigVarsMax["project_id"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", unwrap(testConfigVarsMax["server_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", testutil.ConvertConfigVariable(testConfigVarsMax["server_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "backup_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", unwrap(testConfigVarsMax["schedule_name"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", unwrap(testConfigVarsMax["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", testutil.ConvertConfigVariable(testConfigVarsMax["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(testConfigVarsMax["rrule"])),
 					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", unwrap(testConfigVarsMax["backup_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", testutil.ConvertConfigVariable(testConfigVarsMax["backup_name"])),
 				),
 			},
 			// data source
@@ -209,18 +200,18 @@ func TestAccServerBackupScheduleMaxResource(t *testing.T) {
 				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server backup schedule data
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "project_id", unwrap(testConfigVarsMax["project_id"])),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "server_id", unwrap(testConfigVarsMax["server_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "server_id", testutil.ConvertConfigVariable(testConfigVarsMax["server_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_backup_schedule.schedule_data_test", "backup_schedule_id"),
 					resource.TestCheckResourceAttrSet("data.stackit_server_backup_schedule.schedule_data_test", "id"),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "name", unwrap(testConfigVarsMax["schedule_name"])),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "rrule", unwrap(testConfigVarsMax["rrule"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "name", testutil.ConvertConfigVariable(testConfigVarsMax["schedule_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "rrule", testutil.ConvertConfigVariable(testConfigVarsMax["rrule"])),
 					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "backup_properties.name", unwrap(testConfigVarsMax["backup_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedule.schedule_data_test", "backup_properties.name", testutil.ConvertConfigVariable(testConfigVarsMax["backup_name"])),
 
 					// Server backup schedules data
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "project_id", unwrap(testConfigVarsMax["project_id"])),
-					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "server_id", unwrap(testConfigVarsMax["server_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_backup_schedules.schedules_data_test", "server_id", testutil.ConvertConfigVariable(testConfigVarsMax["server_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_backup_schedules.schedules_data_test", "id"),
 				),
 			},
@@ -248,15 +239,15 @@ func TestAccServerBackupScheduleMaxResource(t *testing.T) {
 				ConfigVariables: configVarsMaxUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Backup schedule data
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", unwrap(configVarsMaxUpdated()["project_id"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", unwrap(configVarsMaxUpdated()["server_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(configVarsMaxUpdated()["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "server_id", testutil.ConvertConfigVariable(configVarsMaxUpdated()["server_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "backup_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_backup_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", unwrap(configVarsMaxUpdated()["schedule_name"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", unwrap(configVarsMaxUpdated()["rrule"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "enabled", unwrap(configVarsMaxUpdated()["enabled"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.retention_period", unwrap(configVarsMaxUpdated()["retention_period"])),
-					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", unwrap(configVarsMaxUpdated()["backup_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "name", testutil.ConvertConfigVariable(configVarsMaxUpdated()["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(configVarsMaxUpdated()["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(configVarsMaxUpdated()["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.retention_period", testutil.ConvertConfigVariable(configVarsMaxUpdated()["retention_period"])),
+					resource.TestCheckResourceAttr("stackit_server_backup_schedule.test_schedule", "backup_properties.name", testutil.ConvertConfigVariable(configVarsMaxUpdated()["backup_name"])),
 				),
 			},
 			// Deletion is done by the framework implicitly

--- a/stackit/internal/services/serverbackup/testdata/resource-max.tf
+++ b/stackit/internal/services/serverbackup/testdata/resource-max.tf
@@ -1,0 +1,24 @@
+variable "project_id" {}
+variable "server_name" {}
+variable "schedule_name" {}
+variable "rrule" {}
+variable "enabled" {}
+variable "maintenance_window" {}
+variable "server_id" {}
+variable "region" {}
+
+resource "stackit_server_update_schedule" "test_schedule" {
+  project_id         = var.project_id
+  server_id          = var.server_id
+  name               = var.schedule_name
+  rrule              = var.rrule
+  enabled            = var.enabled
+  maintenance_window = var.maintenance_window
+  region             = var.region
+}
+
+data "stackit_server_update_schedule" "test_schedule" {
+  project_id         = var.project_id
+  server_id          = var.server_id
+  update_schedule_id = stackit_server_update_schedule.test_schedule.update_schedule_id
+}

--- a/stackit/internal/services/serverbackup/testdata/resource-max.tf
+++ b/stackit/internal/services/serverbackup/testdata/resource-max.tf
@@ -1,24 +1,34 @@
 variable "project_id" {}
-variable "server_name" {}
+variable "server_id" {}
 variable "schedule_name" {}
 variable "rrule" {}
 variable "enabled" {}
-variable "maintenance_window" {}
-variable "server_id" {}
+variable "backup_name" {}
+variable "retention_period" {}
 variable "region" {}
 
-resource "stackit_server_update_schedule" "test_schedule" {
-  project_id         = var.project_id
-  server_id          = var.server_id
-  name               = var.schedule_name
-  rrule              = var.rrule
-  enabled            = var.enabled
-  maintenance_window = var.maintenance_window
-  region             = var.region
+
+resource "stackit_server_backup_schedule" "test_schedule" {
+  project_id = var.project_id
+  server_id  = var.server_id
+  name       = var.schedule_name
+  rrule      = var.rrule
+  enabled    = var.enabled
+  backup_properties = {
+    name             = var.backup_name
+    retention_period = var.retention_period
+    volume_ids       = null
+  }
+  region = var.region
 }
 
-data "stackit_server_update_schedule" "test_schedule" {
+data "stackit_server_backup_schedule" "schedule_data_test" {
   project_id         = var.project_id
   server_id          = var.server_id
-  update_schedule_id = stackit_server_update_schedule.test_schedule.update_schedule_id
+  backup_schedule_id = stackit_server_backup_schedule.test_schedule.backup_schedule_id
+}
+
+data "stackit_server_backup_schedules" "schedules_data_test" {
+  project_id = var.project_id
+  server_id  = var.server_id
 }

--- a/stackit/internal/services/serverbackup/testdata/resource-min.tf
+++ b/stackit/internal/services/serverbackup/testdata/resource-min.tf
@@ -1,0 +1,32 @@
+variable "project_id" {}
+variable "server_id" {}
+variable "schedule_name" {}
+variable "rrule" {}
+variable "enabled" {}
+variable "backup_name" {}
+variable "retention_period" {}
+
+
+resource "stackit_server_backup_schedule" "test_schedule" {
+  project_id = var.project_id
+  server_id  = var.server_id
+  name       = var.schedule_name
+  rrule      = var.rrule
+  enabled    = var.enabled
+  backup_properties = {
+    name             = var.backup_name
+    retention_period = var.retention_period
+    volume_ids       = null
+  }
+}
+
+data "stackit_server_backup_schedule" "schedule_data_test" {
+  project_id         = var.project_id
+  server_id          = var.server_id
+  backup_schedule_id = stackit_server_backup_schedule.test_schedule.backup_schedule_id
+}
+
+data "stackit_server_backup_schedules" "schedules_data_test" {
+  project_id = var.project_id
+  server_id  = var.server_id
+}

--- a/stackit/internal/services/serverupdate/serverupdate_acc_test.go
+++ b/stackit/internal/services/serverupdate/serverupdate_acc_test.go
@@ -2,126 +2,138 @@ package serverupdate_test
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
+	"log"
+	"maps"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	core_config "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/serverupdate"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
 
-// Server update schedule resource data
-var serverUpdateScheduleResource = map[string]string{
-	"project_id":         testutil.ProjectId,
-	"server_id":          testutil.ServerId,
-	"name":               testutil.ResourceNameWithDateTime("server-update-schedule"),
-	"rrule":              "DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1",
-	"maintenance_window": "1",
-}
+var (
+	//go:embed testdata/resource-min.tf
+	resourceMinConfig string
 
-func resourceConfig(maintenanceWindow int64, region *string) string {
-	var regionConfig string
-	if region != nil {
-		regionConfig = fmt.Sprintf(`region = %q`, *region)
+	//go:embed testdata/resource-max.tf
+	resourceMaxConfig string
+)
+
+func unwrap(v config.Variable) string {
+	tmp, err := v.MarshalJSON()
+	if err != nil {
+		log.Panicf("cannot marshal variable %v: %v", v, err)
 	}
-	return fmt.Sprintf(`
-				%s
-
-				resource "stackit_server_update_schedule" "test_schedule" {
-					project_id = "%s"
-					server_id  = "%s"
-					name  = "%s"
- 				 	rrule = "%s"
-                    enabled = true
-                    maintenance_window = %d
-					%s
-				}
-				`,
-		testutil.ServerUpdateProviderConfig(),
-		serverUpdateScheduleResource["project_id"],
-		serverUpdateScheduleResource["server_id"],
-		serverUpdateScheduleResource["name"],
-		serverUpdateScheduleResource["rrule"],
-		maintenanceWindow,
-		regionConfig,
-	)
+	return strings.Trim(string(tmp), `"`)
 }
 
-func TestAccServerUpdateScheduleResource(t *testing.T) {
+var testConfigVarsMin = config.Variables{
+	"project_id":         config.StringVariable(testutil.ProjectId),
+	"server_name":        config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"schedule_name":      config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"rrule":              config.StringVariable("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
+	"enabled":            config.BoolVariable(true),
+	"maintenance_window": config.IntegerVariable(1),
+	"server_id":          config.StringVariable(testutil.ServerId),
+}
+
+var testConfigVarsMax = config.Variables{
+	"project_id":         config.StringVariable(testutil.ProjectId),
+	"server_name":        config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"schedule_name":      config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"rrule":              config.StringVariable("DTSTART;TZID=Europe/Sofia:20200803T023000 RRULE:FREQ=DAILY;INTERVAL=1"),
+	"enabled":            config.BoolVariable(true),
+	"maintenance_window": config.IntegerVariable(1),
+	"region":             config.StringVariable("eu01"),
+	"server_id":          config.StringVariable(testutil.ServerId),
+}
+
+func configVarsInvalid(vars config.Variables) config.Variables {
+	tempConfig := maps.Clone(vars)
+	tempConfig["maintenance_window"] = config.IntegerVariable(0)
+	return tempConfig
+}
+
+func configVarsMinUpdated() config.Variables {
+	tempConfig := maps.Clone(testConfigVarsMin)
+	tempConfig["maintenance_window"] = config.IntegerVariable(12)
+	tempConfig["rrule"] = config.StringVariable("DTSTART;TZID=Europe/Berlin:20250430T010000 RRULE:FREQ=DAILY;INTERVAL=3")
+
+	return tempConfig
+}
+
+func configVarsMaxUpdated() config.Variables {
+	tempConfig := maps.Clone(testConfigVarsMax)
+	tempConfig["maintenance_window"] = config.IntegerVariable(12)
+	tempConfig["rrule"] = config.StringVariable("DTSTART;TZID=Europe/Berlin:20250430T010000 RRULE:FREQ=DAILY;INTERVAL=3")
+	return tempConfig
+}
+
+func TestAccServerUpdateScheduleMinResource(t *testing.T) {
 	if testutil.ServerId == "" {
 		fmt.Println("TF_ACC_SERVER_ID not set, skipping test")
 		return
 	}
-	var invalidMaintenanceWindow int64 = 0
-	var validMaintenanceWindow int64 = 15
-	var updatedMaintenanceWindow int64 = 8
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccCheckServerUpdateScheduleDestroy,
 		Steps: []resource.TestStep{
 			// Creation fail
 			{
-				Config:      resourceConfig(invalidMaintenanceWindow, &testutil.Region),
-				ExpectError: regexp.MustCompile(`.*maintenance_window value must be at least 1*`),
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMinConfig,
+				ConfigVariables: configVarsInvalid(configVarsMinUpdated()),
+				ExpectError:     regexp.MustCompile(`.*maintenance_window value must be at least 1*`),
 			},
 			// Creation
 			{
-				Config: resourceConfig(validMaintenanceWindow, &testutil.Region),
+				ConfigVariables: testConfigVarsMin,
+				Config:          resourceMinConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Update schedule data
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", serverUpdateScheduleResource["project_id"]),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "server_id", serverUpdateScheduleResource["server_id"]),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "server_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", serverUpdateScheduleResource["name"]),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", serverUpdateScheduleResource["rrule"]),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMin["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMin["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMin["enabled"])),
+				//resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
 				),
 			},
 			// data source
 			{
-				Config: fmt.Sprintf(`
-					%s
-
-					data "stackit_server_update_schedules" "schedules_data_test" {
-						project_id  = stackit_server_update_schedule.test_schedule.project_id
-						server_id  = stackit_server_update_schedule.test_schedule.server_id
-					}
-
-					data "stackit_server_update_schedule" "schedule_data_test" {
-						project_id  = stackit_server_update_schedule.test_schedule.project_id
-						server_id  = stackit_server_update_schedule.test_schedule.server_id
-                        update_schedule_id = stackit_server_update_schedule.test_schedule.update_schedule_id
-					}`,
-					resourceConfig(validMaintenanceWindow, &testutil.Region),
-				),
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server update schedule data
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.schedule_data_test", "project_id", serverUpdateScheduleResource["project_id"]),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.schedule_data_test", "server_id", serverUpdateScheduleResource["server_id"]),
-					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.schedule_data_test", "update_schedule_id"),
-					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.schedule_data_test", "id"),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.schedule_data_test", "name", serverUpdateScheduleResource["name"]),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.schedule_data_test", "rrule", serverUpdateScheduleResource["rrule"]),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.schedule_data_test", "enabled", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "update_schedule_id"),
+					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMin["schedule_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMin["rrule"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMin["enabled"])),
 
 					// Server update schedules data
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "project_id", serverUpdateScheduleResource["project_id"]),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "server_id", serverUpdateScheduleResource["server_id"]),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "project_id", unwrap(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "server_id", unwrap(testConfigVarsMin["server_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedules.schedules_data_test", "id"),
 				),
 			},
-			// Import
+			// // Import
 			{
-				ResourceName: "stackit_server_update_schedule.test_schedule",
+				ConfigVariables: testConfigVarsMin,
+				ResourceName:    "stackit_server_update_schedule.test_schedule",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_server_update_schedule.test_schedule"]
 					if !ok {
@@ -136,19 +148,107 @@ func TestAccServerUpdateScheduleResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Update
+			// // Update
 			{
-				Config: resourceConfig(updatedMaintenanceWindow, nil),
+				ConfigVariables: configVarsMinUpdated(),
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMinConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Update schedule data
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", serverUpdateScheduleResource["project_id"]),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "server_id", serverUpdateScheduleResource["server_id"]),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(configVarsMinUpdated()["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", serverUpdateScheduleResource["name"]),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", serverUpdateScheduleResource["rrule"]),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "maintenance_window", strconv.FormatInt(8, 10)),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", unwrap(configVarsMinUpdated()["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(configVarsMinUpdated()["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(configVarsMinUpdated()["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "maintenance_window", unwrap(configVarsMinUpdated()["maintenance_window"])),
+				),
+			},
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccServerUpdateScheduleMaxResource(t *testing.T) {
+	if testutil.ServerId == "" {
+		fmt.Println("TF_ACC_SERVER_ID not set, skipping test")
+		return
+	}
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckServerUpdateScheduleDestroy,
+		Steps: []resource.TestStep{
+			// Creation fail
+			{
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMaxConfig,
+				ConfigVariables: configVarsInvalid(testConfigVarsMax),
+				ExpectError:     regexp.MustCompile(`.*maintenance_window value must be at least 1*`),
+			},
+			// Creation
+			{
+				ConfigVariables: testConfigVarsMax,
+				Config:          resourceMaxConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Update schedule data
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "server_id"),
+					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
+					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMax["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMax["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMax["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
+				),
+			},
+			// data source
+			{
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Server update schedule data
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "update_schedule_id"),
+					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMax["schedule_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMax["rrule"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMax["enabled"])),
+
+					// Server update schedules data
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "server_id", unwrap(testConfigVarsMax["server_id"])),
+					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedules.schedules_data_test", "id"),
+				),
+			},
+			// // Import
+			{
+				ConfigVariables: testConfigVarsMax,
+				ResourceName:    "stackit_server_update_schedule.test_schedule",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					r, ok := s.RootModule().Resources["stackit_server_update_schedule.test_schedule"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find resource stackit_server_update_schedule.test_schedule")
+					}
+					scheduleId, ok := r.Primary.Attributes["update_schedule_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute update_schedule_id")
+					}
+					return fmt.Sprintf("%s,%s,%s,%s", testutil.ProjectId, testutil.Region, testutil.ServerId, scheduleId), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// // Update
+			{
+				ConfigVariables: configVarsMaxUpdated(),
+				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMaxConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Update schedule data
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(configVarsMinUpdated()["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
+					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(configVarsMinUpdated()["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(configVarsMinUpdated()["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "maintenance_window", unwrap(configVarsMinUpdated()["maintenance_window"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -158,13 +258,21 @@ func TestAccServerUpdateScheduleResource(t *testing.T) {
 
 func testAccCheckServerUpdateScheduleDestroy(s *terraform.State) error {
 	ctx := context.Background()
+	if err := deleteSchedule(ctx, s); err != nil {
+		log.Printf("cannot delete schedule: %v", err)
+	}
+
+	return nil
+}
+
+func deleteSchedule(ctx context.Context, s *terraform.State) error {
 	var client *serverupdate.APIClient
 	var err error
 	if testutil.ServerUpdateCustomEndpoint == "" {
 		client, err = serverupdate.NewAPIClient()
 	} else {
 		client, err = serverupdate.NewAPIClient(
-			config.WithEndpoint(testutil.ServerUpdateCustomEndpoint),
+			core_config.WithEndpoint(testutil.ServerUpdateCustomEndpoint),
 		)
 	}
 	if err != nil {

--- a/stackit/internal/services/serverupdate/serverupdate_acc_test.go
+++ b/stackit/internal/services/serverupdate/serverupdate_acc_test.go
@@ -108,7 +108,6 @@ func TestAccServerUpdateScheduleMinResource(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMin["schedule_name"])),
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMin["rrule"])),
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMin["enabled"])),
-				//resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
 				),
 			},
 			// data source

--- a/stackit/internal/services/serverupdate/serverupdate_acc_test.go
+++ b/stackit/internal/services/serverupdate/serverupdate_acc_test.go
@@ -30,14 +30,6 @@ var (
 	resourceMaxConfig string
 )
 
-func unwrap(v config.Variable) string {
-	tmp, err := v.MarshalJSON()
-	if err != nil {
-		log.Panicf("cannot marshal variable %v: %v", v, err)
-	}
-	return strings.Trim(string(tmp), `"`)
-}
-
 var testConfigVarsMin = config.Variables{
 	"project_id":         config.StringVariable(testutil.ProjectId),
 	"server_name":        config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
@@ -101,13 +93,13 @@ func TestAccServerUpdateScheduleMinResource(t *testing.T) {
 				Config:          resourceMinConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Update schedule data
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "server_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMin["schedule_name"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMin["rrule"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMin["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", testutil.ConvertConfigVariable(testConfigVarsMin["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(testConfigVarsMin["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(testConfigVarsMin["enabled"])),
 				),
 			},
 			// data source
@@ -116,16 +108,16 @@ func TestAccServerUpdateScheduleMinResource(t *testing.T) {
 				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server update schedule data
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMin["schedule_name"])),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMin["rrule"])),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMin["enabled"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "name", testutil.ConvertConfigVariable(testConfigVarsMin["schedule_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(testConfigVarsMin["rrule"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(testConfigVarsMin["enabled"])),
 
 					// Server update schedules data
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "project_id", unwrap(testConfigVarsMin["project_id"])),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "server_id", unwrap(testConfigVarsMin["server_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "server_id", testutil.ConvertConfigVariable(testConfigVarsMin["server_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedules.schedules_data_test", "id"),
 				),
 			},
@@ -153,13 +145,13 @@ func TestAccServerUpdateScheduleMinResource(t *testing.T) {
 				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMinConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Update schedule data
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(configVarsMinUpdated()["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(configVarsMinUpdated()["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", unwrap(configVarsMinUpdated()["schedule_name"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(configVarsMinUpdated()["rrule"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(configVarsMinUpdated()["enabled"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "maintenance_window", unwrap(configVarsMinUpdated()["maintenance_window"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", testutil.ConvertConfigVariable(configVarsMinUpdated()["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(configVarsMinUpdated()["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(configVarsMinUpdated()["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "maintenance_window", testutil.ConvertConfigVariable(configVarsMinUpdated()["maintenance_window"])),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -188,13 +180,13 @@ func TestAccServerUpdateScheduleMaxResource(t *testing.T) {
 				Config:          resourceMaxConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Update schedule data
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "server_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMax["schedule_name"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMax["rrule"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMax["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "name", testutil.ConvertConfigVariable(testConfigVarsMax["schedule_name"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(testConfigVarsMax["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(testConfigVarsMax["enabled"])),
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
 				),
 			},
@@ -204,16 +196,16 @@ func TestAccServerUpdateScheduleMaxResource(t *testing.T) {
 				ConfigVariables: testConfigVarsMax,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Server update schedule data
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "project_id", unwrap(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "name", unwrap(testConfigVarsMax["schedule_name"])),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "rrule", unwrap(testConfigVarsMax["rrule"])),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "enabled", unwrap(testConfigVarsMax["enabled"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "name", testutil.ConvertConfigVariable(testConfigVarsMax["schedule_name"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(testConfigVarsMax["rrule"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(testConfigVarsMax["enabled"])),
 
 					// Server update schedules data
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "project_id", unwrap(testConfigVarsMax["project_id"])),
-					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "server_id", unwrap(testConfigVarsMax["server_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_server_update_schedules.schedules_data_test", "server_id", testutil.ConvertConfigVariable(testConfigVarsMax["server_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_server_update_schedules.schedules_data_test", "id"),
 				),
 			},
@@ -241,12 +233,12 @@ func TestAccServerUpdateScheduleMaxResource(t *testing.T) {
 				Config:          testutil.ServerUpdateProviderConfig() + "\n" + resourceMaxConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Update schedule data
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", unwrap(configVarsMinUpdated()["project_id"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "project_id", testutil.ConvertConfigVariable(configVarsMinUpdated()["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "update_schedule_id"),
 					resource.TestCheckResourceAttrSet("stackit_server_update_schedule.test_schedule", "id"),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", unwrap(configVarsMinUpdated()["rrule"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", unwrap(configVarsMinUpdated()["enabled"])),
-					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "maintenance_window", unwrap(configVarsMinUpdated()["maintenance_window"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "rrule", testutil.ConvertConfigVariable(configVarsMinUpdated()["rrule"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "enabled", testutil.ConvertConfigVariable(configVarsMinUpdated()["enabled"])),
+					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "maintenance_window", testutil.ConvertConfigVariable(configVarsMinUpdated()["maintenance_window"])),
 					resource.TestCheckResourceAttr("stackit_server_update_schedule.test_schedule", "region", testutil.Region),
 				),
 			},

--- a/stackit/internal/services/serverupdate/testdata/resource-max.tf
+++ b/stackit/internal/services/serverupdate/testdata/resource-max.tf
@@ -1,0 +1,29 @@
+variable "project_id" {}
+variable "server_name" {}
+variable "schedule_name" {}
+variable "rrule" {}
+variable "enabled" {}
+variable "maintenance_window" {}
+variable "server_id" {}
+variable "region" {}
+
+resource "stackit_server_update_schedule" "test_schedule" {
+  project_id         = var.project_id
+  server_id          = var.server_id
+  name               = var.schedule_name
+  rrule              = var.rrule
+  enabled            = var.enabled
+  maintenance_window = var.maintenance_window
+  region             = var.region
+}
+
+data "stackit_server_update_schedule" "test_schedule" {
+  project_id         = var.project_id
+  server_id          = var.server_id
+  update_schedule_id = stackit_server_update_schedule.test_schedule.update_schedule_id
+}
+
+data "stackit_server_update_schedules" "schedules_data_test" {
+  project_id = var.project_id
+  server_id  = var.server_id
+}

--- a/stackit/internal/services/serverupdate/testdata/resource-min.tf
+++ b/stackit/internal/services/serverupdate/testdata/resource-min.tf
@@ -1,0 +1,27 @@
+variable "project_id" {}
+variable "server_name" {}
+variable "schedule_name" {}
+variable "rrule" {}
+variable "enabled" {}
+variable "maintenance_window" {}
+variable "server_id" {}
+
+resource "stackit_server_update_schedule" "test_schedule" {
+  project_id         = var.project_id
+  server_id          = var.server_id
+  name               = var.schedule_name
+  rrule              = var.rrule
+  enabled            = var.enabled
+  maintenance_window = var.maintenance_window
+}
+
+data "stackit_server_update_schedule" "test_schedule" {
+  project_id         = var.project_id
+  server_id          = var.server_id
+  update_schedule_id = stackit_server_update_schedule.test_schedule.update_schedule_id
+}
+
+data "stackit_server_update_schedules" "schedules_data_test" {
+  project_id = var.project_id
+  server_id  = var.server_id
+}


### PR DESCRIPTION
## Description

Definition of min/max configuration tests for
* DNS
* Server Backup
* Server Update
* Secrets manager

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- ~~[ ] Examples were added / adjusted (see `examples/` directory) (n/a)~~
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- ~~[ ] Unit tests got implemented or updated~~
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
