### PR TITLE
docs: add routing-tables to experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ To enable experiments set the experiments field in the provider definition:
 ```hcl
 provider "stackit" {
   default_region        = "eu01"
-  experiments           = ["iam"]
+  experiments           = ["iam", "routing-tables"]
 }
 ```
 
@@ -192,6 +192,10 @@ provider "stackit" {
 #### `iam`
 
 Enables IAM management features in the Terraform provider. The underlying IAM API is expected to undergo a redesign in the future, which leads to it being considered experimental.
+
+#### `routing-tables`
+
+This feature enables experimental routing table capabilities in the Terraform Provider, available only to designated SNAs at this time.
 
 ## Acceptance Tests
 


### PR DESCRIPTION
## Description

Adds routing-table to readme

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
