### PR TITLE
fix(observability/instance): adjust drift

### DIFF
--- a/stackit/internal/services/observability/instance/resource.go
+++ b/stackit/internal/services/observability/instance/resource.go
@@ -1841,6 +1841,8 @@ func mapGlobalConfigToAttributes(respGlobalConfigs *observability.Global, global
 	smtpAuthIdentity := respGlobalConfigs.SmtpAuthIdentity
 	smtpAuthPassword := respGlobalConfigs.SmtpAuthPassword
 	smtpAuthUsername := respGlobalConfigs.SmtpAuthUsername
+	opsgenieApiKey := respGlobalConfigs.OpsgenieApiKey
+	opsgenieApiUrl := respGlobalConfigs.OpsgenieApiUrl
 	if globalConfigsTF != nil {
 		if respGlobalConfigs.SmtpSmarthost == nil &&
 			!globalConfigsTF.SmtpSmartHost.IsNull() && !globalConfigsTF.SmtpSmartHost.IsUnknown() {
@@ -1858,11 +1860,6 @@ func mapGlobalConfigToAttributes(respGlobalConfigs *observability.Global, global
 			!globalConfigsTF.SmtpAuthUsername.IsNull() && !globalConfigsTF.SmtpAuthUsername.IsUnknown() {
 			smtpAuthUsername = sdkUtils.Ptr(globalConfigsTF.SmtpAuthUsername.ValueString())
 		}
-	}
-	// handle nil value from api
-	opsgenieApiKey := respGlobalConfigs.OpsgenieApiKey
-	opsgenieApiUrl := respGlobalConfigs.OpsgenieApiUrl
-	if globalConfigsTF != nil {
 		if respGlobalConfigs.OpsgenieApiKey == nil {
 			opsgenieApiKey = sdkUtils.Ptr(globalConfigsTF.OpsgenieApiKey.ValueString())
 		}


### PR DESCRIPTION
## Description

With some of the newer versions the Observability Instance Ressource generates a lot of diff noise if a alert_config is specified.

```terraform
 # module.observability.stackit_observability_instance.observability[0] will be updated in-place
  ~ resource "stackit_observability_instance" "observability" ***
      ~ alert_config                           = ***
          ~ global    = ***
              + opsgenie_api_key   = (sensitive value)
              + opsgenie_api_url   = (known after apply)
              ~ resolve_timeout    = "5m" -> (known after apply)
              ~ smtp_auth_identity = "*****" -> (known after apply)
              # Warning: this attribute value will no longer be marked as sensitive
              # after applying this change.
              ~ smtp_auth_password = (sensitive value)
              ~ smtp_auth_username = "*****" -> (known after apply)
              ~ smtp_from          = "observability@observability.stackit.cloud" -> (known after apply)
              ~ smtp_smart_host    = "*****" -> (known after apply)
          *** -> (known after apply)
            # (2 unchanged attributes hidden)
      ***
        id                                     = "redacted"
        name                                   = "redacted"
      ~ plan_id                                = "redacted" -> (known after apply)
        # (24 unchanged attributes hidden)
  ***
```

This issue tries to solve this noisiness.
If there are changes needed just let me know.

## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
