### PR TITLE
added new attribite load_balancer_security_group

### DIFF
--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -242,8 +242,9 @@ import {
 ### Read-Only
 
 - `id` (String) Terraform's internal resource ID. It is structured as "`project_id`","region","`name`".
+- `load_balancer_security_group_id` (String) The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.
 - `private_address` (String) Transient private Load Balancer IP address. It can change any time.
-- `security_group_id` (String) The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.
+- `security_group_id` (String) The ID of the backend security group
 
 <a id="nestedatt--listeners"></a>
 ### Nested Schema for `listeners`

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -119,14 +119,14 @@ resource "stackit_loadbalancer" "example" {
 resource "stackit_network" "lb_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "lb-network-example"
-  ipv4_prefix      = "192.168.1.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 
 resource "stackit_network" "target_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "target-network-example"
-  ipv4_prefix      = "192.168.2.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 

--- a/examples/resources/stackit_loadbalancer/resource.tf
+++ b/examples/resources/stackit_loadbalancer/resource.tf
@@ -100,14 +100,14 @@ resource "stackit_loadbalancer" "example" {
 resource "stackit_network" "lb_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "lb-network-example"
-  ipv4_prefix      = "192.168.1.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 
 resource "stackit_network" "target_network" {
   project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name             = "target-network-example"
-  ipv4_prefix      = "192.168.2.0/24"
+  ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -63,6 +63,7 @@ type Model struct {
 	TargetPools                    types.List   `tfsdk:"target_pools"`
 	Region                         types.String `tfsdk:"region"`
 	SecurityGroupId                types.String `tfsdk:"security_group_id"`
+	LoadBalancerSecurityGroupId    types.String `tfsdk:"load_balancer_security_group_id"`
 }
 
 // Struct corresponding to Model.Listeners[i]
@@ -1246,6 +1247,12 @@ func mapFields(ctx context.Context, lb *loadbalancer.LoadBalancer, m *Model, reg
 	m.ExternalAddress = types.StringPointerValue(lb.ExternalAddress)
 	m.PrivateAddress = types.StringPointerValue(lb.PrivateAddress)
 	m.DisableSecurityGroupAssignment = types.BoolPointerValue(lb.DisableTargetSecurityGroupAssignment)
+
+	if lb.LoadBalancerSecurityGroup != nil {
+		m.LoadBalancerSecurityGroupId = types.StringPointerValue(lb.LoadBalancerSecurityGroup.Id)
+	} else {
+		m.LoadBalancerSecurityGroupId = types.StringNull()
+	}
 
 	if lb.TargetSecurityGroup != nil {
 		m.SecurityGroupId = types.StringPointerValue(lb.TargetSecurityGroup.Id)

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -345,7 +345,8 @@ func (r *loadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 		"targets.display_name":                  "Target display name",
 		"ip":                                    "Target IP",
 		"region":                                "The resource region. If not defined, the provider region is used.",
-		"security_group_id":                     "The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.",
+		"security_group_id":                     "The ID of the backend security group",
+		"load_balancer_security_group_id":       "The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.",
 	}
 
 	resp.Schema = schema.Schema{
@@ -688,6 +689,13 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 			},
 			"security_group_id": schema.StringAttribute{
 				Description: descriptions["security_group_id"],
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"load_balancer_security_group_id": schema.StringAttribute{
+				Description: descriptions["load_balancer_security_group_id"],
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),


### PR DESCRIPTION
## Description

The attribute of the actual loadbalancer security group wasnt in the provider yet and is now added.

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
