### PR TITLE
chore(sqlserverflex): implemented min/max test

### DIFF
--- a/stackit/internal/services/sqlserverflex/sqlserverflex_acc_test.go
+++ b/stackit/internal/services/sqlserverflex/sqlserverflex_acc_test.go
@@ -2,14 +2,17 @@ package sqlserverflex_test
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	core_config "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
 	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex/wait"
@@ -17,111 +20,75 @@ import (
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
 
-// Instance resource data
-var instanceResource = map[string]string{
-	"project_id":              testutil.ProjectId,
-	"name":                    fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum)),
-	"acl":                     "192.168.0.0/16",
-	"flavor_cpu":              "4",
-	"flavor_ram":              "16",
-	"flavor_description":      "SQLServer-Flex-4.16-Standard-EU01",
-	"storage_class":           "premium-perf2-stackit",
-	"storage_size":            "40",
-	"version":                 "2022",
-	"replicas":                "1",
-	"options_retention_days":  "64",
-	"flavor_id":               "4.16-Single",
-	"backup_schedule":         "00 6 * * *",
-	"backup_schedule_updated": "00 12 * * *",
+var (
+	//go:embed testdata/resource-max.tf
+	resourceMaxConfig string
+	//go:embed testdata/resource-min.tf
+	resourceMinConfig string
+)
+var testConfigVarsMin = config.Variables{
+	"project_id":         config.StringVariable(testutil.ProjectId),
+	"name":               config.StringVariable(fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum))),
+	"flavor_cpu":         config.IntegerVariable(4),
+	"flavor_ram":         config.IntegerVariable(16),
+	"flavor_description": config.StringVariable("SQLServer-Flex-4.16-Standard-EU01"),
+	"replicas":           config.IntegerVariable(1),
+	"flavor_id":          config.StringVariable("4.16-Single"),
+	"username":           config.StringVariable(fmt.Sprintf("tf-acc-user-%s", acctest.RandStringFromCharSet(7, acctest.CharSetAlpha))),
+	"role":               config.StringVariable("##STACKIT_LoginManager##"),
 }
 
