### PR TITLE
fix(loadbalancer): set external_address as optional

### DIFF
--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -119,7 +119,6 @@ resource "stackit_loadbalancer" "example" {
 
 ### Required
 
-- `external_address` (String) External Load Balancer IP address where this Load Balancer is exposed.
 - `listeners` (Attributes List) List of all listeners which will accept traffic. Limited to 20. (see [below for nested schema](#nestedatt--listeners))
 - `name` (String) Load balancer name.
 - `networks` (Attributes List) List of networks that listeners and targets reside in. (see [below for nested schema](#nestedatt--networks))
@@ -128,6 +127,7 @@ resource "stackit_loadbalancer" "example" {
 
 ### Optional
 
+- `external_address` (String) External Load Balancer IP address where this Load Balancer is exposed.
 - `options` (Attributes) Defines any optional functionality you want to have enabled on your load balancer. (see [below for nested schema](#nestedatt--options))
 - `region` (String) The resource region. If not defined, the provider region is used.
 

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	loadbalancerUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/loadbalancer/utils"
 
 	"github.com/google/uuid"
@@ -237,6 +238,16 @@ func (r *loadBalancerResource) ModifyPlan(ctx context.Context, req resource.Modi
 	}
 }
 
+// ConfigValidators validates the resource configuration
+func (r *loadBalancerResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.AtLeastOneOf(
+			path.MatchRoot("external_address"),
+			path.MatchRoot("options").AtName("private_network_only"),
+		),
+	}
+}
+
 // Configure adds the provider configured client to the resource.
 func (r *loadBalancerResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	var ok bool
@@ -327,7 +338,7 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 			},
 			"external_address": schema.StringAttribute{
 				Description: descriptions["external_address"],
-				Required:    true,
+				Optional:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -255,17 +255,17 @@ func (r *loadBalancerResource) ValidateConfig(ctx context.Context, req resource.
 		}
 		return
 	}
-	if lbOptions.PrivateNetworkOnly == nil || *lbOptions.PrivateNetworkOnly == false {
+	if lbOptions.PrivateNetworkOnly == nil || !*lbOptions.PrivateNetworkOnly {
 		// private_network_only is not set or false and external_address is not set
 		if !externalAddressIsSet {
-			core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring load balancer", fmt.Sprintf("You need to provide either the `options.private_network_only = true` or `external_address` field."))
+			core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring load balancer", "You need to provide either the `options.private_network_only = true` or `external_address` field.")
 		}
 		return
 	}
 
 	// Both are set
 	if *lbOptions.PrivateNetworkOnly && externalAddressIsSet {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring load balancer", fmt.Sprintf("You need to provide either the `options.private_network_only = true` or `external_address` field."))
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error configuring load balancer", "You need to provide either the `options.private_network_only = true` or `external_address` field.")
 	}
 }
 

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -245,7 +245,7 @@ func (r *loadBalancerResource) ValidateConfig(ctx context.Context, req resource.
 		return
 	}
 
-	externalAddressIsSet := !utils.IsUndefined(model.ExternalAddress)
+	externalAddressIsSet := !model.ExternalAddress.IsNull()
 
 	lbOptions, err := toOptionsPayload(ctx, &model)
 	if err != nil || lbOptions == nil {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #796 

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
