### PR TITLE
Add send_resolved and priority to opsgenie config in observability

### DIFF
--- a/stackit/internal/services/observability/instance/datasource.go
+++ b/stackit/internal/services/observability/instance/datasource.go
@@ -243,6 +243,14 @@ func (d *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 												Description: "The host to send OpsGenie API requests to. Must be a valid URL",
 												Computed:    true,
 											},
+											"priority": schema.StringAttribute{
+												Description: "Priority level of alert. Possible values are P1, P2, P3, P4, and P5.",
+												Computed:    true,
+											},
+											"send_resolved": schema.BoolAttribute{
+												Description: "Whether to notify about resolved alerts.",
+												Computed:    true,
+											},
 											"tags": schema.StringAttribute{
 												Description: "Comma separated list of tags attached to the notifications.",
 												Computed:    true,

--- a/stackit/internal/services/observability/instance/resource.go
+++ b/stackit/internal/services/observability/instance/resource.go
@@ -187,15 +187,19 @@ var emailConfigsTypes = map[string]attr.Type{
 
 // Struct corresponding to Model.AlertConfig.receivers.opsGenieConfigs
 type opsgenieConfigsModel struct {
-	ApiKey types.String `tfsdk:"api_key"`
-	ApiUrl types.String `tfsdk:"api_url"`
-	Tags   types.String `tfsdk:"tags"`
+	ApiKey       types.String `tfsdk:"api_key"`
+	ApiUrl       types.String `tfsdk:"api_url"`
+	Priority     types.String `tfsdk:"priority"`
+	SendResolved types.Bool   `tfsdk:"send_resolved"`
+	Tags         types.String `tfsdk:"tags"`
 }
 
 var opsgenieConfigsTypes = map[string]attr.Type{
-	"api_key": types.StringType,
-	"api_url": types.StringType,
-	"tags":    types.StringType,
+	"api_key":       types.StringType,
+	"api_url":       types.StringType,
+	"priority":      types.StringType,
+	"send_resolved": types.BoolType,
+	"tags":          types.StringType,
 }
 
 // Struct corresponding to Model.AlertConfig.receivers.webHooksConfigs
@@ -1665,9 +1669,11 @@ func mapReceiversToAttributes(ctx context.Context, respReceivers *[]observabilit
 		if receiver.OpsgenieConfigs != nil {
 			for _, opsgenieConfig := range *receiver.OpsgenieConfigs {
 				opsGenieConfigMap := map[string]attr.Value{
-					"api_key": types.StringPointerValue(opsgenieConfig.ApiKey),
-					"api_url": types.StringPointerValue(opsgenieConfig.ApiUrl),
-					"tags":    types.StringPointerValue(opsgenieConfig.Tags),
+					"api_key":       types.StringPointerValue(opsgenieConfig.ApiKey),
+					"api_url":       types.StringPointerValue(opsgenieConfig.ApiUrl),
+					"priority":      types.StringPointerValue(opsgenieConfig.Priority),
+					"send_resolved": types.BoolPointerValue(opsgenieConfig.SendResolved),
+					"tags":          types.StringPointerValue(opsgenieConfig.Tags),
 				}
 				opsGenieConfigModel, diags := types.ObjectValue(opsgenieConfigsTypes, opsGenieConfigMap)
 				if diags.HasError() {
@@ -2014,9 +2020,11 @@ func toReceiverPayload(ctx context.Context, model *alertConfigModel) (*[]observa
 			for i := range opsgenieConfigs {
 				opsgenieConfig := opsgenieConfigs[i]
 				payloadOpsGenieConfigs = append(payloadOpsGenieConfigs, observability.CreateAlertConfigReceiverPayloadOpsgenieConfigsInner{
-					ApiKey: conversion.StringValueToPointer(opsgenieConfig.ApiKey),
-					ApiUrl: conversion.StringValueToPointer(opsgenieConfig.ApiUrl),
-					Tags:   conversion.StringValueToPointer(opsgenieConfig.Tags),
+					ApiKey:       conversion.StringValueToPointer(opsgenieConfig.ApiKey),
+					ApiUrl:       conversion.StringValueToPointer(opsgenieConfig.ApiUrl),
+					Priority:     conversion.StringValueToPointer(opsgenieConfig.Priority),
+					SendResolved: conversion.BoolValueToPointer(opsgenieConfig.SendResolved),
+					Tags:         conversion.StringValueToPointer(opsgenieConfig.Tags),
 				})
 			}
 			receiverPayload.OpsgenieConfigs = &payloadOpsGenieConfigs

--- a/stackit/internal/services/observability/instance/resource_test.go
+++ b/stackit/internal/services/observability/instance/resource_test.go
@@ -33,9 +33,11 @@ func fixtureEmailConfigsModel() basetypes.ListValue {
 func fixtureOpsGenieConfigsModel() basetypes.ListValue {
 	return types.ListValueMust(types.ObjectType{AttrTypes: opsgenieConfigsTypes}, []attr.Value{
 		types.ObjectValueMust(opsgenieConfigsTypes, map[string]attr.Value{
-			"api_key": types.StringValue("key"),
-			"tags":    types.StringValue("tag"),
-			"api_url": types.StringValue("ops.example.com"),
+			"api_key":       types.StringValue("key"),
+			"tags":          types.StringValue("tag"),
+			"api_url":       types.StringValue("ops.example.com"),
+			"priority":      types.StringNull(),
+			"send_resolved": types.BoolNull(),
 		}),
 	})
 }


### PR DESCRIPTION
## Description

Adds send_resolved and priority to the opsgenie config in the observability service. It is needed to configure opsgenie correctly for oncall purposes.

## Checklist

- [-] Issue was linked above
- [x] Code format was applied: `make fmt`
- [-] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [-] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
