### PR TITLE
docs: attach network interface via server attribute

### DIFF
--- a/docs/guides/using_loadbalancer_with_observability.md
+++ b/docs/guides/using_loadbalancer_with_observability.md
@@ -23,7 +23,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    ```hcl
    resource "stackit_observability_instance" "observability01" {
-     project_id                             = var.project_id_prod
+     project_id                             = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name                                   = "example-instance"
      plan_name                              = "Observability-Monitoring-Medium-EU01"
      acl                                    = ["0.0.0.0/0"]
@@ -33,7 +33,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
    }
 
    resource "stackit_observability_credential" "observability01-credential" {
-     project_id                             = var.project_id_prod
+     project_id                             = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      instance_id = stackit_observability_instance.observability01.instance_id
    }
    ```
@@ -44,7 +44,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    ```hcl
     resource "stackit_loadbalancer_observability_credential" "example" {
-      project_id   = var.project_id_prod
+      project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       display_name = "example-credentials"
       username     = stackit_observability_credential.observability01-credential.username
       password     = stackit_observability_credential.observability01-credential.password
@@ -56,7 +56,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
    ```hcl
    # Create a network
    resource "stackit_network" "example_network" {
-     project_id       = var.project_id_prod
+     project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name             = "example-network"
      ipv4_nameservers = ["8.8.8.8"]
      ipv4_prefix      = "192.168.0.0/25"
@@ -68,13 +68,13 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    # Create a network interface
    resource "stackit_network_interface" "nic" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      network_id = stackit_network.example_network.network_id
    }
 
    # Create a public IP for the load balancer
    resource "stackit_public_ip" "public-ip" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      lifecycle {
        ignore_changes = [network_interface_id]
      }
