### PR TITLE
fix: recreation of kubeconfig fails after migration

### DIFF
--- a/stackit/internal/services/ske/kubeconfig/resource.go
+++ b/stackit/internal/services/ske/kubeconfig/resource.go
@@ -276,6 +276,8 @@ func (r *kubeconfigResource) Read(ctx context.Context, req resource.ReadRequest,
 	clusterName := model.ClusterName.ValueString()
 	kubeconfigUUID := model.KubeconfigId.ValueString()
 	region := r.providerData.GetRegionWithOverride(model.Region)
+	// Prevent error state when updating to v2 api version and the kubeconfig is expired
+	model.Region = types.StringValue(region)
 	// Prevent recreation of kubeconfig when updating to v2 api version
 	diags = resp.State.SetAttribute(ctx, path.Root("region"), region)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #924

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
