### PR TITLE
chore(scripts): use bash found in path in shebang

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used to ensure for PRs the docs are up-to-date via the CI pipeline
 # Usage: ./check-docs.sh

--- a/scripts/lint-golangci-lint.sh
+++ b/scripts/lint-golangci-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This script lints the SDK modules and the internal examples
 # Pre-requisites: golangci-lint
 set -eo pipefail

--- a/scripts/project.sh
+++ b/scripts/project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used to manage the project, only used for installing the required tools for now
 # Usage: ./project.sh [action]

--- a/scripts/replace.sh
+++ b/scripts/replace.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Add replace directives to local files to go.work
 set -eo pipefail
 

--- a/scripts/tfplugindocs.sh
+++ b/scripts/tfplugindocs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Pre-requisites: tfplugindocs
 set -eo pipefail
 


### PR DESCRIPTION
## Description

See https://stackoverflow.com/questions/10376206/what-is-the-preferred-bash-shebang/10383546#10383546 , on e.g. NixOS machines `/bin/bash` doesn't work

We can discuss this as soon as I'm back for sure.

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
