### PR TITLE
fix(alertgroups): add expression validator for alertgroups

### DIFF
--- a/stackit/internal/services/observability/alertgroup/resource.go
+++ b/stackit/internal/services/observability/alertgroup/resource.go
@@ -206,6 +206,10 @@ func (a *alertGroupResource) Schema(_ context.Context, _ resource.SchemaRequest,
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.LengthBetween(1, 600),
+								// The API currently accepts expressions with trailing newlines but does not return them,
+								// leading to inconsistent Terraform results. This issue has been reported to the Obs team.
+								// Until it is resolved, we proactively notify users if their input contains a trailing newline.
+								validate.ValidNoTrailingNewline(),
 							},
 						},
 						"for": schema.StringAttribute{

--- a/stackit/internal/services/observability/log-alertgroup/resource.go
+++ b/stackit/internal/services/observability/log-alertgroup/resource.go
@@ -206,6 +206,10 @@ func (l *logAlertGroupResource) Schema(_ context.Context, _ resource.SchemaReque
 							Required:    true,
 							Validators: []validator.String{
 								stringvalidator.LengthBetween(1, 600),
+								// The API currently accepts expressions with trailing newlines but does not return them,
+								// leading to inconsistent Terraform results. This issue has been reported to the Obs team.
+								// Until it is resolved, we proactively notify users if their input contains a trailing newline.
+								validate.ValidNoTrailingNewline(),
 							},
 						},
 						"for": schema.StringAttribute{

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -997,7 +997,7 @@ func toNodepoolsPayload(ctx context.Context, m *Model, availableMachineVersions 
 			if v.IsNull() || v.IsUnknown() {
 				continue
 			}
-			s, err := conversion.ToString(context.TODO(), v)
+			s, err := conversion.ToString(ctx, v)
 			if err != nil {
 				continue
 			}

--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -313,3 +313,34 @@ func ValidDurationString() *Validator {
 		},
 	}
 }
+
+// ValidNoTrailingNewline returns a Validator that checks if the input string has no trailing newline
+// character ("\n" or "\r\n"). If a trailing newline is present, a diagnostic error will be appended.
+func ValidNoTrailingNewline() *Validator {
+	description := `The value must not have a trailing newline character ("\n" or "\r\n"). You can remove a trailing newline by using Terraform's built-in chomp() function.`
+
+	return &Validator{
+		description: description,
+		validate: func(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+			val := req.ConfigValue.ValueString()
+			if val == "" {
+				return
+			}
+			if len(val) >= 2 && val[len(val)-2:] == "\r\n" {
+				resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+					req.Path,
+					description,
+					val,
+				))
+				return
+			}
+			if val[len(val)-1] == '\n' {
+				resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+					req.Path,
+					description,
+					val,
+				))
+			}
+		},
+	}
+}

--- a/stackit/internal/validate/validate_test.go
+++ b/stackit/internal/validate/validate_test.go
@@ -845,3 +845,74 @@ func TestValidTtlDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestValidNoTrailingNewline(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		isValid     bool
+	}{
+		{
+			"string with no trailing newline",
+			"abc",
+			true,
+		},
+		{
+			"string with trailing \\n",
+			"abc\n",
+			false,
+		},
+		{
+			"string with trailing \\r\\n",
+			"abc\r\n",
+			false,
+		},
+		{
+			"string with internal newlines but not trailing",
+			"abc\ndef\nghi",
+			true,
+		},
+		{
+			"empty string",
+			"",
+			true,
+		},
+		{
+			"string that is just \\n",
+			"\n",
+			false,
+		},
+		{
+			"string that is just \\r\\n",
+			"\r\n",
+			false,
+		},
+		{
+			"string with multiple newlines, trailing",
+			"abc\n\n",
+			false,
+		},
+		{
+			"string with newlines but ends with character",
+			"abc\ndef\n",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			r := validator.StringResponse{}
+			va := ValidNoTrailingNewline()
+			va.ValidateString(context.Background(), validator.StringRequest{
+				ConfigValue: types.StringValue(tt.input),
+			}, &r)
+
+			if !tt.isValid && !r.Diagnostics.HasError() {
+				t.Fatalf("Expected validation to fail for input: %q", tt.input)
+			}
+			if tt.isValid && r.Diagnostics.HasError() {
+				t.Fatalf("Expected validation to succeed for input: %q, but got errors: %v", tt.input, r.Diagnostics.Errors())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

The Observability API currently allows expressions with trailing newlines, which can lead to inconsistencies in the Terraform provider. I added a validation to inform users and suggest a workaround. The issue has been reported to the Observability team and is waiting to be fixed. In the meanwhile we are informing users with the workaround.

Case which is not working:
```terraform
resource "stackit_observability_alertgroup" "example" {
  project_id  = var.stackit_project_id
  instance_id = stackit_observability_instance.example.instance_id
  name        = "TestAlertGroup"
  interval    = "60m"
  rules = [
    {
      alert      = "Check"
      expression = <<EOT
(
  kubelet_volume_stats_inodes_free{job="kubelet", namespace=~".*", metrics_path="/metrics"}
    /
  kubelet_volume_stats_inodes{job="kubelet", namespace=~".*", metrics_path="/metrics"}
) < 0.03
EOT
      for        = "60s"
      labels = {
        severity = "critical"
      },
      annotations = {
        summary : "Test Alert is working"
        description : "Test Alert"
      },
    },
  ]
}
```

Validator suggestion:
```terraform
resource "stackit_observability_alertgroup" "example" {
  project_id  = var.stackit_project_id
  instance_id = stackit_observability_instance.example.instance_id
  name        = "TestAlertGroup"
  interval    = "60m"
  rules = [
    {
      alert      = "Check"
      expression = chomp(<<EOT
(
  kubelet_volume_stats_inodes_free{job="kubelet", namespace=~".*", metrics_path="/metrics"}
    /
  kubelet_volume_stats_inodes{job="kubelet", namespace=~".*", metrics_path="/metrics"}
) < 0.03
EOT
)
      for        = "60s"
      labels = {
        severity = "critical"
      },
      annotations = {
        summary : "Test Alert is working"
        description : "Test Alert"
      },
    },
  ]
}
```

Example of validator error message:
![Screenshot 2025-05-07 at 10 35 18](https://github.com/user-attachments/assets/da6b862e-598b-4eee-911d-34d851d453f3)


## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
