### PR TITLE
fix(kubeconfig): Region is not set correctly for Read()

### DIFF
--- a/stackit/internal/services/ske/kubeconfig/resource.go
+++ b/stackit/internal/services/ske/kubeconfig/resource.go
@@ -10,6 +10,7 @@ import (
 	skeUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/ske/utils"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
@@ -274,7 +275,13 @@ func (r *kubeconfigResource) Read(ctx context.Context, req resource.ReadRequest,
 	projectId := model.ProjectId.ValueString()
 	clusterName := model.ClusterName.ValueString()
 	kubeconfigUUID := model.KubeconfigId.ValueString()
-	region := model.Region.ValueString()
+	region := r.providerData.GetRegionWithOverride(model.Region)
+	// Prevent recreation of kubeconfig when updating to v2 api version
+	diags = resp.State.SetAttribute(ctx, path.Root("region"), region)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 	ctx = tflog.SetField(ctx, "project_id", projectId)
 	ctx = tflog.SetField(ctx, "cluster_name", clusterName)
 	ctx = tflog.SetField(ctx, "kube_config_id", kubeconfigUUID)
@@ -321,7 +328,6 @@ func (r *kubeconfigResource) Read(ctx context.Context, req resource.ReadRequest,
 			core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading kubeconfig", fmt.Sprintf("The existing kubeconfig is invalid, creating a new one: %v", err))
 			return
 		}
-
 		// Set state to fully populated data
 		diags = resp.State.Set(ctx, model)
 		resp.Diagnostics.Append(diags...)
@@ -346,7 +352,7 @@ func (r *kubeconfigResource) createKubeconfig(ctx context.Context, model *Model)
 	}
 
 	// Map response body to schema
-	err = mapFields(kubeconfigResp, model, time.Now())
+	err = mapFields(kubeconfigResp, model, time.Now(), model.Region.ValueString())
 	if err != nil {
 		return fmt.Errorf("processing API payload: %w", err)
 	}
@@ -383,7 +389,7 @@ func (r *kubeconfigResource) Delete(ctx context.Context, req resource.DeleteRequ
 	tflog.Info(ctx, "SKE kubeconfig deleted")
 }
 
-func mapFields(kubeconfigResp *ske.Kubeconfig, model *Model, creationTime time.Time) error {
+func mapFields(kubeconfigResp *ske.Kubeconfig, model *Model, creationTime time.Time, region string) error {
 	if kubeconfigResp == nil {
 		return fmt.Errorf("response is nil")
 	}
@@ -403,6 +409,7 @@ func mapFields(kubeconfigResp *ske.Kubeconfig, model *Model, creationTime time.T
 	model.ExpiresAt = types.StringValue(kubeconfigResp.ExpirationTimestamp.Format(time.RFC3339))
 	// set creation time
 	model.CreationTime = types.StringValue(creationTime.Format(time.RFC3339))
+	model.Region = types.StringValue(region)
 	return nil
 }
 

--- a/stackit/internal/services/ske/kubeconfig/resource_test.go
+++ b/stackit/internal/services/ske/kubeconfig/resource_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMapFields(t *testing.T) {
+	const testRegion = "eu01"
 	tests := []struct {
 		description string
 		input       *ske.Kubeconfig
@@ -32,6 +33,7 @@ func TestMapFields(t *testing.T) {
 				Refresh:      types.BoolNull(),
 				ExpiresAt:    types.StringValue("2024-02-07T16:42:12Z"),
 				CreationTime: types.StringValue("2024-02-05T14:40:12Z"),
+				Region:       types.StringValue(testRegion),
 			},
 			true,
 		},
@@ -63,7 +65,7 @@ func TestMapFields(t *testing.T) {
 				ClusterName: tt.expected.ClusterName,
 			}
 			creationTime, _ := time.Parse(time.RFC3339, tt.expected.CreationTime.ValueString())
-			err := mapFields(tt.input, state, creationTime)
+			err := mapFields(tt.input, state, creationTime, testRegion)
 			if !tt.isValid && err == nil {
 				t.Fatalf("Should have failed")
 			}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #924

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