@@ -89,7 +89,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    # Create a server instance
    resource "stackit_server" "boot-from-image" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name       = "example-server"
      boot_volume = {
        size        = 64
@@ -99,18 +99,14 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
      availability_zone = "eu01-1"
      machine_type      = "g1.1"
      keypair_name      = stackit_key_pair.keypair.name
-   }
-
-   # Attach the network interface to the server
-   resource "stackit_server_network_interface_attach" "nic-attachment" {
-     project_id   = var.project_id_prod
-     server_id            = stackit_server.boot-from-image.server_id
-     network_interface_id = stackit_network_interface.nic.network_interface_id
+     network_interfaces = [
+         stackit_network_interface.nic.network_interface_id
+     ]
    }
 
    # Create a load balancer
    resource "stackit_loadbalancer" "example" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name       = "example-load-balancer"
      target_pools = [
        {

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -61,13 +61,9 @@ resource "stackit_server" "boot-from-image" {
   availability_zone = "xxxx-x"
   machine_type      = "g1.1"
   keypair_name      = stackit_key_pair.keypair.name
-}
-
-# Attach the network interface to the server
-resource "stackit_server_network_interface_attach" "nic-attachment" {
-  project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  server_id            = stackit_server.boot-from-image.server_id
-  network_interface_id = stackit_network_interface.nic.network_interface_id
+  network_interfaces = [
+    stackit_network_interface.nic.network_interface_id
+  ]
 }
 
 # Create a load balancer

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -70,18 +70,6 @@ description: |-
   
   Network setup
   
-  resource "stackit_server" "server-with-network" {
-    project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    name         = "example-server"
-    boot_volume = {
-      size        = 64
-      source_type = "image"
-      source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    }
-    machine_type = "g1.1"
-    keypair_name = stackit_key_pair.keypair.name
-  }
-  
   resource "stackit_network" "network" {
     project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     name               = "example-network"
@@ -108,14 +96,23 @@ description: |-
     security_group_ids = [stackit_security_group.sec-group.security_group_id]
   }
   
-  resource "stackit_public_ip" "public-ip" {
-    project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    network_interface_id = stackit_network_interface.nic.network_interface_id
+  resource "stackit_server" "server-with-network" {
+    project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    name         = "example-server"
+    boot_volume = {
+      size        = 64
+      source_type = "image"
+      source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    }
+    machine_type = "g1.1"
+    keypair_name = stackit_key_pair.keypair.name
+    network_interfaces = [
+      stackit_network_interface.nic.network_interface_id
+    ]	
   }
   
-  resource "stackit_server_network_interface_attach" "nic-attachment" {
+  resource "stackit_public_ip" "public-ip" {
     project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-    server_id            = stackit_server.server-with-network.server_id
     network_interface_id = stackit_network_interface.nic.network_interface_id
   }
   
@@ -254,18 +251,6 @@ resource "stackit_server" "boot-from-volume" {
 
 ### Network setup
 ```terraform
-resource "stackit_server" "server-with-network" {
-  project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  name         = "example-server"
-  boot_volume = {
-    size        = 64
-    source_type = "image"
-    source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  }
-  machine_type = "g1.1"
-  keypair_name = stackit_key_pair.keypair.name
-}
-
 resource "stackit_network" "network" {
   project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name               = "example-network"
@@ -292,14 +277,23 @@ resource "stackit_network_interface" "nic" {
   security_group_ids = [stackit_security_group.sec-group.security_group_id]
 }
 
-resource "stackit_public_ip" "public-ip" {
-  project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  network_interface_id = stackit_network_interface.nic.network_interface_id
+resource "stackit_server" "server-with-network" {
+  project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  name         = "example-server"
+  boot_volume = {
+    size        = 64
+    source_type = "image"
+    source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+  machine_type = "g1.1"
+  keypair_name = stackit_key_pair.keypair.name
+  network_interfaces = [
+    stackit_network_interface.nic.network_interface_id
+  ]	
 }
 
-resource "stackit_server_network_interface_attach" "nic-attachment" {
+resource "stackit_public_ip" "public-ip" {
   project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  server_id            = stackit_server.server-with-network.server_id
   network_interface_id = stackit_network_interface.nic.network_interface_id
 }
 

--- a/examples/resources/stackit_loadbalancer/resource.tf
+++ b/examples/resources/stackit_loadbalancer/resource.tf
@@ -42,13 +42,9 @@ resource "stackit_server" "boot-from-image" {
   availability_zone = "xxxx-x"
   machine_type      = "g1.1"
   keypair_name      = stackit_key_pair.keypair.name
-}
-
-# Attach the network interface to the server
-resource "stackit_server_network_interface_attach" "nic-attachment" {
-  project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  server_id            = stackit_server.boot-from-image.server_id
-  network_interface_id = stackit_network_interface.nic.network_interface_id
+  network_interfaces = [
+    stackit_network_interface.nic.network_interface_id
+  ]
 }
 
 # Create a load balancer

--- a/stackit/internal/services/iaas/server/const.go
+++ b/stackit/internal/services/iaas/server/const.go
@@ -69,18 +69,6 @@ resource "stackit_server" "boot-from-volume" {
 
 ### Network setup` + "\n" +
 	"```terraform" + `
-resource "stackit_server" "server-with-network" {
-  project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  name         = "example-server"
-  boot_volume = {
-    size        = 64
-    source_type = "image"
-    source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  }
-  machine_type = "g1.1"
-  keypair_name = stackit_key_pair.keypair.name
-}
-
 resource "stackit_network" "network" {
   project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name               = "example-network"
@@ -107,14 +95,23 @@ resource "stackit_network_interface" "nic" {
   security_group_ids = [stackit_security_group.sec-group.security_group_id]
 }
 
-resource "stackit_public_ip" "public-ip" {
-  project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  network_interface_id = stackit_network_interface.nic.network_interface_id
+resource "stackit_server" "server-with-network" {
+  project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  name         = "example-server"
+  boot_volume = {
+    size        = 64
+    source_type = "image"
+    source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  }
+  machine_type = "g1.1"
+  keypair_name = stackit_key_pair.keypair.name
+  network_interfaces = [
+    stackit_network_interface.nic.network_interface_id
+  ]	
 }
 
-resource "stackit_server_network_interface_attach" "nic-attachment" {
+resource "stackit_public_ip" "public-ip" {
   project_id           = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  server_id            = stackit_server.server-with-network.server_id
   network_interface_id = stackit_network_interface.nic.network_interface_id
 }
 ` + "\n```" + `

--- a/templates/guides/using_loadbalancer_with_observability.md.tmpl
+++ b/templates/guides/using_loadbalancer_with_observability.md.tmpl
@@ -23,7 +23,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    ```hcl
    resource "stackit_observability_instance" "observability01" {
-     project_id                             = var.project_id_prod
+     project_id                             = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name                                   = "example-instance"
      plan_name                              = "Observability-Monitoring-Medium-EU01"
      acl                                    = ["0.0.0.0/0"]
@@ -33,7 +33,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
    }
 
    resource "stackit_observability_credential" "observability01-credential" {
-     project_id                             = var.project_id_prod
+     project_id                             = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      instance_id = stackit_observability_instance.observability01.instance_id
    }
    ```
@@ -44,7 +44,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    ```hcl
     resource "stackit_loadbalancer_observability_credential" "example" {
-      project_id   = var.project_id_prod
+      project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
       display_name = "example-credentials"
       username     = stackit_observability_credential.observability01-credential.username
       password     = stackit_observability_credential.observability01-credential.password
@@ -56,7 +56,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
    ```hcl
    # Create a network
    resource "stackit_network" "example_network" {
-     project_id       = var.project_id_prod
+     project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name             = "example-network"
      ipv4_nameservers = ["8.8.8.8"]
      ipv4_prefix      = "192.168.0.0/25"
@@ -68,13 +68,13 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    # Create a network interface
    resource "stackit_network_interface" "nic" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      network_id = stackit_network.example_network.network_id
    }
 
    # Create a public IP for the load balancer
    resource "stackit_public_ip" "public-ip" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      lifecycle {
        ignore_changes = [network_interface_id]
      }
@@ -89,7 +89,7 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
 
    # Create a server instance
    resource "stackit_server" "boot-from-image" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name       = "example-server"
      boot_volume = {
        size        = 64
@@ -99,18 +99,14 @@ This guide explains how to configure the STACKIT Loadbalancer product to send me
      availability_zone = "eu01-1"
      machine_type      = "g1.1"
      keypair_name      = stackit_key_pair.keypair.name
-   }
-
-   # Attach the network interface to the server
-   resource "stackit_server_network_interface_attach" "nic-attachment" {
-     project_id   = var.project_id_prod
-     server_id            = stackit_server.boot-from-image.server_id
-     network_interface_id = stackit_network_interface.nic.network_interface_id
+     network_interfaces = [
+         stackit_network_interface.nic.network_interface_id
+     ]
    }
 
    # Create a load balancer
    resource "stackit_loadbalancer" "example" {
-     project_id   = var.project_id_prod
+     project_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
      name       = "example-load-balancer"
      target_pools = [
        {


### PR DESCRIPTION
## Description

A small improvement for our docs :-)

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
