### PR TITLE
chore(provider): mark deprecation for service_account_token

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -121,7 +121,7 @@ To test your changes locally, you have to compile the provider (requires Go 1.24
 
 1. Go to the copied example and initialize Terraform by running `terraform init -reconfigure -upgrade`. This will throw an error ("Failed to query available provider packages") which can be ignored since we are using the local provider build.
    > Note: Terraform will store its resources' states locally. To allow multiple people to use the same resources, check [Setup for multi-person usage](#setup-centralized-terraform-state)
-1. Setup authentication by setting the env var `STACKIT_SERVICE_ACCOUNT_TOKEN` as a valid token (see [Authentication](#authentication) for more details on how to autenticate).
+1. Setup authentication (see [Authentication](#authentication) for more details on how to authenticate).
 1. Run `terraform plan` or `terraform apply` commands.
 1. To debug the terraform provider, execute the following steps:
 	* install the compiled terraform provider to binary path defined in the .terraformrc file

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Check one of the examples in the [examples](examples/) folder.
 To authenticate, you will need a [service account](https://docs.stackit.cloud/stackit/en/service-accounts-134415819.html). Create it in the [STACKIT Portal](https://portal.stackit.cloud/) and assign the necessary permissions to it, e.g. `project.owner`. There are multiple ways to authenticate:
 
 - Key flow (recommended)
-- Token flow (will be removed is scheduled for deprecation and will be removed on December 17, 2025.)
+- Token flow (is scheduled for deprecation and will be removed on December 17, 2025.)
 
 When setting up authentication, the provider will always try to use the key flow first and search for credentials in several locations, following a specific order:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Check one of the examples in the [examples](examples/) folder.
 To authenticate, you will need a [service account](https://docs.stackit.cloud/stackit/en/service-accounts-134415819.html). Create it in the [STACKIT Portal](https://portal.stackit.cloud/) and assign the necessary permissions to it, e.g. `project.owner`. There are multiple ways to authenticate:
 
 - Key flow (recommended)
-- Token flow
+- Token flow (will be removed is scheduled for deprecation and will be removed on December 17, 2025.)
 
 When setting up authentication, the provider will always try to use the key flow first and search for credentials in several locations, following a specific order:
 
@@ -111,6 +111,8 @@ To configure the key flow, follow this steps:
 > - setting `STACKIT_PRIVATE_KEY_PATH` in the credentials file (see above)
 
 ### Token flow
+
+> Is scheduled for deprecation and will be removed on December 17, 2025.
 
 Using this flow is less secure since the token is long-lived. You can provide the token in several ways:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -182,7 +182,7 @@ Note: AWS specific checks must be skipped as they do not work on STACKIT. For de
 - `service_account_email` (String, Deprecated) Service account email. It can also be set using the environment variable STACKIT_SERVICE_ACCOUNT_EMAIL. It is required if you want to use the resource manager project resource.
 - `service_account_key` (String) Service account key used for authentication. If set, the key flow will be used to authenticate all operations.
 - `service_account_key_path` (String) Path for the service account key used for authentication. If set, the key flow will be used to authenticate all operations.
-- `service_account_token` (String) Token used for authentication. If set, the token flow will be used to authenticate all operations.
+- `service_account_token` (String, Deprecated) Token used for authentication. If set, the token flow will be used to authenticate all operations.
 - `service_enablement_custom_endpoint` (String) Custom endpoint for the Service Enablement API
 - `ske_custom_endpoint` (String) Custom endpoint for the Kubernetes Engine (SKE) service
 - `sqlserverflex_custom_endpoint` (String) Custom endpoint for the SQL Server Flex service

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ provider "stackit" {
 
 # Authentication
 
-# Token flow
+# Token flow (scheduled for deprecation and will be removed on December 17, 2025)
 provider "stackit" {
   default_region        = "eu01"
   service_account_token = var.service_account_token
@@ -37,7 +37,7 @@ provider "stackit" {
 To authenticate, you will need a [service account](https://docs.stackit.cloud/stackit/en/service-accounts-134415819.html). Create it in the [STACKIT Portal](https://portal.stackit.cloud/) and assign it the necessary permissions, e.g. `project.owner`. There are multiple ways to authenticate:
 
 - Key flow (recommended)
-- Token flow
+- Token flow (is scheduled for deprecation and will be removed on December 17, 2025)
 
 When setting up authentication, the provider will always try to use the key flow first and search for credentials in several locations, following a specific order:
 
@@ -111,6 +111,8 @@ To configure the key flow, follow this steps:
 
 
 ### Token flow
+
+> Is scheduled for deprecation and will be removed on December 17, 2025.
 
 Using this flow is less secure since the token is long-lived. You can provide the token in several ways:
 

--- a/docs/resources/service_account_access_token.md
+++ b/docs/resources/service_account_access_token.md
@@ -4,6 +4,7 @@ page_title: "stackit_service_account_access_token Resource - stackit"
 subcategory: ""
 description: |-
   Service account access token schema.
+  !> This resource is scheduled for deprecation and will be removed on December 17, 2025. To ensure a smooth transition, please refer to our migration guide at https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html for detailed instructions and recommendations.
   Example Usage
   Automatically rotate access tokens
   
@@ -30,6 +31,9 @@ description: |-
 # stackit_service_account_access_token (Resource)
 
 Service account access token schema.
+
+!> This resource is scheduled for deprecation and will be removed on December 17, 2025. To ensure a smooth transition, please refer to our migration guide at https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html for detailed instructions and recommendations.
+
 ## Example Usage
 
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -4,7 +4,7 @@ provider "stackit" {
 
 # Authentication
 
-# Token flow
+# Token flow (scheduled for deprecation and will be removed on December 17, 2025)
 provider "stackit" {
   default_region        = "eu01"
   service_account_token = var.service_account_token

--- a/stackit/internal/services/serviceaccount/token/resource.go
+++ b/stackit/internal/services/serviceaccount/token/resource.go
@@ -85,6 +85,7 @@ func (r *serviceAccountTokenResource) Schema(_ context.Context, _ resource.Schem
 	descriptions := map[string]string{
 		"id":                    "Terraform's internal resource identifier. It is structured as \"`project_id`,`service_account_email`,`access_token_id`\".",
 		"main":                  "Service account access token schema.",
+		"deprecation_message":   "This resource is scheduled for deprecation and will be removed on December 17, 2025. To ensure a smooth transition, please refer to our migration guide at https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html for detailed instructions and recommendations.",
 		"project_id":            "STACKIT project ID associated with the service account token.",
 		"service_account_email": "Email address linked to the service account.",
 		"ttl_days":              "Specifies the token's validity duration in days. If unspecified, defaults to 90 days.",
@@ -96,9 +97,9 @@ func (r *serviceAccountTokenResource) Schema(_ context.Context, _ resource.Schem
 		"valid_until":           "Estimated expiration timestamp of the access token. For precise validity, check the JWT details.",
 	}
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf("%s%s", descriptions["main"], markdownDescription),
+		MarkdownDescription: fmt.Sprintf("%s\n\n!> %s\n%s", descriptions["main"], descriptions["deprecation_message"], markdownDescription),
 		Description:         descriptions["main"],
-		DeprecationMessage:  "This resource is scheduled for deprecation and will be removed on December 17, 2025. To ensure a smooth transition, please refer to our migration guide at https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html for detailed instructions and recommendations.",
+		DeprecationMessage:  descriptions["deprecation_message"],
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],

--- a/stackit/internal/services/serviceaccount/token/resource.go
+++ b/stackit/internal/services/serviceaccount/token/resource.go
@@ -169,6 +169,7 @@ func (r *serviceAccountTokenResource) Schema(_ context.Context, _ resource.Schem
 
 // Create creates the resource and sets the initial Terraform state for service accounts.
 func (r *serviceAccountTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) { // nolint:gocritic // function signature required by Terraform
+	core.LogAndAddWarning(ctx, &resp.Diagnostics, "stackit_service_account_access_token resource deprecated", "use stackit_service_account_key resource instead")
 	// Retrieve the planned values for the resource.
 	var model Model
 	diags := req.Plan.Get(ctx, &model)
@@ -216,6 +217,7 @@ func (r *serviceAccountTokenResource) Create(ctx context.Context, req resource.C
 
 // Read refreshes the Terraform state with the latest service account data.
 func (r *serviceAccountTokenResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) { // nolint:gocritic // function signature required by Terraform
+	core.LogAndAddWarning(ctx, &resp.Diagnostics, "stackit_service_account_access_token resource deprecated", "use stackit_service_account_key resource instead")
 	// Retrieve the current state of the resource.
 	var model Model
 	diags := req.State.Get(ctx, &model)
@@ -284,6 +286,7 @@ func (r *serviceAccountTokenResource) Update(ctx context.Context, _ resource.Upd
 
 // Delete deletes the service account and removes it from the Terraform state on success.
 func (r *serviceAccountTokenResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) { // nolint:gocritic // function signature required by Terraform
+	core.LogAndAddWarning(ctx, &resp.Diagnostics, "stackit_service_account_access_token resource deprecated", "use stackit_service_account_key resource instead")
 	// Retrieve current state of the resource.
 	var model Model
 	diags := req.State.Get(ctx, &model)

--- a/stackit/provider.go
+++ b/stackit/provider.go
@@ -204,6 +204,9 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 			"service_account_token": schema.StringAttribute{
 				Optional:    true,
 				Description: descriptions["service_account_token"],
+				DeprecationMessage: "Authentication via Service Account Token is deprecated and will be removed on December 17, 2025. " +
+					"Please use `service_account_key` or `service_account_key_path` instead. " +
+					"For a smooth transition, refer to our migration guide: https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html",
 			},
 			"service_account_key_path": schema.StringAttribute{
 				Optional:    true,

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -11,7 +11,7 @@ The STACKIT Terraform provider is the official Terraform provider to integrate a
 To authenticate, you will need a [service account](https://docs.stackit.cloud/stackit/en/service-accounts-134415819.html). Create it in the [STACKIT Portal](https://portal.stackit.cloud/) and assign it the necessary permissions, e.g. `project.owner`. There are multiple ways to authenticate:
 
 - Key flow (recommended)
-- Token flow
+- Token flow (is scheduled for deprecation and will be removed on December 17, 2025)
 
 When setting up authentication, the provider will always try to use the key flow first and search for credentials in several locations, following a specific order:
 
@@ -85,6 +85,8 @@ To configure the key flow, follow this steps:
 
 
 ### Token flow
+
+> Is scheduled for deprecation and will be removed on December 17, 2025.
 
 Using this flow is less secure since the token is long-lived. You can provide the token in several ways:
 


### PR DESCRIPTION
## Description

See
https://docs.stackit.cloud/stackit/en/release-notes-23101442.html
https://docs.stackit.cloud/stackit/en/deprecation-plan-for-service-account-access-tokens-and-migration-guide-373293307.html

## Checklist

- [x] Issue was linked above
- [x]  Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
