### PR TITLE
fix(observability/instance): adjust drift

### DIFF
--- a/stackit/internal/services/observability/instance/resource.go
+++ b/stackit/internal/services/observability/instance/resource.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
 
 	observabilityUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/observability/utils"
@@ -459,6 +460,9 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Validators: []validator.String{
 					validate.UUID(),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"parameters": schema.MapAttribute{
 				Description: "Additional parameters.",
@@ -516,16 +520,25 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "Specifies for how many days the raw metrics are kept. Default is set to `90`.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"metrics_retention_days_5m_downsampling": schema.Int64Attribute{
 				Description: "Specifies for how many days the 5m downsampled metrics are kept. must be less than the value of the general retention. Default is set to `90`.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"metrics_retention_days_1h_downsampling": schema.Int64Attribute{
 				Description: "Specifies for how many days the 1h downsampled metrics are kept. must be less than the value of the 5m downsampling retention. Default is set to `90`.",
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"metrics_url": schema.StringAttribute{
 				Description: "Specifies metrics URL.",
@@ -777,10 +790,18 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 								Description: "The API key for OpsGenie.",
 								Optional:    true,
 								Sensitive:   true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"opsgenie_api_url": schema.StringAttribute{
 								Description: "The host to send OpsGenie API requests to. Must be a valid URL",
 								Optional:    true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"resolve_timeout": schema.StringAttribute{
 								Description: "The default value used by alertmanager if the alert does not include EndsAt. After this time passes, it can declare the alert as resolved if it has not been updated. This has no impact on alerts from Prometheus, as they always include EndsAt.",
@@ -793,24 +814,43 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 							"smtp_auth_identity": schema.StringAttribute{
 								Description: "SMTP authentication information. Must be a valid email address",
 								Optional:    true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"smtp_auth_password": schema.StringAttribute{
 								Description: "SMTP Auth using LOGIN and PLAIN.",
 								Optional:    true,
 								Sensitive:   true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"smtp_auth_username": schema.StringAttribute{
 								Description: "SMTP Auth using CRAM-MD5, LOGIN and PLAIN. If empty, Alertmanager doesn't authenticate to the SMTP server.",
 								Optional:    true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"smtp_from": schema.StringAttribute{
 								Description: "The default SMTP From header field. Must be a valid email address",
 								Optional:    true,
 								Computed:    true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 							"smtp_smart_host": schema.StringAttribute{
 								Description: "The default SMTP smarthost used for sending emails, including port number in format `host:port` (eg. `smtp.example.com:587`). Port number usually is 25, or 587 for SMTP over TLS (sometimes referred to as STARTTLS).",
 								Optional:    true,
+								Computed:    true,
+								PlanModifiers: []planmodifier.String{
+									stringplanmodifier.UseStateForUnknown(),
+								},
 							},
 						},
 					},
@@ -1619,10 +1659,21 @@ func mapGlobalConfigToAttributes(respGlobalConfigs *observability.Global, global
 			smtpAuthUsername = sdkUtils.Ptr(globalConfigsTF.SmtpAuthUsername.ValueString())
 		}
 	}
+	//handle nil value from api
+	opsgenieApiKey := respGlobalConfigs.OpsgenieApiKey
+	opsgenieApiUrl := respGlobalConfigs.OpsgenieApiUrl
+	if globalConfigsTF != nil {
+		if respGlobalConfigs.OpsgenieApiKey == nil {
+			opsgenieApiKey = sdkUtils.Ptr(globalConfigsTF.OpsgenieApiKey.ValueString())
+		}
+		if respGlobalConfigs.OpsgenieApiUrl == nil {
+			opsgenieApiUrl = sdkUtils.Ptr(globalConfigsTF.OpsgenieApiUrl.ValueString())
+		}
+	}
 
 	globalConfigObject, diags := types.ObjectValue(globalConfigurationTypes, map[string]attr.Value{
-		"opsgenie_api_key":   types.StringPointerValue(respGlobalConfigs.OpsgenieApiKey),
-		"opsgenie_api_url":   types.StringPointerValue(respGlobalConfigs.OpsgenieApiUrl),
+		"opsgenie_api_key":   types.StringPointerValue(opsgenieApiKey),
+		"opsgenie_api_url":   types.StringPointerValue(opsgenieApiUrl),
 		"resolve_timeout":    types.StringPointerValue(respGlobalConfigs.ResolveTimeout),
 		"smtp_from":          types.StringPointerValue(respGlobalConfigs.SmtpFrom),
 		"smtp_auth_identity": types.StringPointerValue(smtpAuthIdentity),


### PR DESCRIPTION
## Description

With some of the newer versions the Observability Instance Ressource generates a lot of diff noise if a alert_config is specified.

```terraform
 # module.observability.stackit_observability_instance.observability[0] will be updated in-place
  ~ resource "stackit_observability_instance" "observability" ***
      ~ alert_config                           = ***
          ~ global    = ***
              + opsgenie_api_key   = (sensitive value)
              + opsgenie_api_url   = (known after apply)
              ~ resolve_timeout    = "5m" -> (known after apply)
              ~ smtp_auth_identity = "*****" -> (known after apply)
              # Warning: this attribute value will no longer be marked as sensitive
              # after applying this change.
              ~ smtp_auth_password = (sensitive value)
              ~ smtp_auth_username = "*****" -> (known after apply)
              ~ smtp_from          = "observability@observability.stackit.cloud" -> (known after apply)
              ~ smtp_smart_host    = "*****" -> (known after apply)
          *** -> (known after apply)
            # (2 unchanged attributes hidden)
      ***
        id                                     = "redacted"
        name                                   = "redacted"
      ~ plan_id                                = "redacted" -> (known after apply)
        # (24 unchanged attributes hidden)
  ***
```

This issue tries to solve this noisiness.
If there are changes needed just let me know.

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
