### PR TITLE
chore(sa-tokens): mark deprecation on sa-token resource

### DIFF
--- a/stackit/internal/services/serviceaccount/token/resource.go
+++ b/stackit/internal/services/serviceaccount/token/resource.go
@@ -98,6 +98,7 @@ func (r *serviceAccountTokenResource) Schema(_ context.Context, _ resource.Schem
 	resp.Schema = schema.Schema{
 		MarkdownDescription: fmt.Sprintf("%s%s", descriptions["main"], markdownDescription),
 		Description:         descriptions["main"],
+		DeprecationMessage:  "This resource is scheduled for deprecation and will be removed on December 17, 2025. To ensure a smooth transition, please refer to our migration guide at https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html for detailed instructions and recommendations.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],


### PR DESCRIPTION
## Description

See 
https://docs.stackit.cloud/stackit/en/release-notes-23101442.html
https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
