### PR TITLE
feat(rt): fix docs typo

### DIFF
--- a/docs/data-sources/routing_table_route.md
+++ b/docs/data-sources/routing_table_route.md
@@ -61,5 +61,5 @@ Read-Only:
 
 Read-Only:
 
-- `type` (String) Possible values are: `blackhole`, `internet`, `ipv4`, `ipv6`. Only `cidrv4` is supported during experimental stage..
+- `type` (String) Type of the next hop. Possible values are: `blackhole`, `internet`, `ipv4`, `ipv6`.
 - `value` (String) Either IPv4 or IPv6 (not set for blackhole and internet). Only IPv4 supported during experimental stage.

--- a/docs/data-sources/routing_table_routes.md
+++ b/docs/data-sources/routing_table_routes.md
@@ -67,5 +67,5 @@ Read-Only:
 
 Read-Only:
 
-- `type` (String) Possible values are: `blackhole`, `internet`, `ipv4`, `ipv6`. Only `cidrv4` is supported during experimental stage..
+- `type` (String) Type of the next hop. Possible values are: `blackhole`, `internet`, `ipv4`, `ipv6`.
 - `value` (String) Either IPv4 or IPv6 (not set for blackhole and internet). Only IPv4 supported during experimental stage.

--- a/docs/resources/routing_table_route.md
+++ b/docs/resources/routing_table_route.md
@@ -77,7 +77,7 @@ Required:
 
 Required:
 
-- `type` (String) Possible values are: `blackhole`, `internet`, `ipv4`, `ipv6`. Only `cidrv4` is supported during experimental stage..
+- `type` (String) Type of the next hop. Possible values are: `blackhole`, `internet`, `ipv4`, `ipv6`.
 
 Optional:
 

--- a/stackit/internal/services/iaasalpha/routingtable/route/resource.go
+++ b/stackit/internal/services/iaasalpha/routingtable/route/resource.go
@@ -201,7 +201,7 @@ func (r *routeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Required:    true,
 				Attributes: map[string]schema.Attribute{
 					"type": schema.StringAttribute{
-						Description: fmt.Sprintf("%s %s.", utils.FormatPossibleValues("blackhole", "internet", "ipv4", "ipv6"), "Only `cidrv4` is supported during experimental stage."),
+						Description: "Type of the next hop. " + utils.FormatPossibleValues("blackhole", "internet", "ipv4", "ipv6"),
 						Required:    true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplace(),

--- a/stackit/internal/services/iaasalpha/routingtable/shared/shared.go
+++ b/stackit/internal/services/iaasalpha/routingtable/shared/shared.go
@@ -156,7 +156,7 @@ func RouteResponseAttributes() map[string]schema.Attribute {
 			Computed:    true,
 			Attributes: map[string]schema.Attribute{
 				"type": schema.StringAttribute{
-					Description: fmt.Sprintf("%s %s.", utils.FormatPossibleValues("blackhole", "internet", "ipv4", "ipv6"), "Only `cidrv4` is supported during experimental stage."),
+					Description: "Type of the next hop. " + utils.FormatPossibleValues("blackhole", "internet", "ipv4", "ipv6"),
 					Computed:    true,
 				},
 				"value": schema.StringAttribute{


### PR DESCRIPTION
## Description

Fixes small typo in the docs

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
