### PR TITLE
feat(loadbalancer): set custom user-agent header for STACKIT API calls

### DIFF
--- a/stackit/internal/services/loadbalancer/observability-credential/resource.go
+++ b/stackit/internal/services/loadbalancer/observability-credential/resource.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"strings"
 
+	loadbalancerUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/loadbalancer/utils"
+
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -15,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
@@ -90,37 +91,16 @@ func (r *observabilityCredentialResource) ModifyPlan(ctx context.Context, req re
 
 // Configure adds the provider configured client to the resource.
 func (r *observabilityCredentialResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
-	// Prevent panic if the provider has not been configured.
-	if req.ProviderData == nil {
-		return
-	}
-
 	var ok bool
-	r.providerData, ok = req.ProviderData.(core.ProviderData)
+	r.providerData, ok = conversion.ParseProviderData(ctx, req.ProviderData, &resp.Diagnostics)
 	if !ok {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Expected configure type stackit.ProviderData, got %T", req.ProviderData))
 		return
 	}
 
-	var apiClient *loadbalancer.APIClient
-	var err error
-	if r.providerData.LoadBalancerCustomEndpoint != "" {
-		ctx = tflog.SetField(ctx, "loadbalancer_custom_endpoint", r.providerData.LoadBalancerCustomEndpoint)
-		apiClient, err = loadbalancer.NewAPIClient(
-			config.WithCustomAuth(r.providerData.RoundTripper),
-			config.WithEndpoint(r.providerData.LoadBalancerCustomEndpoint),
-		)
-	} else {
-		apiClient, err = loadbalancer.NewAPIClient(
-			config.WithCustomAuth(r.providerData.RoundTripper),
-		)
-	}
-
-	if err != nil {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the resource configuration", err))
+	apiClient := loadbalancerUtils.ConfigureClient(ctx, &r.providerData, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	r.client = apiClient
 	tflog.Info(ctx, "Load Balancer client configured")
 }

--- a/stackit/internal/services/loadbalancer/utils/util.go
+++ b/stackit/internal/services/loadbalancer/utils/util.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
+)
+
+func ConfigureClient(ctx context.Context, providerData *core.ProviderData, diags *diag.Diagnostics) *loadbalancer.APIClient {
+	apiClientConfigOptions := []config.ConfigurationOption{
+		config.WithCustomAuth(providerData.RoundTripper),
+		utils.UserAgentConfigOption(providerData.Version),
+	}
+	if providerData.LoadBalancerCustomEndpoint != "" {
+		apiClientConfigOptions = append(apiClientConfigOptions, config.WithEndpoint(providerData.LoadBalancerCustomEndpoint))
+	}
+	apiClient, err := loadbalancer.NewAPIClient(apiClientConfigOptions...)
+	if err != nil {
+		core.LogAndAddError(ctx, diags, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the resource configuration", err))
+		return nil
+	}
+
+	return apiClient
+}

--- a/stackit/internal/services/loadbalancer/utils/util_test.go
+++ b/stackit/internal/services/loadbalancer/utils/util_test.go
@@ -1,0 +1,93 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	sdkClients "github.com/stackitcloud/stackit-sdk-go/core/clients"
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
+)
+
+const (
+	testVersion        = "1.2.3"
+	testCustomEndpoint = "https://loadbalancer-custom-endpoint.api.stackit.cloud"
+)
+
+func TestConfigureClient(t *testing.T) {
+	/* mock authentication by setting service account token env variable */
+	os.Clearenv()
+	err := os.Setenv(sdkClients.ServiceAccountToken, "mock-val")
+	if err != nil {
+		t.Errorf("error setting env variable: %v", err)
+	}
+
+	type args struct {
+		providerData *core.ProviderData
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		expected *loadbalancer.APIClient
+	}{
+		{
+			name: "default endpoint",
+			args: args{
+				providerData: &core.ProviderData{
+					Version: testVersion,
+				},
+			},
+			expected: func() *loadbalancer.APIClient {
+				apiClient, err := loadbalancer.NewAPIClient(
+					utils.UserAgentConfigOption(testVersion),
+				)
+				if err != nil {
+					t.Errorf("error configuring client: %v", err)
+				}
+				return apiClient
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "custom endpoint",
+			args: args{
+				providerData: &core.ProviderData{
+					Version:                    testVersion,
+					LoadBalancerCustomEndpoint: testCustomEndpoint,
+				},
+			},
+			expected: func() *loadbalancer.APIClient {
+				apiClient, err := loadbalancer.NewAPIClient(
+					utils.UserAgentConfigOption(testVersion),
+					config.WithEndpoint(testCustomEndpoint),
+				)
+				if err != nil {
+					t.Errorf("error configuring client: %v", err)
+				}
+				return apiClient
+			}(),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			diags := diag.Diagnostics{}
+
+			actual := ConfigureClient(ctx, tt.args.providerData, &diags)
+			if diags.HasError() != tt.wantErr {
+				t.Errorf("ConfigureClient() error = %v, want %v", diags.HasError(), tt.wantErr)
+			}
+
+			if !reflect.DeepEqual(actual, tt.expected) {
+				t.Errorf("ConfigureClient() = %v, want %v", actual, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITTPR-184

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
