### PR TITLE
chore(docs): add guide how to create service account in empty org

### DIFF
--- a/docs/guides/stackit_org_service_account.md
+++ b/docs/guides/stackit_org_service_account.md
@@ -1,0 +1,15 @@
+---
+page_title: "Creating projects in empty organization via Terraform"
+---
+# Creating projects in empty organization via Terraform
+
+Consider the following situation: You're starting with an empty STACKIT organization and want to create projects 
+in this organization using the `stackit_resourcemanager_project` resource. Unfortunately it's not possible to create
+a service account on organization level which can be used for authentication in the STACKIT Terraform provider. 
+The following steps will help you to get started:
+
+1. Using the STACKIT portal, create a dummy project in your organization which will hold your service account, let's name it e.g. "dummy-service-account-project".
+2. In this "dummy-service-account-project", create a service account. Create and save a service account key to use for authentication for the STACKIT Terraform provider later as described in the docs. Now copy the e-mail address of the service account you just created.
+3. Here comes the important part: Navigate to your organization, open it and select "Access". Click on the "Grant access" button and paste the e-mail address of your service account. Be careful to grant the service account enough permissions to create projects in your organization, e.g. by assigning the "owner" role to it.
+
+*This problem was brought up initially in [this](https://github.com/stackitcloud/terraform-provider-stackit/issues/855) issue on GitHub.*

--- a/docs/resources/resourcemanager_project.md
+++ b/docs/resources/resourcemanager_project.md
@@ -4,11 +4,14 @@ page_title: "stackit_resourcemanager_project Resource - stackit"
 subcategory: ""
 description: |-
   Resource Manager project resource schema. To use this resource, it is required that you set the service account email in the provider configuration.
+  -> In case you're getting started with an empty STACKIT organization and want to use this resource to create projects in it, check out this guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/stackit_org_service_account for how to create a service account which you can use for authentication in the STACKIT Terraform provider.
 ---
 
 # stackit_resourcemanager_project (Resource)
 
 Resource Manager project resource schema. To use this resource, it is required that you set the service account email in the provider configuration.
+
+-> In case you're getting started with an empty STACKIT organization and want to use this resource to create projects in it, check out [this guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/stackit_org_service_account) for how to create a service account which you can use for authentication in the STACKIT Terraform provider.
 
 ## Example Usage
 

--- a/stackit/internal/services/resourcemanager/project/resource.go
+++ b/stackit/internal/services/resourcemanager/project/resource.go
@@ -91,7 +91,10 @@ func (r *projectResource) Configure(ctx context.Context, req resource.ConfigureR
 // Schema defines the schema for the resource.
 func (r *projectResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                "Resource Manager project resource schema. To use this resource, it is required that you set the service account email in the provider configuration.",
+		"main": fmt.Sprintf("%s\n\n%s",
+			"Resource Manager project resource schema. To use this resource, it is required that you set the service account email in the provider configuration.",
+			"-> In case you're getting started with an empty STACKIT organization and want to use this resource to create projects in it, check out [this guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/stackit_org_service_account) for how to create a service account which you can use for authentication in the STACKIT Terraform provider.",
+		),
 		"id":                  "Terraform's internal resource ID. It is structured as \"`container_id`\".",
 		"project_id":          "Project UUID identifier. This is the ID that can be used in most of the other resources to identify the project.",
 		"container_id":        "Project container ID. Globally unique, user-friendly identifier.",

--- a/templates/guides/stackit_org_service_account.md.tmpl
+++ b/templates/guides/stackit_org_service_account.md.tmpl
@@ -1,0 +1,15 @@
+---
+page_title: "Creating projects in empty organization via Terraform"
+---
+# Creating projects in empty organization via Terraform
+
+Consider the following situation: You're starting with an empty STACKIT organization and want to create projects 
+in this organization using the `stackit_resourcemanager_project` resource. Unfortunately it's not possible to create
+a service account on organization level which can be used for authentication in the STACKIT Terraform provider. 
+The following steps will help you to get started:
+
+1. Using the STACKIT portal, create a dummy project in your organization which will hold your service account, let's name it e.g. "dummy-service-account-project".
+2. In this "dummy-service-account-project", create a service account. Create and save a service account key to use for authentication for the STACKIT Terraform provider later as described in the docs. Now copy the e-mail address of the service account you just created.
+3. Here comes the important part: Navigate to your organization, open it and select "Access". Click on the "Grant access" button and paste the e-mail address of your service account. Be careful to grant the service account enough permissions to create projects in your organization, e.g. by assigning the "owner" role to it.
+
+*This problem was brought up initially in [this](https://github.com/stackitcloud/terraform-provider-stackit/issues/855) issue on GitHub.*


### PR DESCRIPTION


## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #855

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [y] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
