### PR TITLE
changed ipv4 prefix in resources loadbalancer.md to represent a working example

### DIFF
--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -119,14 +119,14 @@ resource "stackit_loadbalancer" "example" {
 resource "stackit_network" "lb_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "lb-network-example"
-  ipv4_prefix      = "192.168.1.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 
 resource "stackit_network" "target_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "target-network-example"
-  ipv4_prefix      = "192.168.2.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 

--- a/examples/resources/stackit_loadbalancer/resource.tf
+++ b/examples/resources/stackit_loadbalancer/resource.tf
@@ -100,14 +100,14 @@ resource "stackit_loadbalancer" "example" {
 resource "stackit_network" "lb_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "lb-network-example"
-  ipv4_prefix      = "192.168.1.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 
 resource "stackit_network" "target_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "target-network-example"
-  ipv4_prefix      = "192.168.2.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 


### PR DESCRIPTION
´
## Description

The docs had a non working example for the advanced example because of the ipv4 prefix which is fixed now.

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
