### PR TITLE
fix(ske): prevent usage of UUID for dns extension

### DIFF
--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -12,6 +12,7 @@ import (
 	serviceenablementUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/serviceenablement/utils"
 	skeUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/ske/utils"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -659,6 +660,9 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 								ElementType: types.StringType,
 								PlanModifiers: []planmodifier.List{
 									listplanmodifier.UseStateForUnknown(),
+								},
+								Validators: []validator.List{
+									listvalidator.ValueStringsAre(validate.NoUUID()),
 								},
 							},
 						},

--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -67,6 +67,23 @@ func UUID() *Validator {
 	}
 }
 
+func NoUUID() *Validator {
+	description := "value must not be an UUID"
+
+	return &Validator{
+		description: description,
+		validate: func(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+			if _, err := uuid.Parse(req.ConfigValue.ValueString()); err == nil {
+				resp.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+					req.Path,
+					description,
+					req.ConfigValue.ValueString(),
+				))
+			}
+		},
+	}
+}
+
 // IP returns a validator that checks, if the given string is a valid IP address.
 // The allowZeroAddress parameter defines, if 0.0.0.0, resp. [::] should be considered valid.
 func IP(allowZeroAddress bool) *Validator {

--- a/stackit/internal/validate/validate_test.go
+++ b/stackit/internal/validate/validate_test.go
@@ -55,6 +55,50 @@ func TestUUID(t *testing.T) {
 	}
 }
 
+func TestNoUUID(t *testing.T) {
+	tests := []struct {
+		description string
+		input       string
+		isValid     bool
+	}{
+		{
+			"UUID",
+			"cae27bba-c43d-498a-861e-d11d241c4ff8",
+			false,
+		},
+		{
+			"no UUID",
+			"a-b-c-d",
+			true,
+		},
+		{
+			"Empty",
+			"",
+			true,
+		},
+		{
+			"domain name",
+			"www.test.de",
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			r := validator.StringResponse{}
+			NoUUID().ValidateString(context.Background(), validator.StringRequest{
+				ConfigValue: types.StringValue(tt.input),
+			}, &r)
+
+			if !tt.isValid && !r.Diagnostics.HasError() {
+				t.Fatalf("Should have failed")
+			}
+			if tt.isValid && r.Diagnostics.HasError() {
+				t.Fatalf("Should not have failed: %v", r.Diagnostics.Errors())
+			}
+		})
+	}
+}
+
 func TestIP(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

fixes #1023

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
