### PR TITLE
feat: force chomp usage on keypair resource

### DIFF
--- a/stackit/internal/services/iaas/keypair/resource.go
+++ b/stackit/internal/services/iaas/keypair/resource.go
@@ -13,12 +13,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 )
 
 // Ensure the implementation satisfies the expected interfaces.
@@ -94,6 +96,9 @@ func (r *keyPairResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					validate.ValidNoTrailingNewline(),
 				},
 			},
 			"fingerprint": schema.StringAttribute{


### PR DESCRIPTION
## Description

Using the file() function in Terraform for the public_key adds a trailing newline, which causes throw an error when SSH access is denied. This PR addresses the issue by recommending chomp() to strip the newline and avoid confusion.

```tf
# Works (chomp removes trailing newline. Also recommended in docs example)
resource "stackit_key_pair" "admin_keypair" {
  name       = "admin-keypair"
  public_key = chomp(file("~/.ssh/id_rsa.pub"))
}

# Throws error (due to trailing newline)
resource "stackit_key_pair" "admin_keypair" {
  name       = "admin-keypair"
  public_key = file("~/.ssh/id_rsa.pub")
}

# ->
Error: Invalid Attribute Value

  with stackit_key_pair.admin_keypair,
  on 01-config.tf line 19, in resource "stackit_key_pair" "admin_keypair":
  19:   public_key = file("~/.ssh/id_rsa.pub")

  Attribute public_key: value must not have a trailing newline character ("\n" or "\r\n"). Use Terraform’s chomp() to remove it. Got: ssh-rsa ..
```

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
