### PR TITLE
feat(rabbitmq): set custom user-agent header for STACKIT API calls

### DIFF
--- a/stackit/internal/services/rabbitmq/credential/datasource.go
+++ b/stackit/internal/services/rabbitmq/credential/datasource.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
+	rabbitmqUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/rabbitmq/utils"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -14,7 +17,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
 )
 
@@ -40,36 +42,15 @@ func (r *credentialDataSource) Metadata(_ context.Context, req datasource.Metada
 
 // Configure adds the provider configured client to the data source.
 func (r *credentialDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	providerData, ok := req.ProviderData.(core.ProviderData)
+	providerData, ok := conversion.ParseProviderData(ctx, req.ProviderData, &resp.Diagnostics)
 	if !ok {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Expected configure type stackit.ProviderData, got %T", req.ProviderData))
 		return
 	}
 
-	var apiClient *rabbitmq.APIClient
-	var err error
-	if providerData.RabbitMQCustomEndpoint != "" {
-		apiClient, err = rabbitmq.NewAPIClient(
-			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithEndpoint(providerData.RabbitMQCustomEndpoint),
-		)
-	} else {
-		apiClient, err = rabbitmq.NewAPIClient(
-			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithRegion(providerData.GetRegion()),
-		)
-	}
-
-	if err != nil {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the data source configuration", err))
+	apiClient := rabbitmqUtils.ConfigureClient(ctx, &providerData, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	r.client = apiClient
 	tflog.Info(ctx, "RabbitMQ credential client configured")
 }

--- a/stackit/internal/services/rabbitmq/credential/resource.go
+++ b/stackit/internal/services/rabbitmq/credential/resource.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
+	rabbitmqUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/rabbitmq/utils"
+
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -18,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
 	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq/wait"
@@ -65,36 +67,15 @@ func (r *credentialResource) Metadata(_ context.Context, req resource.MetadataRe
 
 // Configure adds the provider configured client to the resource.
 func (r *credentialResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	providerData, ok := req.ProviderData.(core.ProviderData)
+	providerData, ok := conversion.ParseProviderData(ctx, req.ProviderData, &resp.Diagnostics)
 	if !ok {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Expected configure type stackit.ProviderData, got %T", req.ProviderData))
 		return
 	}
 
-	var apiClient *rabbitmq.APIClient
-	var err error
-	if providerData.RabbitMQCustomEndpoint != "" {
-		apiClient, err = rabbitmq.NewAPIClient(
-			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithEndpoint(providerData.RabbitMQCustomEndpoint),
-		)
-	} else {
-		apiClient, err = rabbitmq.NewAPIClient(
-			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithRegion(providerData.GetRegion()),
-		)
-	}
-
-	if err != nil {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the resource configuration", err))
+	apiClient := rabbitmqUtils.ConfigureClient(ctx, &providerData, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	r.client = apiClient
 	tflog.Info(ctx, "RabbitMQ credential client configured")
 }

--- a/stackit/internal/services/rabbitmq/instance/datasource.go
+++ b/stackit/internal/services/rabbitmq/instance/datasource.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
+	rabbitmqUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/rabbitmq/utils"
+
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -14,7 +17,6 @@ import (
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
 )
 
@@ -40,36 +42,15 @@ func (r *instanceDataSource) Metadata(_ context.Context, req datasource.Metadata
 
 // Configure adds the provider configured client to the data source.
 func (r *instanceDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
-	providerData, ok := req.ProviderData.(core.ProviderData)
+	providerData, ok := conversion.ParseProviderData(ctx, req.ProviderData, &resp.Diagnostics)
 	if !ok {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Expected configure type stackit.ProviderData, got %T", req.ProviderData))
 		return
 	}
 
-	var apiClient *rabbitmq.APIClient
-	var err error
-	if providerData.RabbitMQCustomEndpoint != "" {
-		apiClient, err = rabbitmq.NewAPIClient(
-			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithEndpoint(providerData.RabbitMQCustomEndpoint),
-		)
-	} else {
-		apiClient, err = rabbitmq.NewAPIClient(
-			config.WithCustomAuth(providerData.RoundTripper),
-			config.WithRegion(providerData.GetRegion()),
-		)
-	}
-
-	if err != nil {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the data source configuration", err))
+	apiClient := rabbitmqUtils.ConfigureClient(ctx, &providerData, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	r.client = apiClient
 	tflog.Info(ctx, "RabbitMQ instance client configured")
 }

--- a/stackit/internal/services/rabbitmq/utils/util.go
+++ b/stackit/internal/services/rabbitmq/utils/util.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
+)
+
+func ConfigureClient(ctx context.Context, providerData *core.ProviderData, diags *diag.Diagnostics) *rabbitmq.APIClient {
+	apiClientConfigOptions := []config.ConfigurationOption{
+		config.WithCustomAuth(providerData.RoundTripper),
+		utils.UserAgentConfigOption(providerData.Version),
+	}
+	if providerData.RabbitMQCustomEndpoint != "" {
+		apiClientConfigOptions = append(apiClientConfigOptions, config.WithEndpoint(providerData.RabbitMQCustomEndpoint))
+	} else {
+		apiClientConfigOptions = append(apiClientConfigOptions, config.WithRegion(providerData.GetRegion()))
+	}
+	apiClient, err := rabbitmq.NewAPIClient(apiClientConfigOptions...)
+	if err != nil {
+		core.LogAndAddError(ctx, diags, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the resource configuration", err))
+		return nil
+	}
+
+	return apiClient
+}

--- a/stackit/internal/services/rabbitmq/utils/util_test.go
+++ b/stackit/internal/services/rabbitmq/utils/util_test.go
@@ -1,0 +1,94 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	sdkClients "github.com/stackitcloud/stackit-sdk-go/core/clients"
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/services/rabbitmq"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
+)
+
+const (
+	testVersion        = "1.2.3"
+	testCustomEndpoint = "https://rabbitmq-custom-endpoint.api.stackit.cloud"
+)
+
+func TestConfigureClient(t *testing.T) {
+	/* mock authentication by setting service account token env variable */
+	os.Clearenv()
+	err := os.Setenv(sdkClients.ServiceAccountToken, "mock-val")
+	if err != nil {
+		t.Errorf("error setting env variable: %v", err)
+	}
+
+	type args struct {
+		providerData *core.ProviderData
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		expected *rabbitmq.APIClient
+	}{
+		{
+			name: "default endpoint",
+			args: args{
+				providerData: &core.ProviderData{
+					Version: testVersion,
+				},
+			},
+			expected: func() *rabbitmq.APIClient {
+				apiClient, err := rabbitmq.NewAPIClient(
+					config.WithRegion("eu01"),
+					utils.UserAgentConfigOption(testVersion),
+				)
+				if err != nil {
+					t.Errorf("error configuring client: %v", err)
+				}
+				return apiClient
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "custom endpoint",
+			args: args{
+				providerData: &core.ProviderData{
+					Version:                testVersion,
+					RabbitMQCustomEndpoint: testCustomEndpoint,
+				},
+			},
+			expected: func() *rabbitmq.APIClient {
+				apiClient, err := rabbitmq.NewAPIClient(
+					utils.UserAgentConfigOption(testVersion),
+					config.WithEndpoint(testCustomEndpoint),
+				)
+				if err != nil {
+					t.Errorf("error configuring client: %v", err)
+				}
+				return apiClient
+			}(),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			diags := diag.Diagnostics{}
+
+			actual := ConfigureClient(ctx, tt.args.providerData, &diags)
+			if diags.HasError() != tt.wantErr {
+				t.Errorf("ConfigureClient() error = %v, want %v", diags.HasError(), tt.wantErr)
+			}
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("ConfigureClient() = %v, want %v", actual, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITTPR-184

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
