### PR TITLE
fix(observability): Remove parameters from acc test

### DIFF
--- a/stackit/internal/services/observability/observability_acc_test.go
+++ b/stackit/internal/services/observability/observability_acc_test.go
@@ -69,7 +69,6 @@ var testConfigVarsMax = config.Variables{
 	"alert_annotation": config.StringVariable("annotation1"),
 	"alert_interval":   config.StringVariable("5h"),
 	// max instance
-	// "instance_parameters":                    config.StringVariable("param1"), -> not working right now
 	"metrics_retention_days":                 config.StringVariable("30"),
 	"metrics_retention_days_5m_downsampling": config.StringVariable("10"),
 	"metrics_retention_days_1h_downsampling": config.StringVariable("5"),

--- a/stackit/internal/services/observability/testdata/resource-max.tf
+++ b/stackit/internal/services/observability/testdata/resource-max.tf
@@ -11,7 +11,6 @@ variable "alert_interval" {}
 
 variable "instance_name" {}
 variable "plan_name" {}
-##variable "instance_parameters" {}
 variable "metrics_retention_days" {}
 variable "metrics_retention_days_5m_downsampling" {}
 variable "metrics_retention_days_1h_downsampling" {}


### PR DESCRIPTION
This is not implemented and will be set to deprecated in the near future.

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
