### PR TITLE
docs: add `STACKIT_SERVICE_ACCOUNT_KEY` and `STACKIT_PRIVATE_KEY` envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To authenticate, you will need a [service account](https://docs.stackit.cloud/st
 When setting up authentication, the provider will always try to use the key flow first and search for credentials in several locations, following a specific order:
 
 1. Explicit configuration, e.g. by setting the field `service_account_key_path` in the provider block (see example below)
-2. Environment variable, e.g. by setting `STACKIT_SERVICE_ACCOUNT_KEY_PATH`
+2. Environment variable, e.g. by setting `STACKIT_SERVICE_ACCOUNT_KEY_PATH` or `STACKIT_SERVICE_ACCOUNT_KEY`
 3. Credentials file
 
    The provider will check the credentials file located in the path defined by the `STACKIT_CREDENTIALS_PATH` env var, if specified,
@@ -99,13 +99,15 @@ To configure the key flow, follow this steps:
 3. Configure the service account key for authentication in the provider by following one of the alternatives below:
 
    - setting the fields in the provider block: `service_account_key` or `service_account_key_path`
-   - setting the environment variable: `STACKIT_SERVICE_ACCOUNT_KEY_PATH`
+   - setting the environment variable: `STACKIT_SERVICE_ACCOUNT_KEY_PATH` or `STACKIT_SERVICE_ACCOUNT_KEY`
+     - ensure the set the service account key in `STACKIT_SERVICE_ACCOUNT_KEY` is correctly formatted. Use e.g.
+       `$ export STACKIT_SERVICE_ACCOUNT_KEY=$(cat ./service-account-key.json)`
    - setting `STACKIT_SERVICE_ACCOUNT_KEY_PATH` in the credentials file (see above)
 
 > **Optionally, only if you have provided your own RSA key-pair when creating the service account key**, you also need to configure your private key (takes precedence over the one included in the service account key, if present). **The private key must be PEM encoded** and can be provided using one of the options below:
 >
 > - setting the field in the provider block: `private_key` or `private_key_path`
-> - setting the environment variable: `STACKIT_PRIVATE_KEY_PATH`
+> - setting the environment variable: `STACKIT_PRIVATE_KEY_PATH` or `STACKIT_PRIVATE_KEY`
 > - setting `STACKIT_PRIVATE_KEY_PATH` in the credentials file (see above)
 
 ### Token flow


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to -

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI) 

## Testing instructions

- Use the following tf-file and run `$ terraform apply`:
  - This should result in an error, with the message that no credentials were found

```hcl
provider "stackit" {
}

resource "stackit_key_pair" "keypair" {
  name       = "test-key-pair"
  public_key = chomp(file("~/.ssh/<path-to-your-ssh-key>.pub"))
}
```

- Read you service account key file into the env `STACKIT_SERVICE_ACCOUNT_KEY`:
  - `$ export STACKIT_SERVICE_ACCOUNT_KEY=$(cat ./<path-to-your-sa-key>.json)`
- Rerun `$ terraform apply`
  - This time it should work
- Cleanup by running `$ terraform destroy`