### PR TITLE
fix(dns): store IDs immediately after provisioning

### DIFF
--- a/stackit/internal/services/dns/recordset/resource.go
+++ b/stackit/internal/services/dns/recordset/resource.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -218,7 +217,16 @@ func (r *recordSetResource) Create(ctx context.Context, req resource.CreateReque
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating record set", fmt.Sprintf("Calling API: %v", err))
 		return
 	}
-	ctx = tflog.SetField(ctx, "record_set_id", *recordSetResp.Rrset.Id)
+
+	// Write id attributes to state before polling via the wait handler - just in case anything goes wrong during the wait handler
+	utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"project_id":    projectId,
+		"zone_id":       zoneId,
+		"record_set_id": *recordSetResp.Rrset.Id,
+	})
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	waitResp, err := wait.CreateRecordSetWaitHandler(ctx, r.client, projectId, zoneId, *recordSetResp.Rrset.Id).WaitWithContext(ctx)
 	if err != nil {
@@ -372,9 +380,11 @@ func (r *recordSetResource) ImportState(ctx context.Context, req resource.Import
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("zone_id"), idParts[1])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("record_set_id"), idParts[2])...)
+	utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]interface{}{
+		"project_id":    idParts[0],
+		"zone_id":       idParts[1],
+		"record_set_id": idParts[2],
+	})
 	tflog.Info(ctx, "DNS record set state imported")
 }
 

--- a/stackit/internal/utils/utils.go
+++ b/stackit/internal/utils/utils.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -184,5 +186,13 @@ func CheckListRemoval(ctx context.Context, configModelList, planModelList types.
 		} else {
 			resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, destination, types.ListNull(listType))...)
 		}
+	}
+}
+
+// SetAndLogStateFields writes the given map of key-value pairs to the state
+func SetAndLogStateFields(ctx context.Context, diags *diag.Diagnostics, state *tfsdk.State, values map[string]any) {
+	for key, val := range values {
+		ctx = tflog.SetField(ctx, key, val)
+		diags.Append(state.SetAttribute(ctx, path.Root(key), val)...)
 	}
 }

--- a/stackit/internal/utils/utils_test.go
+++ b/stackit/internal/utils/utils_test.go
@@ -6,6 +6,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
@@ -547,6 +550,95 @@ func TestCheckListRemoval(t *testing.T) {
 				if diff != "" {
 					t.Fatalf("plan should not be adjusted but diff is: %s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestSetAndLogStateFields(t *testing.T) {
+	testSchema := schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"project_id":  schema.StringAttribute{},
+			"instance_id": schema.StringAttribute{},
+		},
+	}
+
+	type args struct {
+		diags  *diag.Diagnostics
+		state  *tfsdk.State
+		values map[string]interface{}
+	}
+	type want struct {
+		hasError bool
+		state    *tfsdk.State
+	}
+	tests := []struct {
+		name string
+		args args
+		want want
+	}{
+		{
+			name: "empty map",
+			args: args{
+				diags:  &diag.Diagnostics{},
+				state:  &tfsdk.State{},
+				values: map[string]interface{}{},
+			},
+			want: want{
+				hasError: false,
+				state:    &tfsdk.State{},
+			},
+		},
+		{
+			name: "base",
+			args: args{
+				diags: &diag.Diagnostics{},
+				state: func() *tfsdk.State {
+					ctx := context.Background()
+					state := tfsdk.State{
+						Raw: tftypes.NewValue(testSchema.Type().TerraformType(ctx), map[string]tftypes.Value{
+							"project_id":  tftypes.NewValue(tftypes.String, "9b15d120-86f8-45f5-81d8-a554f09c7582"),
+							"instance_id": tftypes.NewValue(tftypes.String, nil),
+						}),
+						Schema: testSchema,
+					}
+					return &state
+				}(),
+				values: map[string]interface{}{
+					"project_id":  "a414f971-3f7a-4e9a-8671-51a8acb7bcc8",
+					"instance_id": "97073250-8cad-46c3-8424-6258ac0b3731",
+				},
+			},
+			want: want{
+				hasError: false,
+				state: func() *tfsdk.State {
+					ctx := context.Background()
+					state := tfsdk.State{
+						Raw: tftypes.NewValue(testSchema.Type().TerraformType(ctx), map[string]tftypes.Value{
+							"project_id":  tftypes.NewValue(tftypes.String, nil),
+							"instance_id": tftypes.NewValue(tftypes.String, nil),
+						}),
+						Schema: testSchema,
+					}
+					state.SetAttribute(ctx, path.Root("project_id"), "a414f971-3f7a-4e9a-8671-51a8acb7bcc8")
+					state.SetAttribute(ctx, path.Root("instance_id"), "97073250-8cad-46c3-8424-6258ac0b3731")
+					return &state
+				}(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			SetAndLogStateFields(ctx, tt.args.diags, tt.args.state, tt.args.values)
+
+			if tt.args.diags.HasError() != tt.want.hasError {
+				t.Errorf("TestSetAndLogStateFields() error count = %v, hasErr %v", tt.args.diags.ErrorsCount(), tt.want.hasError)
+			}
+
+			diff := cmp.Diff(tt.args.state, tt.want.state)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITTPR-373

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
