### PR TITLE
docs(cdn): remove comment above example

### DIFF
--- a/docs/resources/cdn_custom_domain.md
+++ b/docs/resources/cdn_custom_domain.md
@@ -16,7 +16,6 @@ CDN distribution data source schema.
 ## Example Usage
 
 ```terraform
-# Create a CDN custom domain
 resource "stackit_cdn_custom_domain" "example" {
   project_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   distribution_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/docs/resources/cdn_distribution.md
+++ b/docs/resources/cdn_distribution.md
@@ -16,7 +16,6 @@ CDN distribution data source schema.
 ## Example Usage
 
 ```terraform
-# Create a CDN distribution
 resource "stackit_cdn_distribution" "example_distribution" {
   project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   config = {

--- a/examples/resources/stackit_cdn_custom_domain/resource.tf
+++ b/examples/resources/stackit_cdn_custom_domain/resource.tf
@@ -1,4 +1,3 @@
-# Create a CDN custom domain
 resource "stackit_cdn_custom_domain" "example" {
   project_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   distribution_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/examples/resources/stackit_cdn_distribution/resource.tf
+++ b/examples/resources/stackit_cdn_distribution/resource.tf
@@ -1,4 +1,3 @@
-# Create a CDN distribution
 resource "stackit_cdn_distribution" "example_distribution" {
   project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   config = {


### PR DESCRIPTION
## Description

Removes a comment above the example to keep all examples identical

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