-// User resource data
-var userResource = map[string]string{
-	"username":   fmt.Sprintf("tf-acc-user-%s", acctest.RandStringFromCharSet(7, acctest.CharSetAlpha)),
-	"role":       "##STACKIT_LoginManager##",
-	"project_id": instanceResource["project_id"],
+var testConfigVarsMax = config.Variables{
+	"project_id":             config.StringVariable(testutil.ProjectId),
+	"name":                   config.StringVariable(fmt.Sprintf("tf-acc-%s", acctest.RandStringFromCharSet(7, acctest.CharSetAlphaNum))),
+	"acl1":                   config.StringVariable("192.168.0.0/16"),
+	"flavor_cpu":             config.IntegerVariable(4),
+	"flavor_ram":             config.IntegerVariable(16),
+	"flavor_description":     config.StringVariable("SQLServer-Flex-4.16-Standard-EU01"),
+	"storage_class":          config.StringVariable("premium-perf2-stackit"),
+	"storage_size":           config.IntegerVariable(40),
+	"server_version":         config.StringVariable("2022"),
+	"replicas":               config.IntegerVariable(1),
+	"options_retention_days": config.IntegerVariable(64),
+	"flavor_id":              config.StringVariable("4.16-Single"),
+	"backup_schedule":        config.StringVariable("00 6 * * *"),
+	"username":               config.StringVariable(fmt.Sprintf("tf-acc-user-%s", acctest.RandStringFromCharSet(7, acctest.CharSetAlpha))),
+	"role":                   config.StringVariable("##STACKIT_LoginManager##"),
+	"region":                 config.StringVariable(testutil.Region),
 }
 
-func configResources(backupSchedule string, region *string) string {
-	var regionConfig string
-	if region != nil {
-		regionConfig = fmt.Sprintf(`region = %q`, *region)
-	}
-	return fmt.Sprintf(`
-				%s
-
-				resource "stackit_sqlserverflex_instance" "instance" {
-					project_id = "%s"
-					name    = "%s"
-					acl = ["%s"]
-					flavor = {
-						cpu = %s
-						ram = %s
-					}
-					storage = {
-						class = "%s"
-						size = %s
-					}
-					version = "%s"
-					options = {
-						retention_days = %s
-					}
-					backup_schedule = "%s"
-					%s
-				}
-
-                resource "stackit_sqlserverflex_user" "user" {
-					project_id = stackit_sqlserverflex_instance.instance.project_id
-					instance_id = stackit_sqlserverflex_instance.instance.instance_id
-					username = "%s"
-					roles = ["%s"]
-					%s
-				}
-				`,
-		testutil.SQLServerFlexProviderConfig(),
-		instanceResource["project_id"],
-		instanceResource["name"],
-		instanceResource["acl"],
-		instanceResource["flavor_cpu"],
-		instanceResource["flavor_ram"],
-		instanceResource["storage_class"],
-		instanceResource["storage_size"],
-		instanceResource["version"],
-		instanceResource["options_retention_days"],
-		backupSchedule,
-		regionConfig,
-		userResource["username"],
-		userResource["role"],
-		regionConfig,
-	)
+func configVarsMinUpdated() config.Variables {
+	temp := maps.Clone(testConfigVarsMax)
+	temp["name"] = config.StringVariable(testutil.ConvertConfigVariable(temp["name"]) + "changed")
+	return temp
 }
 
-func TestAccSQLServerFlexResource(t *testing.T) {
+func configVarsMaxUpdated() config.Variables {
+	temp := maps.Clone(testConfigVarsMax)
+	temp["backup_schedule"] = config.StringVariable("00 12 * * *")
+	return temp
+}
+
+func TestAccSQLServerFlexMinResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccChecksqlserverflexDestroy,
 		Steps: []resource.TestStep{
 			// Creation
 			{
-				Config: configResources(instanceResource["backup_schedule"], &testutil.Region),
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", instanceResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", instanceResource["name"]),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMin["name"])),
 					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.#", "1"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.0", instanceResource["acl"]),
 					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.id"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.description", instanceResource["flavor_description"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "replicas", instanceResource["replicas"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", instanceResource["flavor_cpu"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", instanceResource["flavor_ram"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.class", instanceResource["storage_class"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.size", instanceResource["storage_size"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "version", instanceResource["version"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", instanceResource["options_retention_days"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "backup_schedule", instanceResource["backup_schedule"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "region", testutil.Region),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.description", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_description"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "replicas", testutil.ConvertConfigVariable(testConfigVarsMin["replicas"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_cpu"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_ram"])),
 					// User
 					resource.TestCheckResourceAttrPair(
 						"stackit_sqlserverflex_user.user", "project_id",
@@ -137,25 +104,18 @@ func TestAccSQLServerFlexResource(t *testing.T) {
 			},
 			// Update
 			{
-				Config: configResources(instanceResource["backup_schedule"], nil),
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", instanceResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", instanceResource["name"]),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMin["name"])),
 					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.#", "1"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.0", instanceResource["acl"]),
 					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.id"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.description", instanceResource["flavor_description"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "replicas", instanceResource["replicas"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", instanceResource["flavor_cpu"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", instanceResource["flavor_ram"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.class", instanceResource["storage_class"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.size", instanceResource["storage_size"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "version", instanceResource["version"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", instanceResource["options_retention_days"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "backup_schedule", instanceResource["backup_schedule"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "region", testutil.Region),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.description", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_description"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_cpu"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_ram"])),
 					// User
 					resource.TestCheckResourceAttrPair(
 						"stackit_sqlserverflex_user.user", "project_id",
@@ -171,26 +131,12 @@ func TestAccSQLServerFlexResource(t *testing.T) {
 			},
 			// data source
 			{
-				Config: fmt.Sprintf(`
-					%s
-
-					data "stackit_sqlserverflex_instance" "instance" {
-						project_id     = stackit_sqlserverflex_instance.instance.project_id
-						instance_id    = stackit_sqlserverflex_instance.instance.instance_id
-					}
-
-					data "stackit_sqlserverflex_user" "user" {
-						project_id     = stackit_sqlserverflex_instance.instance.project_id
-						instance_id    = stackit_sqlserverflex_instance.instance.instance_id
-						user_id        = stackit_sqlserverflex_user.user.user_id
-					}
-					`,
-					configResources(instanceResource["backup_schedule"], nil),
-				),
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMinConfig,
+				ConfigVariables: testConfigVarsMin,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance data
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "project_id", instanceResource["project_id"]),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "name", instanceResource["name"]),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMin["name"])),
 					resource.TestCheckResourceAttrPair(
 						"data.stackit_sqlserverflex_instance.instance", "project_id",
 						"stackit_sqlserverflex_instance.instance", "project_id",
@@ -205,28 +151,23 @@ func TestAccSQLServerFlexResource(t *testing.T) {
 					),
 
 					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "acl.#", "1"),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "acl.0", instanceResource["acl"]),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.id", instanceResource["flavor_id"]),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.description", instanceResource["flavor_description"]),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.cpu", instanceResource["flavor_cpu"]),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.ram", instanceResource["flavor_ram"]),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "replicas", instanceResource["replicas"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", instanceResource["options_retention_days"]),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "backup_schedule", instanceResource["backup_schedule"]),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.id", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_id"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.description", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_description"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_cpu"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(testConfigVarsMin["flavor_ram"])),
 
 					// User data
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "project_id", userResource["project_id"]),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "project_id", testutil.ConvertConfigVariable(testConfigVarsMin["project_id"])),
 					resource.TestCheckResourceAttrSet("data.stackit_sqlserverflex_user.user", "user_id"),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "username", userResource["username"]),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "username", testutil.ConvertConfigVariable(testConfigVarsMin["username"])),
 					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "roles.#", "1"),
-					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "roles.0", userResource["role"]),
-					resource.TestCheckResourceAttrSet("data.stackit_sqlserverflex_user.user", "host"),
-					resource.TestCheckResourceAttrSet("data.stackit_sqlserverflex_user.user", "port"),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "roles.0", testutil.ConvertConfigVariable(testConfigVarsMax["role"])),
 				),
 			},
 			// Import
 			{
-				ResourceName: "stackit_sqlserverflex_instance.instance",
+				ConfigVariables: testConfigVarsMin,
+				ResourceName:    "stackit_sqlserverflex_instance.instance",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_sqlserverflex_instance.instance"]
 					if !ok {
@@ -246,14 +187,12 @@ func TestAccSQLServerFlexResource(t *testing.T) {
 					if len(s) != 1 {
 						return fmt.Errorf("expected 1 state, got %d", len(s))
 					}
-					if s[0].Attributes["backup_schedule"] != instanceResource["backup_schedule"] {
-						return fmt.Errorf("expected backup_schedule %s, got %s", instanceResource["backup_schedule"], s[0].Attributes["backup_schedule"])
-					}
 					return nil
 				},
 			},
 			{
-				ResourceName: "stackit_sqlserverflex_user.user",
+				ResourceName:    "stackit_sqlserverflex_user.user",
+				ConfigVariables: testConfigVarsMin,
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_sqlserverflex_user.user"]
 					if !ok {
@@ -276,24 +215,214 @@ func TestAccSQLServerFlexResource(t *testing.T) {
 			},
 			// Update
 			{
-				Config: configResources(instanceResource["backup_schedule_updated"], nil),
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMinConfig,
+				ConfigVariables: configVarsMinUpdated(),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Instance data
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", instanceResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(configVarsMinUpdated()["project_id"])),
 					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "instance_id"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", instanceResource["name"]),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(configVarsMinUpdated()["name"])),
 					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.#", "1"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.0", instanceResource["acl"]),
 					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.id"),
 					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.description"),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", instanceResource["flavor_cpu"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", instanceResource["flavor_ram"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "replicas", instanceResource["replicas"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.class", instanceResource["storage_class"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.size", instanceResource["storage_size"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "version", instanceResource["version"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", instanceResource["options_retention_days"]),
-					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "backup_schedule", instanceResource["backup_schedule_updated"]),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(configVarsMinUpdated()["flavor_cpu"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(configVarsMinUpdated()["flavor_ram"])),
+				),
+			},
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccSQLServerFlexMaxResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccChecksqlserverflexDestroy,
+		Steps: []resource.TestStep{
+			// Creation
+			{
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Instance
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "instance_id"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMax["name"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.#", "1"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.0", testutil.ConvertConfigVariable(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.id"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.description", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_description"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "replicas", testutil.ConvertConfigVariable(testConfigVarsMax["replicas"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_cpu"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_ram"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.class", testutil.ConvertConfigVariable(testConfigVarsMax["storage_class"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.size", testutil.ConvertConfigVariable(testConfigVarsMax["storage_size"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "version", testutil.ConvertConfigVariable(testConfigVarsMax["server_version"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", testutil.ConvertConfigVariable(testConfigVarsMax["options_retention_days"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "backup_schedule", testutil.ConvertConfigVariable(testConfigVarsMax["backup_schedule"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "region", testutil.Region),
+					// User
+					resource.TestCheckResourceAttrPair(
+						"stackit_sqlserverflex_user.user", "project_id",
+						"stackit_sqlserverflex_instance.instance", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sqlserverflex_user.user", "instance_id",
+						"stackit_sqlserverflex_instance.instance", "instance_id",
+					),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_user.user", "user_id"),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_user.user", "password"),
+				),
+			},
+			// Update
+			{
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Instance
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "instance_id"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMax["name"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.#", "1"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.0", testutil.ConvertConfigVariable(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.id"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.description", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_description"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "replicas", testutil.ConvertConfigVariable(testConfigVarsMax["replicas"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_cpu"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_ram"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.class", testutil.ConvertConfigVariable(testConfigVarsMax["storage_class"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.size", testutil.ConvertConfigVariable(testConfigVarsMax["storage_size"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "version", testutil.ConvertConfigVariable(testConfigVarsMax["server_version"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", testutil.ConvertConfigVariable(testConfigVarsMax["options_retention_days"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "backup_schedule", testutil.ConvertConfigVariable(testConfigVarsMax["backup_schedule"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "region", testutil.Region),
+					// User
+					resource.TestCheckResourceAttrPair(
+						"stackit_sqlserverflex_user.user", "project_id",
+						"stackit_sqlserverflex_instance.instance", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sqlserverflex_user.user", "instance_id",
+						"stackit_sqlserverflex_instance.instance", "instance_id",
+					),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_user.user", "user_id"),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_user.user", "password"),
+				),
+			},
+			// data source
+			{
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMaxConfig,
+				ConfigVariables: testConfigVarsMax,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Instance data
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(testConfigVarsMax["name"])),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sqlserverflex_instance.instance", "project_id",
+						"stackit_sqlserverflex_instance.instance", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sqlserverflex_instance.instance", "instance_id",
+						"stackit_sqlserverflex_instance.instance", "instance_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sqlserverflex_user.user", "instance_id",
+						"stackit_sqlserverflex_user.user", "instance_id",
+					),
+
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "acl.#", "1"),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "acl.0", testutil.ConvertConfigVariable(testConfigVarsMax["acl1"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.id", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_id"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.description", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_description"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_cpu"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(testConfigVarsMax["flavor_ram"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "replicas", testutil.ConvertConfigVariable(testConfigVarsMax["replicas"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", testutil.ConvertConfigVariable(testConfigVarsMax["options_retention_days"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_instance.instance", "backup_schedule", testutil.ConvertConfigVariable(testConfigVarsMax["backup_schedule"])),
+
+					// User data
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "project_id", testutil.ConvertConfigVariable(testConfigVarsMax["project_id"])),
+					resource.TestCheckResourceAttrSet("data.stackit_sqlserverflex_user.user", "user_id"),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "username", testutil.ConvertConfigVariable(testConfigVarsMax["username"])),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "roles.#", "1"),
+					resource.TestCheckResourceAttr("data.stackit_sqlserverflex_user.user", "roles.0", testutil.ConvertConfigVariable(testConfigVarsMax["role"])),
+					resource.TestCheckResourceAttrSet("data.stackit_sqlserverflex_user.user", "host"),
+					resource.TestCheckResourceAttrSet("data.stackit_sqlserverflex_user.user", "port"),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigVarsMax,
+				ResourceName:    "stackit_sqlserverflex_instance.instance",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					r, ok := s.RootModule().Resources["stackit_sqlserverflex_instance.instance"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find resource stackit_sqlserverflex_instance.instance")
+					}
+					instanceId, ok := r.Primary.Attributes["instance_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute instance_id")
+					}
+
+					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, testutil.Region, instanceId), nil
+				},
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"backup_schedule"},
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state, got %d", len(s))
+					}
+					if s[0].Attributes["backup_schedule"] != testutil.ConvertConfigVariable(testConfigVarsMax["backup_schedule"]) {
+						return fmt.Errorf("expected backup_schedule %s, got %s", testConfigVarsMax["backup_schedule"], s[0].Attributes["backup_schedule"])
+					}
+					return nil
+				},
+			},
+			{
+				ResourceName:    "stackit_sqlserverflex_user.user",
+				ConfigVariables: testConfigVarsMax,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					r, ok := s.RootModule().Resources["stackit_sqlserverflex_user.user"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find resource stackit_sqlserverflex_user.user")
+					}
+					instanceId, ok := r.Primary.Attributes["instance_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute instance_id")
+					}
+					userId, ok := r.Primary.Attributes["user_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute user_id")
+					}
+
+					return fmt.Sprintf("%s,%s,%s,%s", testutil.ProjectId, testutil.Region, instanceId, userId), nil
+				},
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			// Update
+			{
+				Config:          testutil.SQLServerFlexProviderConfig() + "\n" + resourceMaxConfig,
+				ConfigVariables: configVarsMaxUpdated(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Instance data
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "project_id", testutil.ConvertConfigVariable(configVarsMaxUpdated()["project_id"])),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "instance_id"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "name", testutil.ConvertConfigVariable(configVarsMaxUpdated()["name"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.#", "1"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "acl.0", testutil.ConvertConfigVariable(configVarsMaxUpdated()["acl1"])),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.id"),
+					resource.TestCheckResourceAttrSet("stackit_sqlserverflex_instance.instance", "flavor.description"),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.cpu", testutil.ConvertConfigVariable(configVarsMaxUpdated()["flavor_cpu"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "flavor.ram", testutil.ConvertConfigVariable(configVarsMaxUpdated()["flavor_ram"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "replicas", testutil.ConvertConfigVariable(configVarsMaxUpdated()["replicas"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.class", testutil.ConvertConfigVariable(configVarsMaxUpdated()["storage_class"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "storage.size", testutil.ConvertConfigVariable(configVarsMaxUpdated()["storage_size"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "version", testutil.ConvertConfigVariable(configVarsMaxUpdated()["server_version"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "options.retention_days", testutil.ConvertConfigVariable(configVarsMaxUpdated()["options_retention_days"])),
+					resource.TestCheckResourceAttr("stackit_sqlserverflex_instance.instance", "backup_schedule", testutil.ConvertConfigVariable(configVarsMaxUpdated()["backup_schedule"])),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -309,7 +438,7 @@ func testAccChecksqlserverflexDestroy(s *terraform.State) error {
 		client, err = sqlserverflex.NewAPIClient()
 	} else {
 		client, err = sqlserverflex.NewAPIClient(
-			config.WithEndpoint(testutil.SQLServerFlexCustomEndpoint),
+			core_config.WithEndpoint(testutil.SQLServerFlexCustomEndpoint),
 		)
 	}
 	if err != nil {

--- a/stackit/internal/services/sqlserverflex/testdata/resource-max.tf
+++ b/stackit/internal/services/sqlserverflex/testdata/resource-max.tf
@@ -1,0 +1,51 @@
+variable "project_id" {}
+variable "name" {}
+variable "acl1" {}
+variable "flavor_cpu" {}
+variable "flavor_ram" {}
+variable "storage_class" {}
+variable "storage_size" {}
+variable "options_retention_days" {}
+variable "backup_schedule" {}
+variable "username" {}
+variable "role" {}
+variable "server_version" {}
+variable "region" {}
+
+resource "stackit_sqlserverflex_instance" "instance" {
+  project_id = var.project_id
+  name       = var.name
+  acl        = [var.acl1]
+  flavor = {
+    cpu = var.flavor_cpu
+    ram = var.flavor_ram
+  }
+  storage = {
+    class = var.storage_class
+    size  = var.storage_size
+  }
+  version = var.server_version
+  options = {
+    retention_days = var.options_retention_days
+  }
+  backup_schedule = var.backup_schedule
+  region          = var.region
+}
+
+resource "stackit_sqlserverflex_user" "user" {
+  project_id  = stackit_sqlserverflex_instance.instance.project_id
+  instance_id = stackit_sqlserverflex_instance.instance.instance_id
+  username    = var.username
+  roles       = [var.role]
+}
+
+data "stackit_sqlserverflex_instance" "instance" {
+  project_id  = var.project_id
+  instance_id = stackit_sqlserverflex_instance.instance.instance_id
+}
+
+data "stackit_sqlserverflex_user" "user" {
+  project_id  = var.project_id
+  instance_id = stackit_sqlserverflex_instance.instance.instance_id
+  user_id     = stackit_sqlserverflex_user.user.user_id
+}

--- a/stackit/internal/services/sqlserverflex/testdata/resource-min.tf
+++ b/stackit/internal/services/sqlserverflex/testdata/resource-min.tf
@@ -1,0 +1,33 @@
+variable "project_id" {}
+variable "name" {}
+variable "flavor_cpu" {}
+variable "flavor_ram" {}
+variable "username" {}
+variable "role" {}
+
+resource "stackit_sqlserverflex_instance" "instance" {
+  project_id = var.project_id
+  name       = var.name
+  flavor = {
+    cpu = var.flavor_cpu
+    ram = var.flavor_ram
+  }
+}
+
+resource "stackit_sqlserverflex_user" "user" {
+  project_id  = stackit_sqlserverflex_instance.instance.project_id
+  instance_id = stackit_sqlserverflex_instance.instance.instance_id
+  username    = var.username
+  roles       = [var.role]
+}
+
+data "stackit_sqlserverflex_instance" "instance" {
+  project_id  = var.project_id
+  instance_id = stackit_sqlserverflex_instance.instance.instance_id
+}
+
+data "stackit_sqlserverflex_user" "user" {
+  project_id  = var.project_id
+  instance_id = stackit_sqlserverflex_instance.instance.instance_id
+  user_id     = stackit_sqlserverflex_user.user.user_id
+}


### PR DESCRIPTION
## Description

Min/Max acceptance test for the sqlserverflex service

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- ~~[ ] Examples were added / adjusted (see `examples/` directory)~~
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- ~~[ ] Unit tests got implemented or updated~~
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
