### PR TITLE
fix(acc-tests): enable beta resources properly where needed

### DIFF
--- a/stackit/internal/testutil/testutil.go
+++ b/stackit/internal/testutil/testutil.go
@@ -95,11 +95,15 @@ func ObservabilityProviderConfig() string {
 }
 func CdnProviderConfig() string {
 	if CdnCustomEndpoint == "" {
-		return `provider "stackit" {}`
+		return `
+		provider "stackit" {
+			enable_beta_resources = true
+		}`
 	}
 	return fmt.Sprintf(`
 		provider "stackit" {
 			cdn_custom_endpoint = "%s"
+			enable_beta_resources = true
 		}`,
 		CdnCustomEndpoint,
 	)
@@ -154,7 +158,6 @@ func LoadBalancerProviderConfig() string {
 		return `
 		provider "stackit" {
 			default_region = "eu01"
-			enable_beta_resources = true
 		}`
 	}
 	return fmt.Sprintf(`
@@ -383,6 +386,7 @@ func ServerUpdateProviderConfig() string {
 	return fmt.Sprintf(`
 		provider "stackit" {
 			server_update_custom_endpoint = "%s"
+			enable_beta_resources = true
 		}`,
 		ServerUpdateCustomEndpoint,
 	)


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #906

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
