### PR TITLE
chore(docs): new default region fallback hint

### DIFF
--- a/docs/data-sources/iaas_project.md
+++ b/docs/data-sources/iaas_project.md
@@ -3,12 +3,12 @@
 page_title: "stackit_iaas_project Data Source - stackit"
 subcategory: ""
 description: |-
-  Project details. Must have a region specified in the provider configuration.
+  Project details. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_iaas_project (Data Source)
 
-Project details. Must have a `region` specified in the provider configuration.
+Project details. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -3,12 +3,12 @@
 page_title: "stackit_image Data Source - stackit"
 subcategory: ""
 description: |-
-  Image datasource schema. Must have a region specified in the provider configuration.
+  Image datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_image (Data Source)
 
-Image datasource schema. Must have a `region` specified in the provider configuration.
+Image datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/image_v2.md
+++ b/docs/data-sources/image_v2.md
@@ -3,7 +3,7 @@
 page_title: "stackit_image_v2 Data Source - stackit"
 subcategory: ""
 description: |-
-  Image datasource schema. Must have a region specified in the provider configuration.
+  Image datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> Important: When using the name, name_regex, or filter attributes to select images dynamically, be aware that image IDs may change frequently. Each OS patch or update results in a new unique image ID. If this data source is used to populate fields like boot_volume.source_id in a server resource, it may cause Terraform to detect changes and recreate the associated resource.
   To avoid unintended updates or resource replacements:
   Prefer using a static image_id to pin a specific image version.If you accept automatic image updates but wish to suppress resource changes, use a lifecycle block to ignore relevant changes. For example:
@@ -29,7 +29,7 @@ description: |-
 
 # stackit_image_v2 (Data Source)
 
-Image datasource schema. Must have a `region` specified in the provider configuration.
+Image datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> Important: When using the `name`, `name_regex`, or `filter` attributes to select images dynamically, be aware that image IDs may change frequently. Each OS patch or update results in a new unique image ID. If this data source is used to populate fields like `boot_volume.source_id` in a server resource, it may cause Terraform to detect changes and recreate the associated resource.
 

--- a/docs/data-sources/key_pair.md
+++ b/docs/data-sources/key_pair.md
@@ -3,12 +3,12 @@
 page_title: "stackit_key_pair Data Source - stackit"
 subcategory: ""
 description: |-
-  Key pair resource schema. Must have a region specified in the provider configuration.
+  Key pair resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_key_pair (Data Source)
 
-Key pair resource schema. Must have a `region` specified in the provider configuration.
+Key pair resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/loadbalancer.md
+++ b/docs/data-sources/loadbalancer.md
@@ -3,12 +3,12 @@
 page_title: "stackit_loadbalancer Data Source - stackit"
 subcategory: ""
 description: |-
-  Load Balancer data source schema. Must have a region specified in the provider configuration.
+  Load Balancer data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_loadbalancer (Data Source)
 
-Load Balancer data source schema. Must have a `region` specified in the provider configuration.
+Load Balancer data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/logme_credential.md
+++ b/docs/data-sources/logme_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_logme_credential Data Source - stackit"
 subcategory: ""
 description: |-
-  LogMe credential data source schema. Must have a region specified in the provider configuration.
+  LogMe credential data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_logme_credential (Data Source)
 
-LogMe credential data source schema. Must have a `region` specified in the provider configuration.
+LogMe credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/logme_instance.md
+++ b/docs/data-sources/logme_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_logme_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  LogMe instance data source schema. Must have a region specified in the provider configuration.
+  LogMe instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_logme_instance (Data Source)
 
-LogMe instance data source schema. Must have a `region` specified in the provider configuration.
+LogMe instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/mariadb_credential.md
+++ b/docs/data-sources/mariadb_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mariadb_credential Data Source - stackit"
 subcategory: ""
 description: |-
-  MariaDB credential data source schema. Must have a region specified in the provider configuration.
+  MariaDB credential data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mariadb_credential (Data Source)
 
-MariaDB credential data source schema. Must have a `region` specified in the provider configuration.
+MariaDB credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/mariadb_instance.md
+++ b/docs/data-sources/mariadb_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mariadb_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  MariaDB instance data source schema. Must have a region specified in the provider configuration.
+  MariaDB instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mariadb_instance (Data Source)
 
-MariaDB instance data source schema. Must have a `region` specified in the provider configuration.
+MariaDB instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/mongodbflex_instance.md
+++ b/docs/data-sources/mongodbflex_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mongodbflex_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  MongoDB Flex instance data source schema. Must have a region specified in the provider configuration.
+  MongoDB Flex instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mongodbflex_instance (Data Source)
 
-MongoDB Flex instance data source schema. Must have a `region` specified in the provider configuration.
+MongoDB Flex instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/mongodbflex_user.md
+++ b/docs/data-sources/mongodbflex_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mongodbflex_user Data Source - stackit"
 subcategory: ""
 description: |-
-  MongoDB Flex user data source schema. Must have a region specified in the provider configuration.
+  MongoDB Flex user data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mongodbflex_user (Data Source)
 
-MongoDB Flex user data source schema. Must have a `region` specified in the provider configuration.
+MongoDB Flex user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -3,12 +3,12 @@
 page_title: "stackit_network Data Source - stackit"
 subcategory: ""
 description: |-
-  Network resource schema. Must have a region specified in the provider configuration.
+  Network resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_network (Data Source)
 
-Network resource schema. Must have a `region` specified in the provider configuration.
+Network resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/network_area.md
+++ b/docs/data-sources/network_area.md
@@ -3,12 +3,12 @@
 page_title: "stackit_network_area Data Source - stackit"
 subcategory: ""
 description: |-
-  Network area datasource schema. Must have a region specified in the provider configuration.
+  Network area datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_network_area (Data Source)
 
-Network area datasource schema. Must have a `region` specified in the provider configuration.
+Network area datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/network_area_route.md
+++ b/docs/data-sources/network_area_route.md
@@ -3,12 +3,12 @@
 page_title: "stackit_network_area_route Data Source - stackit"
 subcategory: ""
 description: |-
-  Network area route data resource schema. Must have a region specified in the provider configuration.
+  Network area route data resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_network_area_route (Data Source)
 
-Network area route data resource schema. Must have a `region` specified in the provider configuration.
+Network area route data resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/network_interface.md
+++ b/docs/data-sources/network_interface.md
@@ -3,12 +3,12 @@
 page_title: "stackit_network_interface Data Source - stackit"
 subcategory: ""
 description: |-
-  Network interface datasource schema. Must have a region specified in the provider configuration.
+  Network interface datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_network_interface (Data Source)
 
-Network interface datasource schema. Must have a `region` specified in the provider configuration.
+Network interface datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/objectstorage_bucket.md
+++ b/docs/data-sources/objectstorage_bucket.md
@@ -3,12 +3,12 @@
 page_title: "stackit_objectstorage_bucket Data Source - stackit"
 subcategory: ""
 description: |-
-  ObjectStorage bucket data source schema. Must have a region specified in the provider configuration.
+  ObjectStorage bucket data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_objectstorage_bucket (Data Source)
 
-ObjectStorage bucket data source schema. Must have a `region` specified in the provider configuration.
+ObjectStorage bucket data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/objectstorage_credential.md
+++ b/docs/data-sources/objectstorage_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_objectstorage_credential Data Source - stackit"
 subcategory: ""
 description: |-
-  ObjectStorage credential data source schema. Must have a region specified in the provider configuration.
+  ObjectStorage credential data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_objectstorage_credential (Data Source)
 
-ObjectStorage credential data source schema. Must have a `region` specified in the provider configuration.
+ObjectStorage credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/objectstorage_credentials_group.md
+++ b/docs/data-sources/objectstorage_credentials_group.md
@@ -3,12 +3,12 @@
 page_title: "stackit_objectstorage_credentials_group Data Source - stackit"
 subcategory: ""
 description: |-
-  ObjectStorage credentials group data source schema. Must have a region specified in the provider configuration.
+  ObjectStorage credentials group data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_objectstorage_credentials_group (Data Source)
 
-ObjectStorage credentials group data source schema. Must have a `region` specified in the provider configuration.
+ObjectStorage credentials group data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/observability_alertgroup.md
+++ b/docs/data-sources/observability_alertgroup.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_alertgroup Data Source - stackit"
 subcategory: ""
 description: |-
-  Observability alert group datasource schema. Used to create alerts based on metrics (Thanos). Must have a region specified in the provider configuration.
+  Observability alert group datasource schema. Used to create alerts based on metrics (Thanos). Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_alertgroup (Data Source)
 
-Observability alert group datasource schema. Used to create alerts based on metrics (Thanos). Must have a `region` specified in the provider configuration.
+Observability alert group datasource schema. Used to create alerts based on metrics (Thanos). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/observability_instance.md
+++ b/docs/data-sources/observability_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  Observability instance data source schema. Must have a region specified in the provider configuration.
+  Observability instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_instance (Data Source)
 
-Observability instance data source schema. Must have a `region` specified in the provider configuration.
+Observability instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/observability_logalertgroup.md
+++ b/docs/data-sources/observability_logalertgroup.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_logalertgroup Data Source - stackit"
 subcategory: ""
 description: |-
-  Observability log alert group datasource schema. Used to create alerts based on logs (Loki). Must have a region specified in the provider configuration.
+  Observability log alert group datasource schema. Used to create alerts based on logs (Loki). Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_logalertgroup (Data Source)
 
-Observability log alert group datasource schema. Used to create alerts based on logs (Loki). Must have a `region` specified in the provider configuration.
+Observability log alert group datasource schema. Used to create alerts based on logs (Loki). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/observability_scrapeconfig.md
+++ b/docs/data-sources/observability_scrapeconfig.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_scrapeconfig Data Source - stackit"
 subcategory: ""
 description: |-
-  Observability scrape config data source schema. Must have a region specified in the provider configuration.
+  Observability scrape config data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_scrapeconfig (Data Source)
 
-Observability scrape config data source schema. Must have a `region` specified in the provider configuration.
+Observability scrape config data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/opensearch_credential.md
+++ b/docs/data-sources/opensearch_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_opensearch_credential Data Source - stackit"
 subcategory: ""
 description: |-
-  OpenSearch credential data source schema. Must have a region specified in the provider configuration.
+  OpenSearch credential data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_opensearch_credential (Data Source)
 
-OpenSearch credential data source schema. Must have a `region` specified in the provider configuration.
+OpenSearch credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/opensearch_instance.md
+++ b/docs/data-sources/opensearch_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_opensearch_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  OpenSearch instance data source schema. Must have a region specified in the provider configuration.
+  OpenSearch instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_opensearch_instance (Data Source)
 
-OpenSearch instance data source schema. Must have a `region` specified in the provider configuration.
+OpenSearch instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/postgresflex_database.md
+++ b/docs/data-sources/postgresflex_database.md
@@ -3,12 +3,12 @@
 page_title: "stackit_postgresflex_database Data Source - stackit"
 subcategory: ""
 description: |-
-  Postgres Flex database resource schema. Must have a region specified in the provider configuration.
+  Postgres Flex database resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_postgresflex_database (Data Source)
 
-Postgres Flex database resource schema. Must have a `region` specified in the provider configuration.
+Postgres Flex database resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/postgresflex_instance.md
+++ b/docs/data-sources/postgresflex_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_postgresflex_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  Postgres Flex instance data source schema. Must have a region specified in the provider configuration.
+  Postgres Flex instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_postgresflex_instance (Data Source)
 
-Postgres Flex instance data source schema. Must have a `region` specified in the provider configuration.
+Postgres Flex instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/postgresflex_user.md
+++ b/docs/data-sources/postgresflex_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_postgresflex_user Data Source - stackit"
 subcategory: ""
 description: |-
-  Postgres Flex user data source schema. Must have a region specified in the provider configuration.
+  Postgres Flex user data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_postgresflex_user (Data Source)
 
-Postgres Flex user data source schema. Must have a `region` specified in the provider configuration.
+Postgres Flex user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/public_ip.md
+++ b/docs/data-sources/public_ip.md
@@ -3,12 +3,12 @@
 page_title: "stackit_public_ip Data Source - stackit"
 subcategory: ""
 description: |-
-  Public IP resource schema. Must have a region specified in the provider configuration.
+  Public IP resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_public_ip (Data Source)
 
-Public IP resource schema. Must have a `region` specified in the provider configuration.
+Public IP resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/rabbitmq_credential.md
+++ b/docs/data-sources/rabbitmq_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_rabbitmq_credential Data Source - stackit"
 subcategory: ""
 description: |-
-  RabbitMQ credential data source schema. Must have a region specified in the provider configuration.
+  RabbitMQ credential data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_rabbitmq_credential (Data Source)
 
-RabbitMQ credential data source schema. Must have a `region` specified in the provider configuration.
+RabbitMQ credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/rabbitmq_instance.md
+++ b/docs/data-sources/rabbitmq_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_rabbitmq_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  RabbitMQ instance data source schema. Must have a region specified in the provider configuration.
+  RabbitMQ instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_rabbitmq_instance (Data Source)
 
-RabbitMQ instance data source schema. Must have a `region` specified in the provider configuration.
+RabbitMQ instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/redis_credential.md
+++ b/docs/data-sources/redis_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_redis_credential Data Source - stackit"
 subcategory: ""
 description: |-
-  Redis credential data source schema. Must have a region specified in the provider configuration.
+  Redis credential data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_redis_credential (Data Source)
 
-Redis credential data source schema. Must have a `region` specified in the provider configuration.
+Redis credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/redis_instance.md
+++ b/docs/data-sources/redis_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_redis_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  Redis instance data source schema. Must have a region specified in the provider configuration.
+  Redis instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_redis_instance (Data Source)
 
-Redis instance data source schema. Must have a `region` specified in the provider configuration.
+Redis instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/routing_table.md
+++ b/docs/data-sources/routing_table.md
@@ -3,13 +3,13 @@
 page_title: "stackit_routing_table Data Source - stackit"
 subcategory: ""
 description: |-
-  Routing table datasource schema. Must have a region specified in the provider configuration.
+  Routing table datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table (Data Source)
 
-Routing table datasource schema. Must have a `region` specified in the provider configuration.
+Routing table datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/data-sources/routing_table_route.md
+++ b/docs/data-sources/routing_table_route.md
@@ -3,13 +3,13 @@
 page_title: "stackit_routing_table_route Data Source - stackit"
 subcategory: ""
 description: |-
-  Routing table route datasource schema. Must have a region specified in the provider configuration.
+  Routing table route datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table_route (Data Source)
 
-Routing table route datasource schema. Must have a `region` specified in the provider configuration.
+Routing table route datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/data-sources/routing_table_routes.md
+++ b/docs/data-sources/routing_table_routes.md
@@ -3,13 +3,13 @@
 page_title: "stackit_routing_table_routes Data Source - stackit"
 subcategory: ""
 description: |-
-  Routing table routes datasource schema. Must have a region specified in the provider configuration.
+  Routing table routes datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table_routes (Data Source)
 
-Routing table routes datasource schema. Must have a `region` specified in the provider configuration.
+Routing table routes datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/data-sources/routing_tables.md
+++ b/docs/data-sources/routing_tables.md
@@ -3,13 +3,13 @@
 page_title: "stackit_routing_tables Data Source - stackit"
 subcategory: ""
 description: |-
-  Routing table datasource schema. Must have a region specified in the provider configuration.
+  Routing table datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_tables (Data Source)
 
-Routing table datasource schema. Must have a `region` specified in the provider configuration.
+Routing table datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/data-sources/scf_organization.md
+++ b/docs/data-sources/scf_organization.md
@@ -3,12 +3,12 @@
 page_title: "stackit_scf_organization Data Source - stackit"
 subcategory: ""
 description: |-
-  STACKIT Cloud Foundry organization datasource schema. Must have a region specified in the provider configuration.
+  STACKIT Cloud Foundry organization datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_scf_organization (Data Source)
 
-STACKIT Cloud Foundry organization datasource schema. Must have a `region` specified in the provider configuration.
+STACKIT Cloud Foundry organization datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/secretsmanager_instance.md
+++ b/docs/data-sources/secretsmanager_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_secretsmanager_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  Secrets Manager instance data source schema. Must have a region specified in the provider configuration.
+  Secrets Manager instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_secretsmanager_instance (Data Source)
 
-Secrets Manager instance data source schema. Must have a `region` specified in the provider configuration.
+Secrets Manager instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/secretsmanager_user.md
+++ b/docs/data-sources/secretsmanager_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_secretsmanager_user Data Source - stackit"
 subcategory: ""
 description: |-
-  Secrets Manager user data source schema. Must have a region specified in the provider configuration.
+  Secrets Manager user data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_secretsmanager_user (Data Source)
 
-Secrets Manager user data source schema. Must have a `region` specified in the provider configuration.
+Secrets Manager user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/security_group.md
+++ b/docs/data-sources/security_group.md
@@ -3,12 +3,12 @@
 page_title: "stackit_security_group Data Source - stackit"
 subcategory: ""
 description: |-
-  Security group datasource schema. Must have a region specified in the provider configuration.
+  Security group datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_security_group (Data Source)
 
-Security group datasource schema. Must have a `region` specified in the provider configuration.
+Security group datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/security_group_rule.md
+++ b/docs/data-sources/security_group_rule.md
@@ -3,12 +3,12 @@
 page_title: "stackit_security_group_rule Data Source - stackit"
 subcategory: ""
 description: |-
-  Security group datasource schema. Must have a region specified in the provider configuration.
+  Security group datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_security_group_rule (Data Source)
 
-Security group datasource schema. Must have a `region` specified in the provider configuration.
+Security group datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -3,12 +3,12 @@
 page_title: "stackit_server Data Source - stackit"
 subcategory: ""
 description: |-
-  Server datasource schema. Must have a region specified in the provider configuration.
+  Server datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_server (Data Source)
 
-Server datasource schema. Must have a `region` specified in the provider configuration.
+Server datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/server_backup_schedule.md
+++ b/docs/data-sources/server_backup_schedule.md
@@ -3,13 +3,13 @@
 page_title: "stackit_server_backup_schedule Data Source - stackit"
 subcategory: ""
 description: |-
-  Server backup schedule datasource schema. Must have a region specified in the provider configuration.
+  Server backup schedule datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_backup_schedule (Data Source)
 
-Server backup schedule datasource schema. Must have a `region` specified in the provider configuration.
+Server backup schedule datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 

--- a/docs/data-sources/server_backup_schedules.md
+++ b/docs/data-sources/server_backup_schedules.md
@@ -3,13 +3,13 @@
 page_title: "stackit_server_backup_schedules Data Source - stackit"
 subcategory: ""
 description: |-
-  Server backup schedules datasource schema. Must have a region specified in the provider configuration.
+  Server backup schedules datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_backup_schedules (Data Source)
 
-Server backup schedules datasource schema. Must have a `region` specified in the provider configuration.
+Server backup schedules datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 

--- a/docs/data-sources/server_update_schedule.md
+++ b/docs/data-sources/server_update_schedule.md
@@ -3,13 +3,13 @@
 page_title: "stackit_server_update_schedule Data Source - stackit"
 subcategory: ""
 description: |-
-  Server update schedule datasource schema. Must have a region specified in the provider configuration.
+  Server update schedule datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_update_schedule (Data Source)
 
-Server update schedule datasource schema. Must have a `region` specified in the provider configuration.
+Server update schedule datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 

--- a/docs/data-sources/server_update_schedules.md
+++ b/docs/data-sources/server_update_schedules.md
@@ -3,13 +3,13 @@
 page_title: "stackit_server_update_schedules Data Source - stackit"
 subcategory: ""
 description: |-
-  Server update schedules datasource schema. Must have a region specified in the provider configuration.
+  Server update schedules datasource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_update_schedules (Data Source)
 
-Server update schedules datasource schema. Must have a `region` specified in the provider configuration.
+Server update schedules datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This datasource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 

--- a/docs/data-sources/ske_cluster.md
+++ b/docs/data-sources/ske_cluster.md
@@ -3,12 +3,12 @@
 page_title: "stackit_ske_cluster Data Source - stackit"
 subcategory: ""
 description: |-
-  SKE Cluster data source schema. Must have a region specified in the provider configuration.
+  SKE Cluster data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_ske_cluster (Data Source)
 
-SKE Cluster data source schema. Must have a `region` specified in the provider configuration.
+SKE Cluster data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/sqlserverflex_instance.md
+++ b/docs/data-sources/sqlserverflex_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_sqlserverflex_instance Data Source - stackit"
 subcategory: ""
 description: |-
-  SQLServer Flex instance data source schema. Must have a region specified in the provider configuration.
+  SQLServer Flex instance data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_sqlserverflex_instance (Data Source)
 
-SQLServer Flex instance data source schema. Must have a `region` specified in the provider configuration.
+SQLServer Flex instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/sqlserverflex_user.md
+++ b/docs/data-sources/sqlserverflex_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_sqlserverflex_user Data Source - stackit"
 subcategory: ""
 description: |-
-  SQLServer Flex user data source schema. Must have a region specified in the provider configuration.
+  SQLServer Flex user data source schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_sqlserverflex_user (Data Source)
 
-SQLServer Flex user data source schema. Must have a `region` specified in the provider configuration.
+SQLServer Flex user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/data-sources/volume.md
+++ b/docs/data-sources/volume.md
@@ -3,12 +3,12 @@
 page_title: "stackit_volume Data Source - stackit"
 subcategory: ""
 description: |-
-  Volume resource schema. Must have a region specified in the provider configuration.
+  Volume resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_volume (Data Source)
 
-Volume resource schema. Must have a `region` specified in the provider configuration.
+Volume resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/affinity_group.md
+++ b/docs/resources/affinity_group.md
@@ -3,7 +3,7 @@
 page_title: "stackit_affinity_group Resource - stackit"
 subcategory: ""
 description: |-
-  Affinity Group schema. Must have a region specified in the provider configuration.
+  Affinity Group schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   Usage with server
   
   resource "stackit_affinity_group" "affinity-group" {
@@ -39,7 +39,7 @@ description: |-
 
 # stackit_affinity_group (Resource)
 
-Affinity Group schema. Must have a `region` specified in the provider configuration.
+Affinity Group schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 
 

--- a/docs/resources/image.md
+++ b/docs/resources/image.md
@@ -3,12 +3,12 @@
 page_title: "stackit_image Resource - stackit"
 subcategory: ""
 description: |-
-  Image resource schema. Must have a region specified in the provider configuration.
+  Image resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_image (Resource)
 
-Image resource schema. Must have a `region` specified in the provider configuration.
+Image resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/key_pair.md
+++ b/docs/resources/key_pair.md
@@ -3,7 +3,7 @@
 page_title: "stackit_key_pair Resource - stackit"
 subcategory: ""
 description: |-
-  Key pair resource schema. Must have a region specified in the provider configuration. Allows uploading an SSH public key to be used for server authentication.
+  Key pair resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level. Allows uploading an SSH public key to be used for server authentication.
   Usage with server
   
   resource "stackit_key_pair" "keypair" {
@@ -27,7 +27,7 @@ description: |-
 
 # stackit_key_pair (Resource)
 
-Key pair resource schema. Must have a `region` specified in the provider configuration. Allows uploading an SSH public key to be used for server authentication.
+Key pair resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. Allows uploading an SSH public key to be used for server authentication.
 
 
 

--- a/docs/resources/loadbalancer_observability_credential.md
+++ b/docs/resources/loadbalancer_observability_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_loadbalancer_observability_credential Resource - stackit"
 subcategory: ""
 description: |-
-  Load balancer observability credential resource schema. Must have a region specified in the provider configuration. These contain the username and password for the observability service (e.g. Argus) where the load balancer logs/metrics will be pushed into
+  Load balancer observability credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level. These contain the username and password for the observability service (e.g. Argus) where the load balancer logs/metrics will be pushed into
 ---
 
 # stackit_loadbalancer_observability_credential (Resource)
 
-Load balancer observability credential resource schema. Must have a `region` specified in the provider configuration. These contain the username and password for the observability service (e.g. Argus) where the load balancer logs/metrics will be pushed into
+Load balancer observability credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. These contain the username and password for the observability service (e.g. Argus) where the load balancer logs/metrics will be pushed into
 
 ## Example Usage
 

--- a/docs/resources/logme_credential.md
+++ b/docs/resources/logme_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_logme_credential Resource - stackit"
 subcategory: ""
 description: |-
-  LogMe credential resource schema. Must have a region specified in the provider configuration.
+  LogMe credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_logme_credential (Resource)
 
-LogMe credential resource schema. Must have a `region` specified in the provider configuration.
+LogMe credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/logme_instance.md
+++ b/docs/resources/logme_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_logme_instance Resource - stackit"
 subcategory: ""
 description: |-
-  LogMe instance resource schema. Must have a region specified in the provider configuration.
+  LogMe instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_logme_instance (Resource)
 
-LogMe instance resource schema. Must have a `region` specified in the provider configuration.
+LogMe instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/mariadb_credential.md
+++ b/docs/resources/mariadb_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mariadb_credential Resource - stackit"
 subcategory: ""
 description: |-
-  MariaDB credential resource schema. Must have a region specified in the provider configuration.
+  MariaDB credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mariadb_credential (Resource)
 
-MariaDB credential resource schema. Must have a `region` specified in the provider configuration.
+MariaDB credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/mariadb_instance.md
+++ b/docs/resources/mariadb_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mariadb_instance Resource - stackit"
 subcategory: ""
 description: |-
-  MariaDB instance resource schema. Must have a region specified in the provider configuration.
+  MariaDB instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mariadb_instance (Resource)
 
-MariaDB instance resource schema. Must have a `region` specified in the provider configuration.
+MariaDB instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/mongodbflex_instance.md
+++ b/docs/resources/mongodbflex_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mongodbflex_instance Resource - stackit"
 subcategory: ""
 description: |-
-  MongoDB Flex instance resource schema. Must have a region specified in the provider configuration.
+  MongoDB Flex instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mongodbflex_instance (Resource)
 
-MongoDB Flex instance resource schema. Must have a `region` specified in the provider configuration.
+MongoDB Flex instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/mongodbflex_user.md
+++ b/docs/resources/mongodbflex_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_mongodbflex_user Resource - stackit"
 subcategory: ""
 description: |-
-  MongoDB Flex user resource schema. Must have a region specified in the provider configuration.
+  MongoDB Flex user resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_mongodbflex_user (Resource)
 
-MongoDB Flex user resource schema. Must have a `region` specified in the provider configuration.
+MongoDB Flex user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -3,7 +3,7 @@
 page_title: "stackit_network Resource - stackit"
 subcategory: ""
 description: |-
-  Network resource schema. Must have a region specified in the provider configuration.
+  Network resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> Behavior of not configured ipv4_nameservers will change from January 2026. When ipv4_nameservers is not set, it will be set to the network area's default_nameservers.
   To prevent any nameserver configuration, the ipv4_nameservers attribute should be explicitly set to an empty list [].
   In cases where ipv4_nameservers are defined within the resource, the existing behavior will remain unchanged.
@@ -11,7 +11,7 @@ description: |-
 
 # stackit_network (Resource)
 
-Network resource schema. Must have a `region` specified in the provider configuration.
+Network resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 ~> Behavior of not configured `ipv4_nameservers` will change from January 2026. When `ipv4_nameservers` is not set, it will be set to the network area's `default_nameservers`.
 To prevent any nameserver configuration, the `ipv4_nameservers` attribute should be explicitly set to an empty list `[]`.
 In cases where `ipv4_nameservers` are defined within the resource, the existing behavior will remain unchanged.

--- a/docs/resources/network_area.md
+++ b/docs/resources/network_area.md
@@ -3,12 +3,12 @@
 page_title: "stackit_network_area Resource - stackit"
 subcategory: ""
 description: |-
-  Network area resource schema. Must have a region specified in the provider configuration.
+  Network area resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_network_area (Resource)
 
-Network area resource schema. Must have a `region` specified in the provider configuration.
+Network area resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/network_area_route.md
+++ b/docs/resources/network_area_route.md
@@ -3,12 +3,12 @@
 page_title: "stackit_network_area_route Resource - stackit"
 subcategory: ""
 description: |-
-  Network area route resource schema. Must have a region specified in the provider configuration.
+  Network area route resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_network_area_route (Resource)
 
-Network area route resource schema. Must have a `region` specified in the provider configuration.
+Network area route resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/network_interface.md
+++ b/docs/resources/network_interface.md
@@ -3,12 +3,12 @@
 page_title: "stackit_network_interface Resource - stackit"
 subcategory: ""
 description: |-
-  Network interface resource schema. Must have a region specified in the provider configuration.
+  Network interface resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_network_interface (Resource)
 
-Network interface resource schema. Must have a `region` specified in the provider configuration.
+Network interface resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/objectstorage_bucket.md
+++ b/docs/resources/objectstorage_bucket.md
@@ -3,12 +3,12 @@
 page_title: "stackit_objectstorage_bucket Resource - stackit"
 subcategory: ""
 description: |-
-  ObjectStorage bucket resource schema. Must have a region specified in the provider configuration. If you are creating credentialsgroup and bucket resources simultaneously, please include the depends_on field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
+  ObjectStorage bucket resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level. If you are creating credentialsgroup and bucket resources simultaneously, please include the depends_on field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
 ---
 
 # stackit_objectstorage_bucket (Resource)
 
-ObjectStorage bucket resource schema. Must have a `region` specified in the provider configuration. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
+ObjectStorage bucket resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
 
 ## Example Usage
 

--- a/docs/resources/objectstorage_credential.md
+++ b/docs/resources/objectstorage_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_objectstorage_credential Resource - stackit"
 subcategory: ""
 description: |-
-  ObjectStorage credential resource schema. Must have a region specified in the provider configuration.
+  ObjectStorage credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_objectstorage_credential (Resource)
 
-ObjectStorage credential resource schema. Must have a `region` specified in the provider configuration.
+ObjectStorage credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/objectstorage_credentials_group.md
+++ b/docs/resources/objectstorage_credentials_group.md
@@ -3,12 +3,12 @@
 page_title: "stackit_objectstorage_credentials_group Resource - stackit"
 subcategory: ""
 description: |-
-  ObjectStorage credentials group resource schema. Must have a region specified in the provider configuration. If you are creating credentialsgroup and bucket resources simultaneously, please include the depends_on field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
+  ObjectStorage credentials group resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level. If you are creating credentialsgroup and bucket resources simultaneously, please include the depends_on field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
 ---
 
 # stackit_objectstorage_credentials_group (Resource)
 
-ObjectStorage credentials group resource schema. Must have a `region` specified in the provider configuration. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
+ObjectStorage credentials group resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.
 
 ## Example Usage
 

--- a/docs/resources/observability_alertgroup.md
+++ b/docs/resources/observability_alertgroup.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_alertgroup Resource - stackit"
 subcategory: ""
 description: |-
-  Observability alert group resource schema. Used to create alerts based on metrics (Thanos). Must have a region specified in the provider configuration.
+  Observability alert group resource schema. Used to create alerts based on metrics (Thanos). Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_alertgroup (Resource)
 
-Observability alert group resource schema. Used to create alerts based on metrics (Thanos). Must have a `region` specified in the provider configuration.
+Observability alert group resource schema. Used to create alerts based on metrics (Thanos). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/observability_credential.md
+++ b/docs/resources/observability_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_credential Resource - stackit"
 subcategory: ""
 description: |-
-  Observability credential resource schema. Must have a region specified in the provider configuration.
+  Observability credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_credential (Resource)
 
-Observability credential resource schema. Must have a `region` specified in the provider configuration.
+Observability credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/observability_instance.md
+++ b/docs/resources/observability_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_instance Resource - stackit"
 subcategory: ""
 description: |-
-  Observability instance resource schema. Must have a region specified in the provider configuration.
+  Observability instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_instance (Resource)
 
-Observability instance resource schema. Must have a `region` specified in the provider configuration.
+Observability instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/observability_logalertgroup.md
+++ b/docs/resources/observability_logalertgroup.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_logalertgroup Resource - stackit"
 subcategory: ""
 description: |-
-  Observability log alert group resource schema. Used to create alerts based on logs (Loki). Must have a region specified in the provider configuration.
+  Observability log alert group resource schema. Used to create alerts based on logs (Loki). Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_logalertgroup (Resource)
 
-Observability log alert group resource schema. Used to create alerts based on logs (Loki). Must have a `region` specified in the provider configuration.
+Observability log alert group resource schema. Used to create alerts based on logs (Loki). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/observability_scrapeconfig.md
+++ b/docs/resources/observability_scrapeconfig.md
@@ -3,12 +3,12 @@
 page_title: "stackit_observability_scrapeconfig Resource - stackit"
 subcategory: ""
 description: |-
-  Observability scrape config resource schema. Must have a region specified in the provider configuration.
+  Observability scrape config resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_observability_scrapeconfig (Resource)
 
-Observability scrape config resource schema. Must have a `region` specified in the provider configuration.
+Observability scrape config resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/opensearch_credential.md
+++ b/docs/resources/opensearch_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_opensearch_credential Resource - stackit"
 subcategory: ""
 description: |-
-  OpenSearch credential resource schema. Must have a region specified in the provider configuration.
+  OpenSearch credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_opensearch_credential (Resource)
 
-OpenSearch credential resource schema. Must have a `region` specified in the provider configuration.
+OpenSearch credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/opensearch_instance.md
+++ b/docs/resources/opensearch_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_opensearch_instance Resource - stackit"
 subcategory: ""
 description: |-
-  OpenSearch instance resource schema. Must have a region specified in the provider configuration.
+  OpenSearch instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_opensearch_instance (Resource)
 
-OpenSearch instance resource schema. Must have a `region` specified in the provider configuration.
+OpenSearch instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/postgresflex_database.md
+++ b/docs/resources/postgresflex_database.md
@@ -3,12 +3,12 @@
 page_title: "stackit_postgresflex_database Resource - stackit"
 subcategory: ""
 description: |-
-  Postgres Flex database resource schema. Must have a region specified in the provider configuration.
+  Postgres Flex database resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_postgresflex_database (Resource)
 
-Postgres Flex database resource schema. Must have a `region` specified in the provider configuration.
+Postgres Flex database resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/postgresflex_instance.md
+++ b/docs/resources/postgresflex_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_postgresflex_instance Resource - stackit"
 subcategory: ""
 description: |-
-  Postgres Flex instance resource schema. Must have a region specified in the provider configuration.
+  Postgres Flex instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_postgresflex_instance (Resource)
 
-Postgres Flex instance resource schema. Must have a `region` specified in the provider configuration.
+Postgres Flex instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/postgresflex_user.md
+++ b/docs/resources/postgresflex_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_postgresflex_user Resource - stackit"
 subcategory: ""
 description: |-
-  Postgres Flex user resource schema. Must have a region specified in the provider configuration.
+  Postgres Flex user resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_postgresflex_user (Resource)
 
-Postgres Flex user resource schema. Must have a `region` specified in the provider configuration.
+Postgres Flex user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/public_ip.md
+++ b/docs/resources/public_ip.md
@@ -3,12 +3,12 @@
 page_title: "stackit_public_ip Resource - stackit"
 subcategory: ""
 description: |-
-  Public IP resource schema. Must have a region specified in the provider configuration.
+  Public IP resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_public_ip (Resource)
 
-Public IP resource schema. Must have a `region` specified in the provider configuration.
+Public IP resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/public_ip_associate.md
+++ b/docs/resources/public_ip_associate.md
@@ -3,14 +3,14 @@
 page_title: "stackit_public_ip_associate Resource - stackit"
 subcategory: ""
 description: |-
-  Associates an existing public IP to a network interface. This is useful for situations where you have a pre-allocated public IP or unable to use the stackit_public_ip resource to create a new public IP. Must have a region specified in the provider configuration.
+  Associates an existing public IP to a network interface. This is useful for situations where you have a pre-allocated public IP or unable to use the stackit_public_ip resource to create a new public IP. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   !> The stackit_public_ip_associate resource should not be used together with the stackit_public_ip resource for the same public IP or for the same network interface.
   Using both resources together for the same public IP or network interface WILL lead to conflicts, as they both have control of the public IP and network interface association.
 ---
 
 # stackit_public_ip_associate (Resource)
 
-Associates an existing public IP to a network interface. This is useful for situations where you have a pre-allocated public IP or unable to use the `stackit_public_ip` resource to create a new public IP. Must have a `region` specified in the provider configuration.
+Associates an existing public IP to a network interface. This is useful for situations where you have a pre-allocated public IP or unable to use the `stackit_public_ip` resource to create a new public IP. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 !> The `stackit_public_ip_associate` resource should not be used together with the `stackit_public_ip` resource for the same public IP or for the same network interface. 
 Using both resources together for the same public IP or network interface WILL lead to conflicts, as they both have control of the public IP and network interface association.

--- a/docs/resources/rabbitmq_credential.md
+++ b/docs/resources/rabbitmq_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_rabbitmq_credential Resource - stackit"
 subcategory: ""
 description: |-
-  RabbitMQ credential resource schema. Must have a region specified in the provider configuration.
+  RabbitMQ credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_rabbitmq_credential (Resource)
 
-RabbitMQ credential resource schema. Must have a `region` specified in the provider configuration.
+RabbitMQ credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/rabbitmq_instance.md
+++ b/docs/resources/rabbitmq_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_rabbitmq_instance Resource - stackit"
 subcategory: ""
 description: |-
-  RabbitMQ instance resource schema. Must have a region specified in the provider configuration.
+  RabbitMQ instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_rabbitmq_instance (Resource)
 
-RabbitMQ instance resource schema. Must have a `region` specified in the provider configuration.
+RabbitMQ instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/redis_credential.md
+++ b/docs/resources/redis_credential.md
@@ -3,12 +3,12 @@
 page_title: "stackit_redis_credential Resource - stackit"
 subcategory: ""
 description: |-
-  Redis credential resource schema. Must have a region specified in the provider configuration.
+  Redis credential resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_redis_credential (Resource)
 
-Redis credential resource schema. Must have a `region` specified in the provider configuration.
+Redis credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/redis_instance.md
+++ b/docs/resources/redis_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_redis_instance Resource - stackit"
 subcategory: ""
 description: |-
-  Redis instance resource schema. Must have a region specified in the provider configuration.
+  Redis instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_redis_instance (Resource)
 
-Redis instance resource schema. Must have a `region` specified in the provider configuration.
+Redis instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/routing_table.md
+++ b/docs/resources/routing_table.md
@@ -3,13 +3,13 @@
 page_title: "stackit_routing_table Resource - stackit"
 subcategory: ""
 description: |-
-  Routing table resource schema. Must have a region specified in the provider configuration.
+  Routing table resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table (Resource)
 
-Routing table resource schema. Must have a `region` specified in the provider configuration.
+Routing table resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/resources/routing_table_route.md
+++ b/docs/resources/routing_table_route.md
@@ -3,13 +3,13 @@
 page_title: "stackit_routing_table_route Resource - stackit"
 subcategory: ""
 description: |-
-  Routing table route resource schema. Must have a region specified in the provider configuration.
+  Routing table route resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table_route (Resource)
 
-Routing table route resource schema. Must have a `region` specified in the provider configuration.
+Routing table route resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/resources/scf_organization.md
+++ b/docs/resources/scf_organization.md
@@ -3,12 +3,12 @@
 page_title: "stackit_scf_organization Resource - stackit"
 subcategory: ""
 description: |-
-  STACKIT Cloud Foundry organization resource schema. Must have a region specified in the provider configuration.
+  STACKIT Cloud Foundry organization resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_scf_organization (Resource)
 
-STACKIT Cloud Foundry organization resource schema. Must have a `region` specified in the provider configuration.
+STACKIT Cloud Foundry organization resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/secretsmanager_instance.md
+++ b/docs/resources/secretsmanager_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_secretsmanager_instance Resource - stackit"
 subcategory: ""
 description: |-
-  Secrets Manager instance resource schema. Must have a region specified in the provider configuration.
+  Secrets Manager instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_secretsmanager_instance (Resource)
 
-Secrets Manager instance resource schema. Must have a `region` specified in the provider configuration.
+Secrets Manager instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/secretsmanager_user.md
+++ b/docs/resources/secretsmanager_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_secretsmanager_user Resource - stackit"
 subcategory: ""
 description: |-
-  Secrets Manager user resource schema. Must have a region specified in the provider configuration.
+  Secrets Manager user resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_secretsmanager_user (Resource)
 
-Secrets Manager user resource schema. Must have a `region` specified in the provider configuration.
+Secrets Manager user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/security_group.md
+++ b/docs/resources/security_group.md
@@ -3,12 +3,12 @@
 page_title: "stackit_security_group Resource - stackit"
 subcategory: ""
 description: |-
-  Security group resource schema. Must have a region specified in the provider configuration.
+  Security group resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_security_group (Resource)
 
-Security group resource schema. Must have a `region` specified in the provider configuration.
+Security group resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/security_group_rule.md
+++ b/docs/resources/security_group_rule.md
@@ -3,12 +3,12 @@
 page_title: "stackit_security_group_rule Resource - stackit"
 subcategory: ""
 description: |-
-  Security group rule resource schema. Must have a region specified in the provider configuration.
+  Security group rule resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_security_group_rule (Resource)
 
-Security group rule resource schema. Must have a `region` specified in the provider configuration.
+Security group rule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/server_backup_schedule.md
+++ b/docs/resources/server_backup_schedule.md
@@ -3,13 +3,13 @@
 page_title: "stackit_server_backup_schedule Resource - stackit"
 subcategory: ""
 description: |-
-  Server backup schedule resource schema. Must have a region specified in the provider configuration.
+  Server backup schedule resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_backup_schedule (Resource)
 
-Server backup schedule resource schema. Must have a `region` specified in the provider configuration.
+Server backup schedule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 

--- a/docs/resources/server_network_interface_attach.md
+++ b/docs/resources/server_network_interface_attach.md
@@ -3,12 +3,12 @@
 page_title: "stackit_server_network_interface_attach Resource - stackit"
 subcategory: ""
 description: |-
-  Network interface attachment resource schema. Attaches a network interface to a server. Must have a region specified in the provider configuration. The attachment only takes full effect after server reboot.
+  Network interface attachment resource schema. Attaches a network interface to a server. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level. The attachment only takes full effect after server reboot.
 ---
 
 # stackit_server_network_interface_attach (Resource)
 
-Network interface attachment resource schema. Attaches a network interface to a server. Must have a `region` specified in the provider configuration. The attachment only takes full effect after server reboot.
+Network interface attachment resource schema. Attaches a network interface to a server. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. The attachment only takes full effect after server reboot.
 
 ## Example Usage
 

--- a/docs/resources/server_service_account_attach.md
+++ b/docs/resources/server_service_account_attach.md
@@ -3,12 +3,12 @@
 page_title: "stackit_server_service_account_attach Resource - stackit"
 subcategory: ""
 description: |-
-  Service account attachment resource schema. Attaches a service account to a server. Must have a region specified in the provider configuration.
+  Service account attachment resource schema. Attaches a service account to a server. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_server_service_account_attach (Resource)
 
-Service account attachment resource schema. Attaches a service account to a server. Must have a `region` specified in the provider configuration.
+Service account attachment resource schema. Attaches a service account to a server. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/server_update_schedule.md
+++ b/docs/resources/server_update_schedule.md
@@ -3,13 +3,13 @@
 page_title: "stackit_server_update_schedule Resource - stackit"
 subcategory: ""
 description: |-
-  Server update schedule resource schema. Must have a region specified in the provider configuration.
+  Server update schedule resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources.
 ---
 
 # stackit_server_update_schedule (Resource)
 
-Server update schedule resource schema. Must have a `region` specified in the provider configuration.
+Server update schedule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources.
 

--- a/docs/resources/server_volume_attach.md
+++ b/docs/resources/server_volume_attach.md
@@ -3,12 +3,12 @@
 page_title: "stackit_server_volume_attach Resource - stackit"
 subcategory: ""
 description: |-
-  Volume attachment resource schema. Attaches a volume to a server. Must have a region specified in the provider configuration.
+  Volume attachment resource schema. Attaches a volume to a server. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_server_volume_attach (Resource)
 
-Volume attachment resource schema. Attaches a volume to a server. Must have a `region` specified in the provider configuration.
+Volume attachment resource schema. Attaches a volume to a server. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/ske_cluster.md
+++ b/docs/resources/ske_cluster.md
@@ -3,13 +3,13 @@
 page_title: "stackit_ske_cluster Resource - stackit"
 subcategory: ""
 description: |-
-  SKE Cluster Resource schema. Must have a region specified in the provider configuration.
+  SKE Cluster Resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
   -> When updating node_pools of a stackit_ske_cluster, the Terraform plan might appear incorrect as it matches the node pools by index rather than by name. However, the SKE API correctly identifies node pools by name and applies the intended changes. Please review your changes carefully to ensure the correct configuration will be applied.
 ---
 
 # stackit_ske_cluster (Resource)
 
-SKE Cluster Resource schema. Must have a `region` specified in the provider configuration.
+SKE Cluster Resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 -> When updating `node_pools` of a `stackit_ske_cluster`, the Terraform plan might appear incorrect as it matches the node pools by index rather than by name. However, the SKE API correctly identifies node pools by name and applies the intended changes. Please review your changes carefully to ensure the correct configuration will be applied.
 

--- a/docs/resources/ske_kubeconfig.md
+++ b/docs/resources/ske_kubeconfig.md
@@ -3,12 +3,12 @@
 page_title: "stackit_ske_kubeconfig Resource - stackit"
 subcategory: ""
 description: |-
-  SKE kubeconfig resource schema. Must have a region specified in the provider configuration.
+  SKE kubeconfig resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_ske_kubeconfig (Resource)
 
-SKE kubeconfig resource schema. Must have a `region` specified in the provider configuration.
+SKE kubeconfig resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/sqlserverflex_instance.md
+++ b/docs/resources/sqlserverflex_instance.md
@@ -3,12 +3,12 @@
 page_title: "stackit_sqlserverflex_instance Resource - stackit"
 subcategory: ""
 description: |-
-  SQLServer Flex instance resource schema. Must have a region specified in the provider configuration.
+  SQLServer Flex instance resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_sqlserverflex_instance (Resource)
 
-SQLServer Flex instance resource schema. Must have a `region` specified in the provider configuration.
+SQLServer Flex instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/sqlserverflex_user.md
+++ b/docs/resources/sqlserverflex_user.md
@@ -3,12 +3,12 @@
 page_title: "stackit_sqlserverflex_user Resource - stackit"
 subcategory: ""
 description: |-
-  SQLServer Flex user resource schema. Must have a region specified in the provider configuration.
+  SQLServer Flex user resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_sqlserverflex_user (Resource)
 
-SQLServer Flex user resource schema. Must have a `region` specified in the provider configuration.
+SQLServer Flex user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/docs/resources/volume.md
+++ b/docs/resources/volume.md
@@ -3,12 +3,12 @@
 page_title: "stackit_volume Resource - stackit"
 subcategory: ""
 description: |-
-  Volume resource schema. Must have a region specified in the provider configuration.
+  Volume resource schema. Uses the default_region specified in the provider configuration as a fallback in case no region is defined on resource level.
 ---
 
 # stackit_volume (Resource)
 
-Volume resource schema. Must have a `region` specified in the provider configuration.
+Volume resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.
 
 ## Example Usage
 

--- a/stackit/internal/services/iaas/affinitygroup/resource.go
+++ b/stackit/internal/services/iaas/affinitygroup/resource.go
@@ -75,7 +75,7 @@ func (r *affinityGroupResource) Configure(ctx context.Context, req resource.Conf
 }
 
 func (r *affinityGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Affinity Group schema. Must have a `region` specified in the provider configuration."
+	description := "Affinity Group schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description + "\n\n" + exampleUsageWithServer + policies,

--- a/stackit/internal/services/iaas/image/datasource.go
+++ b/stackit/internal/services/iaas/image/datasource.go
@@ -73,7 +73,7 @@ func (d *imageDataSource) Configure(ctx context.Context, req datasource.Configur
 
 // Schema defines the schema for the datasource.
 func (r *imageDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Image datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Image datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/image/resource.go
+++ b/stackit/internal/services/iaas/image/resource.go
@@ -137,7 +137,7 @@ func (r *imageResource) Configure(ctx context.Context, req resource.ConfigureReq
 // Schema defines the schema for the resource.
 func (r *imageResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Image resource schema. Must have a `region` specified in the provider configuration.",
+		Description: "Image resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource ID. It is structured as \"`project_id`,`image_id`\".",

--- a/stackit/internal/services/iaas/imagev2/datasource.go
+++ b/stackit/internal/services/iaas/imagev2/datasource.go
@@ -161,7 +161,7 @@ func (d *imageDataV2Source) ConfigValidators(_ context.Context) []datasource.Con
 func (d *imageDataV2Source) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	description := features.AddBetaDescription(fmt.Sprintf(
 		"%s\n\n~> %s",
-		"Image datasource schema. Must have a `region` specified in the provider configuration.",
+		"Image datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"Important: When using the `name`, `name_regex`, or `filter` attributes to select images dynamically, be aware that image IDs may change frequently. Each OS patch or update results in a new unique image ID. If this data source is used to populate fields like `boot_volume.source_id` in a server resource, it may cause Terraform to detect changes and recreate the associated resource.\n\n"+
 			"To avoid unintended updates or resource replacements:\n"+
 			" - Prefer using a static `image_id` to pin a specific image version.\n"+

--- a/stackit/internal/services/iaas/keypair/datasource.go
+++ b/stackit/internal/services/iaas/keypair/datasource.go
@@ -52,7 +52,7 @@ func (d *keyPairDataSource) Configure(ctx context.Context, req datasource.Config
 
 // Schema defines the schema for the resource.
 func (r *keyPairDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Key pair resource schema. Must have a `region` specified in the provider configuration."
+	description := "Key pair resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/keypair/resource.go
+++ b/stackit/internal/services/iaas/keypair/resource.go
@@ -68,7 +68,7 @@ func (r *keyPairResource) Configure(ctx context.Context, req resource.ConfigureR
 
 // Schema defines the schema for the resource.
 func (r *keyPairResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Key pair resource schema. Must have a `region` specified in the provider configuration. Allows uploading an SSH public key to be used for server authentication."
+	description := "Key pair resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. Allows uploading an SSH public key to be used for server authentication."
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description + "\n\n" + exampleUsageWithServer,

--- a/stackit/internal/services/iaas/network/datasource.go
+++ b/stackit/internal/services/iaas/network/datasource.go
@@ -77,7 +77,7 @@ func (d *networkDataSource) Configure(ctx context.Context, req datasource.Config
 // Schema defines the schema for the data source.
 func (d *networkDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Network resource schema. Must have a `region` specified in the provider configuration.",
+		Description: "Network resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource ID. It is structured as \"`project_id`,`network_id`\".",

--- a/stackit/internal/services/iaas/network/resource.go
+++ b/stackit/internal/services/iaas/network/resource.go
@@ -185,7 +185,7 @@ func (r *networkResource) ConfigValidators(_ context.Context) []resource.ConfigV
 
 // Schema defines the schema for the resource.
 func (r *networkResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Network resource schema. Must have a `region` specified in the provider configuration."
+	description := "Network resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	descriptionNote := fmt.Sprintf("~> %s. %s", ipv4BehaviorChangeTitle, ipv4BehaviorChangeDescription)
 	resp.Schema = schema.Schema{
 		MarkdownDescription: fmt.Sprintf("%s\n%s", description, descriptionNote),

--- a/stackit/internal/services/iaas/networkarea/datasource.go
+++ b/stackit/internal/services/iaas/networkarea/datasource.go
@@ -58,7 +58,7 @@ func (d *networkAreaDataSource) Configure(ctx context.Context, req datasource.Co
 
 // Schema defines the schema for the data source.
 func (d *networkAreaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Network area datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Network area datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkarea/resource.go
+++ b/stackit/internal/services/iaas/networkarea/resource.go
@@ -106,7 +106,7 @@ func (r *networkAreaResource) Configure(ctx context.Context, req resource.Config
 
 // Schema defines the schema for the resource.
 func (r *networkAreaResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Network area resource schema. Must have a `region` specified in the provider configuration."
+	description := "Network area resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkarearoute/datasource.go
+++ b/stackit/internal/services/iaas/networkarearoute/datasource.go
@@ -55,7 +55,7 @@ func (d *networkAreaRouteDataSource) Configure(ctx context.Context, req datasour
 
 // Schema defines the schema for the data source.
 func (d *networkAreaRouteDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Network area route data resource schema. Must have a `region` specified in the provider configuration."
+	description := "Network area route data resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkarearoute/resource.go
+++ b/stackit/internal/services/iaas/networkarearoute/resource.go
@@ -74,7 +74,7 @@ func (r *networkAreaRouteResource) Configure(ctx context.Context, req resource.C
 
 // Schema defines the schema for the resource.
 func (r *networkAreaRouteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Network area route resource schema. Must have a `region` specified in the provider configuration."
+	description := "Network area route resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkinterface/datasource.go
+++ b/stackit/internal/services/iaas/networkinterface/datasource.go
@@ -56,7 +56,7 @@ func (d *networkInterfaceDataSource) Configure(ctx context.Context, req datasour
 // Schema defines the schema for the data source.
 func (d *networkInterfaceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	typeOptions := []string{"server", "metadata", "gateway"}
-	description := "Network interface datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Network interface datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkinterface/resource.go
+++ b/stackit/internal/services/iaas/networkinterface/resource.go
@@ -117,7 +117,7 @@ func (r *networkInterfaceResource) Configure(ctx context.Context, req resource.C
 // Schema defines the schema for the resource.
 func (r *networkInterfaceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	typeOptions := []string{"server", "metadata", "gateway"}
-	description := "Network interface resource schema. Must have a `region` specified in the provider configuration."
+	description := "Network interface resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkinterfaceattach/resource.go
+++ b/stackit/internal/services/iaas/networkinterfaceattach/resource.go
@@ -71,7 +71,7 @@ func (r *networkInterfaceAttachResource) Configure(ctx context.Context, req reso
 
 // Schema defines the schema for the resource.
 func (r *networkInterfaceAttachResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Network interface attachment resource schema. Attaches a network interface to a server. Must have a `region` specified in the provider configuration. The attachment only takes full effect after server reboot."
+	description := "Network interface attachment resource schema. Attaches a network interface to a server. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. The attachment only takes full effect after server reboot."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/project/datasource.go
+++ b/stackit/internal/services/iaas/project/datasource.go
@@ -65,7 +65,7 @@ func (d *projectDataSource) Metadata(_ context.Context, req datasource.MetadataR
 // Schema defines the schema for the datasource.
 func (d *projectDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":            "Project details. Must have a `region` specified in the provider configuration.",
+		"main":            "Project details. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":              "Terraform's internal resource ID. It is structured as \"`project_id`\".",
 		"project_id":      "STACKIT project ID.",
 		"area_id":         "The area ID to which the project belongs to.",

--- a/stackit/internal/services/iaas/publicip/datasource.go
+++ b/stackit/internal/services/iaas/publicip/datasource.go
@@ -55,7 +55,7 @@ func (d *publicIpDataSource) Configure(ctx context.Context, req datasource.Confi
 
 // Schema defines the schema for the resource.
 func (r *publicIpDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Public IP resource schema. Must have a `region` specified in the provider configuration."
+	description := "Public IP resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/publicip/resource.go
+++ b/stackit/internal/services/iaas/publicip/resource.go
@@ -73,7 +73,7 @@ func (r *publicIpResource) Configure(ctx context.Context, req resource.Configure
 
 // Schema defines the schema for the resource.
 func (r *publicIpResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Public IP resource schema. Must have a `region` specified in the provider configuration."
+	description := "Public IP resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/publicipassociate/resource.go
+++ b/stackit/internal/services/iaas/publicipassociate/resource.go
@@ -79,7 +79,7 @@ func (r *publicIpAssociateResource) Schema(_ context.Context, _ resource.SchemaR
 	descriptions := map[string]string{
 		"main": "Associates an existing public IP to a network interface. " +
 			"This is useful for situations where you have a pre-allocated public IP or unable to use the `stackit_public_ip` resource to create a new public IP. " +
-			"Must have a `region` specified in the provider configuration.",
+			"Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"warning_message": "The `stackit_public_ip_associate` resource should not be used together with the `stackit_public_ip` resource for the same public IP or for the same network interface. \n" +
 			"Using both resources together for the same public IP or network interface WILL lead to conflicts, as they both have control of the public IP and network interface association.",
 	}

--- a/stackit/internal/services/iaas/securitygroup/datasource.go
+++ b/stackit/internal/services/iaas/securitygroup/datasource.go
@@ -55,7 +55,7 @@ func (d *securityGroupDataSource) Configure(ctx context.Context, req datasource.
 
 // Schema defines the schema for the resource.
 func (r *securityGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Security group datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Security group datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/securitygroup/resource.go
+++ b/stackit/internal/services/iaas/securitygroup/resource.go
@@ -77,7 +77,7 @@ func (r *securityGroupResource) Configure(ctx context.Context, req resource.Conf
 
 // Schema defines the schema for the resource.
 func (r *securityGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Security group resource schema. Must have a `region` specified in the provider configuration."
+	description := "Security group resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/securitygrouprule/datasource.go
+++ b/stackit/internal/services/iaas/securitygrouprule/datasource.go
@@ -55,7 +55,7 @@ func (d *securityGroupRuleDataSource) Configure(ctx context.Context, req datasou
 // Schema defines the schema for the resource.
 func (r *securityGroupRuleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	directionOptions := []string{"ingress", "egress"}
-	description := "Security group datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Security group datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/securitygrouprule/resource.go
+++ b/stackit/internal/services/iaas/securitygrouprule/resource.go
@@ -171,7 +171,7 @@ func (r securityGroupRuleResource) ValidateConfig(ctx context.Context, req resou
 // Schema defines the schema for the resource.
 func (r *securityGroupRuleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	directionOptions := []string{"ingress", "egress"}
-	description := "Security group rule resource schema. Must have a `region` specified in the provider configuration."
+	description := "Security group rule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/server/datasource.go
+++ b/stackit/internal/services/iaas/server/datasource.go
@@ -82,7 +82,7 @@ func (d *serverDataSource) Configure(ctx context.Context, req datasource.Configu
 
 // Schema defines the schema for the datasource.
 func (r *serverDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Server datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Server datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/server/resource.go
+++ b/stackit/internal/services/iaas/server/resource.go
@@ -164,7 +164,7 @@ func (r *serverResource) Configure(ctx context.Context, req resource.ConfigureRe
 func (r *serverResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: markdownDescription,
-		Description:         "Server resource schema. Must have a `region` specified in the provider configuration.",
+		Description:         "Server resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource ID. It is structured as \"`project_id`,`server_id`\".",

--- a/stackit/internal/services/iaas/serviceaccountattach/resource.go
+++ b/stackit/internal/services/iaas/serviceaccountattach/resource.go
@@ -71,7 +71,7 @@ func (r *networkInterfaceAttachResource) Configure(ctx context.Context, req reso
 
 // Schema defines the schema for the resource.
 func (r *networkInterfaceAttachResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Service account attachment resource schema. Attaches a service account to a server. Must have a `region` specified in the provider configuration."
+	description := "Service account attachment resource schema. Attaches a service account to a server. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/volume/datasource.go
+++ b/stackit/internal/services/iaas/volume/datasource.go
@@ -55,7 +55,7 @@ func (d *volumeDataSource) Configure(ctx context.Context, req datasource.Configu
 
 // Schema defines the schema for the resource.
 func (r *volumeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Volume resource schema. Must have a `region` specified in the provider configuration."
+	description := "Volume resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/volume/resource.go
+++ b/stackit/internal/services/iaas/volume/resource.go
@@ -109,7 +109,7 @@ func (r *volumeResource) Configure(ctx context.Context, req resource.ConfigureRe
 
 // Schema defines the schema for the resource.
 func (r *volumeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Volume resource schema. Must have a `region` specified in the provider configuration."
+	description := "Volume resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaas/volumeattach/resource.go
+++ b/stackit/internal/services/iaas/volumeattach/resource.go
@@ -73,7 +73,7 @@ func (r *volumeAttachResource) Configure(ctx context.Context, req resource.Confi
 
 // Schema defines the schema for the resource.
 func (r *volumeAttachResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Volume attachment resource schema. Attaches a volume to a server. Must have a `region` specified in the provider configuration."
+	description := "Volume attachment resource schema. Attaches a volume to a server. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,
 		Description:         description,

--- a/stackit/internal/services/iaasalpha/routingtable/route/datasource.go
+++ b/stackit/internal/services/iaasalpha/routingtable/route/datasource.go
@@ -61,7 +61,7 @@ func (d *routingTableRouteDataSource) Configure(ctx context.Context, req datasou
 
 // Schema defines the schema for the data source.
 func (d *routingTableRouteDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table route datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table route datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),

--- a/stackit/internal/services/iaasalpha/routingtable/route/resource.go
+++ b/stackit/internal/services/iaasalpha/routingtable/route/resource.go
@@ -103,7 +103,7 @@ func (r *routeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 
 // Schema defines the schema for the resource.
 func (r *routeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Routing table route resource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table route resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Resource),

--- a/stackit/internal/services/iaasalpha/routingtable/routes/datasource.go
+++ b/stackit/internal/services/iaasalpha/routingtable/routes/datasource.go
@@ -72,7 +72,7 @@ func (d *routingTableRoutesDataSource) Configure(ctx context.Context, req dataso
 
 // Schema defines the schema for the data source.
 func (d *routingTableRoutesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table routes datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table routes datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),

--- a/stackit/internal/services/iaasalpha/routingtable/table/datasource.go
+++ b/stackit/internal/services/iaasalpha/routingtable/table/datasource.go
@@ -64,7 +64,7 @@ func (d *routingTableDataSource) Configure(ctx context.Context, req datasource.C
 
 // Schema defines the schema for the data source.
 func (d *routingTableDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),

--- a/stackit/internal/services/iaasalpha/routingtable/table/resource.go
+++ b/stackit/internal/services/iaasalpha/routingtable/table/resource.go
@@ -120,7 +120,7 @@ func (r *routingTableResource) ModifyPlan(ctx context.Context, req resource.Modi
 }
 
 func (r *routingTableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Routing table resource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Resource),

--- a/stackit/internal/services/iaasalpha/routingtable/tables/datasource.go
+++ b/stackit/internal/services/iaasalpha/routingtable/tables/datasource.go
@@ -73,7 +73,7 @@ func (d *routingTablesDataSource) Configure(ctx context.Context, req datasource.
 
 // Schema defines the schema for the data source.
 func (d *routingTablesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),

--- a/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
@@ -65,7 +65,7 @@ func (r *loadBalancerDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 	servicePlanOptions := []string{"p10", "p50", "p250", "p750"}
 
 	descriptions := map[string]string{
-		"main":                                  "Load Balancer data source schema. Must have a `region` specified in the provider configuration.",
+		"main":                                  "Load Balancer data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":                                    "Terraform's internal resource ID. It is structured as \"`project_id`\",\"region\",\"`name`\".",
 		"project_id":                            "STACKIT project ID to which the Load Balancer is associated.",
 		"external_address":                      "External Load Balancer IP address where this Load Balancer is exposed.",

--- a/stackit/internal/services/loadbalancer/observability-credential/resource.go
+++ b/stackit/internal/services/loadbalancer/observability-credential/resource.go
@@ -108,7 +108,7 @@ func (r *observabilityCredentialResource) Configure(ctx context.Context, req res
 // Schema defines the schema for the resource.
 func (r *observabilityCredentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":            "Load balancer observability credential resource schema. Must have a `region` specified in the provider configuration. These contain the username and password for the observability service (e.g. Argus) where the load balancer logs/metrics will be pushed into",
+		"main":            "Load balancer observability credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. These contain the username and password for the observability service (e.g. Argus) where the load balancer logs/metrics will be pushed into",
 		"id":              "Terraform's internal resource ID. It is structured as \"`project_id`\",\"region\",\"`credentials_ref`\".",
 		"credentials_ref": "The credentials reference is used by the Load Balancer to define which credentials it will use.",
 		"project_id":      "STACKIT project ID to which the load balancer observability credential is associated.",

--- a/stackit/internal/services/logme/credential/datasource.go
+++ b/stackit/internal/services/logme/credential/datasource.go
@@ -57,7 +57,7 @@ func (r *credentialDataSource) Configure(ctx context.Context, req datasource.Con
 // Schema defines the schema for the data source.
 func (r *credentialDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "LogMe credential data source schema. Must have a `region` specified in the provider configuration.",
+		"main":          "LogMe credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the LogMe instance.",

--- a/stackit/internal/services/logme/credential/resource.go
+++ b/stackit/internal/services/logme/credential/resource.go
@@ -79,7 +79,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (r *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "LogMe credential resource schema. Must have a `region` specified in the provider configuration.",
+		"main":          "LogMe credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal resource identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the LogMe instance.",

--- a/stackit/internal/services/logme/instance/datasource.go
+++ b/stackit/internal/services/logme/instance/datasource.go
@@ -58,7 +58,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "LogMe instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "LogMe instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the LogMe instance.",
 		"project_id":  "STACKIT Project ID to which the instance is associated.",

--- a/stackit/internal/services/logme/instance/resource.go
+++ b/stackit/internal/services/logme/instance/resource.go
@@ -140,7 +140,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "LogMe instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "LogMe instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the LogMe instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/mariadb/credential/datasource.go
+++ b/stackit/internal/services/mariadb/credential/datasource.go
@@ -58,7 +58,7 @@ func (r *credentialDataSource) Configure(ctx context.Context, req datasource.Con
 // Schema defines the schema for the data source.
 func (r *credentialDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "MariaDB credential data source schema. Must have a `region` specified in the provider configuration.",
+		"main":          "MariaDB credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the MariaDB instance.",

--- a/stackit/internal/services/mariadb/credential/resource.go
+++ b/stackit/internal/services/mariadb/credential/resource.go
@@ -80,7 +80,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (r *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "MariaDB credential resource schema. Must have a `region` specified in the provider configuration.",
+		"main":          "MariaDB credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal resource identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the MariaDB instance.",

--- a/stackit/internal/services/mariadb/instance/datasource.go
+++ b/stackit/internal/services/mariadb/instance/datasource.go
@@ -58,7 +58,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "MariaDB instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "MariaDB instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the MariaDB instance.",
 		"project_id":  "STACKIT Project ID to which the instance is associated.",

--- a/stackit/internal/services/mariadb/instance/resource.go
+++ b/stackit/internal/services/mariadb/instance/resource.go
@@ -110,7 +110,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "MariaDB instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "MariaDB instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the MariaDB instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/mongodbflex/instance/datasource.go
+++ b/stackit/internal/services/mongodbflex/instance/datasource.go
@@ -61,7 +61,7 @@ func (d *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (d *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                              "MongoDB Flex instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":                              "MongoDB Flex instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":                                "Terraform's internal data source ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
 		"instance_id":                       "ID of the MongoDB Flex instance.",
 		"project_id":                        "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/mongodbflex/instance/resource.go
+++ b/stackit/internal/services/mongodbflex/instance/resource.go
@@ -172,7 +172,7 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 	typeOptions := []string{"Replica", "Sharded", "Single"}
 
 	descriptions := map[string]string{
-		"main":                              "MongoDB Flex instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":                              "MongoDB Flex instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":                                "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
 		"instance_id":                       "ID of the MongoDB Flex instance.",
 		"project_id":                        "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/mongodbflex/user/datasource.go
+++ b/stackit/internal/services/mongodbflex/user/datasource.go
@@ -74,7 +74,7 @@ func (d *userDataSource) Configure(ctx context.Context, req datasource.Configure
 // Schema defines the schema for the data source.
 func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "MongoDB Flex user data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "MongoDB Flex user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. ID. It is structured as \"`project_id`,`region`,`instance_id`,`user_id`\".",
 		"user_id":     "User ID.",
 		"instance_id": "ID of the MongoDB Flex instance.",

--- a/stackit/internal/services/mongodbflex/user/resource.go
+++ b/stackit/internal/services/mongodbflex/user/resource.go
@@ -115,7 +115,7 @@ func (r *userResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 // Schema defines the schema for the resource.
 func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "MongoDB Flex user resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "MongoDB Flex user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`,`user_id`\".",
 		"user_id":     "User ID.",
 		"instance_id": "ID of the MongoDB Flex instance.",

--- a/stackit/internal/services/objectstorage/bucket/datasource.go
+++ b/stackit/internal/services/objectstorage/bucket/datasource.go
@@ -59,7 +59,7 @@ func (r *bucketDataSource) Configure(ctx context.Context, req datasource.Configu
 // Schema defines the schema for the data source.
 func (r *bucketDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                     "ObjectStorage bucket data source schema. Must have a `region` specified in the provider configuration.",
+		"main":                     "ObjectStorage bucket data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":                       "Terraform's internal data source identifier. It is structured as \"`project_id`,`region`,`name`\".",
 		"name":                     "The bucket name. It must be DNS conform.",
 		"project_id":               "STACKIT Project ID to which the bucket is associated.",

--- a/stackit/internal/services/objectstorage/bucket/resource.go
+++ b/stackit/internal/services/objectstorage/bucket/resource.go
@@ -109,7 +109,7 @@ func (r *bucketResource) Configure(ctx context.Context, req resource.ConfigureRe
 // Schema defines the schema for the resource.
 func (r *bucketResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                     "ObjectStorage bucket resource schema. Must have a `region` specified in the provider configuration. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.",
+		"main":                     "ObjectStorage bucket resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.",
 		"id":                       "Terraform's internal resource identifier. It is structured as \"`project_id`,`region`,`name`\".",
 		"name":                     "The bucket name. It must be DNS conform.",
 		"project_id":               "STACKIT Project ID to which the bucket is associated.",

--- a/stackit/internal/services/objectstorage/credential/datasource.go
+++ b/stackit/internal/services/objectstorage/credential/datasource.go
@@ -69,7 +69,7 @@ func (r *credentialDataSource) Configure(ctx context.Context, req datasource.Con
 // Schema defines the schema for the datasource.
 func (r *credentialDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                 "ObjectStorage credential data source schema. Must have a `region` specified in the provider configuration.",
+		"main":                 "ObjectStorage credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":                   "Terraform's internal resource identifier. It is structured as \"`project_id`,`region`,`credentials_group_id`,`credential_id`\".",
 		"credential_id":        "The credential ID.",
 		"credentials_group_id": "The credential group ID.",

--- a/stackit/internal/services/objectstorage/credential/resource.go
+++ b/stackit/internal/services/objectstorage/credential/resource.go
@@ -151,7 +151,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (r *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                 "ObjectStorage credential resource schema. Must have a `region` specified in the provider configuration.",
+		"main":                 "ObjectStorage credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":                   "Terraform's internal resource identifier. It is structured as \"`project_id`,`region`,`credentials_group_id`,`credential_id`\".",
 		"credential_id":        "The credential ID.",
 		"credentials_group_id": "The credential group ID.",

--- a/stackit/internal/services/objectstorage/credentialsgroup/datasource.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/datasource.go
@@ -58,7 +58,7 @@ func (r *credentialsGroupDataSource) Configure(ctx context.Context, req datasour
 // Schema defines the schema for the data source.
 func (r *credentialsGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                 "ObjectStorage credentials group data source schema. Must have a `region` specified in the provider configuration.",
+		"main":                 "ObjectStorage credentials group data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":                   "Terraform's internal data source identifier. It is structured as \"`project_id`,`region`,`credentials_group_id`\".",
 		"credentials_group_id": "The credentials group ID.",
 		"name":                 "The credentials group's display name.",

--- a/stackit/internal/services/objectstorage/credentialsgroup/resource.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/resource.go
@@ -108,7 +108,7 @@ func (r *credentialsGroupResource) Configure(ctx context.Context, req resource.C
 // Schema defines the schema for the resource.
 func (r *credentialsGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":                 "ObjectStorage credentials group resource schema. Must have a `region` specified in the provider configuration. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.",
+		"main":                 "ObjectStorage credentials group resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level. If you are creating `credentialsgroup` and `bucket` resources simultaneously, please include the `depends_on` field so that they are created sequentially. This prevents errors from concurrent calls to the service enablement that is done in the background.",
 		"id":                   "Terraform's internal data source identifier. It is structured as \"`project_id`,`region`,`credentials_group_id`\".",
 		"credentials_group_id": "The credentials group ID",
 		"name":                 "The credentials group's display name.",

--- a/stackit/internal/services/observability/alertgroup/datasource.go
+++ b/stackit/internal/services/observability/alertgroup/datasource.go
@@ -59,7 +59,7 @@ func (a *alertGroupDataSource) Metadata(_ context.Context, req datasource.Metada
 // Schema defines the schema for the alert group data source.
 func (a *alertGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability alert group datasource schema. Used to create alerts based on metrics (Thanos). Must have a `region` specified in the provider configuration.",
+		Description: "Observability alert group datasource schema. Used to create alerts based on metrics (Thanos). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],

--- a/stackit/internal/services/observability/alertgroup/resource.go
+++ b/stackit/internal/services/observability/alertgroup/resource.go
@@ -110,7 +110,7 @@ func (a *alertGroupResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (a *alertGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability alert group resource schema. Used to create alerts based on metrics (Thanos). Must have a `region` specified in the provider configuration.",
+		Description: "Observability alert group resource schema. Used to create alerts based on metrics (Thanos). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],

--- a/stackit/internal/services/observability/credential/resource.go
+++ b/stackit/internal/services/observability/credential/resource.go
@@ -69,7 +69,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 
 func (r *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability credential resource schema. Must have a `region` specified in the provider configuration.",
+		Description: "Observability credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`,`username`\".",

--- a/stackit/internal/services/observability/instance/datasource.go
+++ b/stackit/internal/services/observability/instance/datasource.go
@@ -57,7 +57,7 @@ func (d *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (d *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability instance data source schema. Must have a `region` specified in the provider configuration.",
+		Description: "Observability instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal data source. ID. It is structured as \"`project_id`,`instance_id`\".",

--- a/stackit/internal/services/observability/instance/resource.go
+++ b/stackit/internal/services/observability/instance/resource.go
@@ -408,7 +408,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability instance resource schema. Must have a `region` specified in the provider configuration.",
+		Description: "Observability instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",

--- a/stackit/internal/services/observability/log-alertgroup/datasource.go
+++ b/stackit/internal/services/observability/log-alertgroup/datasource.go
@@ -59,7 +59,7 @@ func (l *logAlertGroupDataSource) Metadata(_ context.Context, req datasource.Met
 // Schema defines the schema for the log alert group data source.
 func (l *logAlertGroupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability log alert group datasource schema. Used to create alerts based on logs (Loki). Must have a `region` specified in the provider configuration.",
+		Description: "Observability log alert group datasource schema. Used to create alerts based on logs (Loki). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],

--- a/stackit/internal/services/observability/log-alertgroup/resource.go
+++ b/stackit/internal/services/observability/log-alertgroup/resource.go
@@ -110,7 +110,7 @@ func (l *logAlertGroupResource) Configure(ctx context.Context, req resource.Conf
 // Schema defines the schema for the resource.
 func (l *logAlertGroupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability log alert group resource schema. Used to create alerts based on logs (Loki). Must have a `region` specified in the provider configuration.",
+		Description: "Observability log alert group resource schema. Used to create alerts based on logs (Loki). Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],

--- a/stackit/internal/services/observability/scrapeconfig/datasource.go
+++ b/stackit/internal/services/observability/scrapeconfig/datasource.go
@@ -59,7 +59,7 @@ func (d *scrapeConfigDataSource) Configure(ctx context.Context, req datasource.C
 // Schema defines the schema for the data source.
 func (d *scrapeConfigDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability scrape config data source schema. Must have a `region` specified in the provider configuration.",
+		Description: "Observability scrape config data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal data source. ID. It is structured as \"`project_id`,`instance_id`,`name`\".",

--- a/stackit/internal/services/observability/scrapeconfig/resource.go
+++ b/stackit/internal/services/observability/scrapeconfig/resource.go
@@ -135,7 +135,7 @@ func (r *scrapeConfigResource) Configure(ctx context.Context, req resource.Confi
 // Schema defines the schema for the resource.
 func (r *scrapeConfigResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Observability scrape config resource schema. Must have a `region` specified in the provider configuration.",
+		Description: "Observability scrape config resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`,`name`\".",

--- a/stackit/internal/services/opensearch/credential/datasource.go
+++ b/stackit/internal/services/opensearch/credential/datasource.go
@@ -58,7 +58,7 @@ func (r *credentialDataSource) Configure(ctx context.Context, req datasource.Con
 // Schema defines the schema for the data source.
 func (r *credentialDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "OpenSearch credential data source schema. Must have a `region` specified in the provider configuration.",
+		"main":          "OpenSearch credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the OpenSearch instance.",

--- a/stackit/internal/services/opensearch/credential/resource.go
+++ b/stackit/internal/services/opensearch/credential/resource.go
@@ -80,7 +80,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (r *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "OpenSearch credential resource schema. Must have a `region` specified in the provider configuration.",
+		"main":          "OpenSearch credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal resource identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the OpenSearch instance.",

--- a/stackit/internal/services/opensearch/instance/datasource.go
+++ b/stackit/internal/services/opensearch/instance/datasource.go
@@ -58,7 +58,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "OpenSearch instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "OpenSearch instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the OpenSearch instance.",
 		"project_id":  "STACKIT Project ID to which the instance is associated.",

--- a/stackit/internal/services/opensearch/instance/resource.go
+++ b/stackit/internal/services/opensearch/instance/resource.go
@@ -123,7 +123,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "OpenSearch instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "OpenSearch instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the OpenSearch instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/postgresflex/database/datasource.go
+++ b/stackit/internal/services/postgresflex/database/datasource.go
@@ -59,7 +59,7 @@ func (r *databaseDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *databaseDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Postgres Flex database resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Postgres Flex database resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`,`database_id`\".",
 		"database_id": "Database ID.",
 		"instance_id": "ID of the Postgres Flex instance.",

--- a/stackit/internal/services/postgresflex/database/resource.go
+++ b/stackit/internal/services/postgresflex/database/resource.go
@@ -109,7 +109,7 @@ func (r *databaseResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *databaseResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Postgres Flex database resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Postgres Flex database resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`,`database_id`\".",
 		"database_id": "Database ID.",
 		"instance_id": "ID of the Postgres Flex instance.",

--- a/stackit/internal/services/postgresflex/instance/datasource.go
+++ b/stackit/internal/services/postgresflex/instance/datasource.go
@@ -62,7 +62,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Postgres Flex instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Postgres Flex instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
 		"instance_id": "ID of the PostgresFlex instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/postgresflex/instance/resource.go
+++ b/stackit/internal/services/postgresflex/instance/resource.go
@@ -147,7 +147,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Postgres Flex instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Postgres Flex instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
 		"instance_id": "ID of the PostgresFlex instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/postgresflex/user/datasource.go
+++ b/stackit/internal/services/postgresflex/user/datasource.go
@@ -73,7 +73,7 @@ func (r *userDataSource) Configure(ctx context.Context, req datasource.Configure
 // Schema defines the schema for the data source.
 func (r *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Postgres Flex user data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Postgres Flex user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. ID. It is structured as \"`project_id`,`region`,`instance_id`,`user_id`\".",
 		"user_id":     "User ID.",
 		"instance_id": "ID of the PostgresFlex instance.",

--- a/stackit/internal/services/postgresflex/user/resource.go
+++ b/stackit/internal/services/postgresflex/user/resource.go
@@ -118,7 +118,7 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 	rolesOptions := []string{"login", "createdb"}
 
 	descriptions := map[string]string{
-		"main":        "Postgres Flex user resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Postgres Flex user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`,`user_id`\".",
 		"user_id":     "User ID.",
 		"instance_id": "ID of the PostgresFlex instance.",

--- a/stackit/internal/services/rabbitmq/credential/datasource.go
+++ b/stackit/internal/services/rabbitmq/credential/datasource.go
@@ -58,7 +58,7 @@ func (r *credentialDataSource) Configure(ctx context.Context, req datasource.Con
 // Schema defines the schema for the data source.
 func (r *credentialDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "RabbitMQ credential data source schema. Must have a `region` specified in the provider configuration.",
+		"main":          "RabbitMQ credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the RabbitMQ instance.",

--- a/stackit/internal/services/rabbitmq/credential/resource.go
+++ b/stackit/internal/services/rabbitmq/credential/resource.go
@@ -83,7 +83,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (r *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "RabbitMQ credential resource schema. Must have a `region` specified in the provider configuration.",
+		"main":          "RabbitMQ credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal resource identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the RabbitMQ instance.",

--- a/stackit/internal/services/rabbitmq/instance/datasource.go
+++ b/stackit/internal/services/rabbitmq/instance/datasource.go
@@ -58,7 +58,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "RabbitMQ instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "RabbitMQ instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the RabbitMQ instance.",
 		"project_id":  "STACKIT Project ID to which the instance is associated.",

--- a/stackit/internal/services/rabbitmq/instance/resource.go
+++ b/stackit/internal/services/rabbitmq/instance/resource.go
@@ -120,7 +120,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "RabbitMQ instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "RabbitMQ instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the RabbitMQ instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/redis/credential/datasource.go
+++ b/stackit/internal/services/redis/credential/datasource.go
@@ -58,7 +58,7 @@ func (r *credentialDataSource) Configure(ctx context.Context, req datasource.Con
 // Schema defines the schema for the data source.
 func (r *credentialDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "Redis credential data source schema. Must have a `region` specified in the provider configuration.",
+		"main":          "Redis credential data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the Redis instance.",

--- a/stackit/internal/services/redis/credential/resource.go
+++ b/stackit/internal/services/redis/credential/resource.go
@@ -80,7 +80,7 @@ func (r *credentialResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (r *credentialResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "Redis credential resource schema. Must have a `region` specified in the provider configuration.",
+		"main":          "Redis credential resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal resource identifier. It is structured as \"`project_id`,`instance_id`,`credential_id`\".",
 		"credential_id": "The credential's ID.",
 		"instance_id":   "ID of the Redis instance.",

--- a/stackit/internal/services/redis/instance/datasource.go
+++ b/stackit/internal/services/redis/instance/datasource.go
@@ -58,7 +58,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Redis instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Redis instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. identifier. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the Redis instance.",
 		"project_id":  "STACKIT Project ID to which the instance is associated.",

--- a/stackit/internal/services/redis/instance/resource.go
+++ b/stackit/internal/services/redis/instance/resource.go
@@ -139,7 +139,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Redis instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Redis instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the Redis instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/scf/organization/datasource.go
+++ b/stackit/internal/services/scf/organization/datasource.go
@@ -123,7 +123,7 @@ func (s *scfOrganizationDataSource) Schema(_ context.Context, _ datasource.Schem
 				Computed:    true,
 			},
 		},
-		Description: "STACKIT Cloud Foundry organization datasource schema. Must have a `region` specified in the provider configuration.",
+		Description: "STACKIT Cloud Foundry organization datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 	}
 }
 

--- a/stackit/internal/services/scf/organization/resource.go
+++ b/stackit/internal/services/scf/organization/resource.go
@@ -127,7 +127,7 @@ func (r *scfOrganizationResource) ModifyPlan(ctx context.Context, req resource.M
 
 func (s *scfOrganizationResource) Schema(_ context.Context, _ resource.SchemaRequest, response *resource.SchemaResponse) {
 	response.Schema = schema.Schema{
-		Description: "STACKIT Cloud Foundry organization resource schema. Must have a `region` specified in the provider configuration.",
+		Description: "STACKIT Cloud Foundry organization resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],

--- a/stackit/internal/services/secretsmanager/instance/datasource.go
+++ b/stackit/internal/services/secretsmanager/instance/datasource.go
@@ -58,7 +58,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Secrets Manager instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Secrets Manager instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the Secrets Manager instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/secretsmanager/instance/resource.go
+++ b/stackit/internal/services/secretsmanager/instance/resource.go
@@ -78,7 +78,7 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Secrets Manager instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "Secrets Manager instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`instance_id`\".",
 		"instance_id": "ID of the Secrets Manager instance.",
 		"project_id":  "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/secretsmanager/user/datasource.go
+++ b/stackit/internal/services/secretsmanager/user/datasource.go
@@ -68,7 +68,7 @@ func (r *userDataSource) Configure(ctx context.Context, req datasource.Configure
 // Schema defines the schema for the data source.
 func (r *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "Secrets Manager user data source schema. Must have a `region` specified in the provider configuration.",
+		"main":          "Secrets Manager user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal data source identifier. It is structured as \"`project_id`,`instance_id`,`user_id`\".",
 		"user_id":       "The user's ID.",
 		"instance_id":   "ID of the Secrets Manager instance.",

--- a/stackit/internal/services/secretsmanager/user/resource.go
+++ b/stackit/internal/services/secretsmanager/user/resource.go
@@ -77,7 +77,7 @@ func (r *userResource) Configure(ctx context.Context, req resource.ConfigureRequ
 // Schema defines the schema for the resource.
 func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":          "Secrets Manager user resource schema. Must have a `region` specified in the provider configuration.",
+		"main":          "Secrets Manager user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":            "Terraform's internal resource identifier. It is structured as \"`project_id`,`instance_id`,`user_id`\".",
 		"user_id":       "The user's ID.",
 		"instance_id":   "ID of the Secrets Manager instance.",

--- a/stackit/internal/services/serverbackup/schedule/resource.go
+++ b/stackit/internal/services/serverbackup/schedule/resource.go
@@ -130,8 +130,8 @@ func (r *scheduleResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "Server backup schedule resource schema. Must have a `region` specified in the provider configuration.",
-		MarkdownDescription: features.AddBetaDescription("Server backup schedule resource schema. Must have a `region` specified in the provider configuration.", core.Resource),
+		Description:         "Server backup schedule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
+		MarkdownDescription: features.AddBetaDescription("Server backup schedule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.", core.Resource),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource identifier. It is structured as \"`project_id`,`region`,`server_id`,`backup_schedule_id`\".",

--- a/stackit/internal/services/serverbackup/schedule/schedule_datasource.go
+++ b/stackit/internal/services/serverbackup/schedule/schedule_datasource.go
@@ -76,8 +76,8 @@ func (r *scheduleDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "Server backup schedule datasource schema. Must have a `region` specified in the provider configuration.",
-		MarkdownDescription: features.AddBetaDescription("Server backup schedule datasource schema. Must have a `region` specified in the provider configuration.", core.Datasource),
+		Description:         "Server backup schedule datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
+		MarkdownDescription: features.AddBetaDescription("Server backup schedule datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.", core.Datasource),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource identifier. It is structured as \"`project_id`,`server_id`,`backup_schedule_id`\".",

--- a/stackit/internal/services/serverbackup/schedule/schedules_datasource.go
+++ b/stackit/internal/services/serverbackup/schedule/schedules_datasource.go
@@ -75,8 +75,8 @@ func (r *schedulesDataSource) Configure(ctx context.Context, req datasource.Conf
 // Schema defines the schema for the data source.
 func (r *schedulesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "Server backup schedules datasource schema. Must have a `region` specified in the provider configuration.",
-		MarkdownDescription: features.AddBetaDescription("Server backup schedules datasource schema. Must have a `region` specified in the provider configuration.", core.Datasource),
+		Description:         "Server backup schedules datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
+		MarkdownDescription: features.AddBetaDescription("Server backup schedules datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.", core.Datasource),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal data source identifier. It is structured as \"`project_id`,`server_id`\".",

--- a/stackit/internal/services/serverupdate/schedule/resource.go
+++ b/stackit/internal/services/serverupdate/schedule/resource.go
@@ -121,8 +121,8 @@ func (r *scheduleResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "Server update schedule resource schema. Must have a `region` specified in the provider configuration.",
-		MarkdownDescription: features.AddBetaDescription("Server update schedule resource schema. Must have a `region` specified in the provider configuration.", core.Resource),
+		Description:         "Server update schedule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
+		MarkdownDescription: features.AddBetaDescription("Server update schedule resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.", core.Resource),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource identifier. It is structured as \"`project_id`,`region`,`server_id`,`update_schedule_id`\".",

--- a/stackit/internal/services/serverupdate/schedule/schedule_datasource.go
+++ b/stackit/internal/services/serverupdate/schedule/schedule_datasource.go
@@ -75,8 +75,8 @@ func (r *scheduleDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "Server update schedule datasource schema. Must have a `region` specified in the provider configuration.",
-		MarkdownDescription: features.AddBetaDescription("Server update schedule datasource schema. Must have a `region` specified in the provider configuration.", core.Datasource),
+		Description:         "Server update schedule datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
+		MarkdownDescription: features.AddBetaDescription("Server update schedule datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.", core.Datasource),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal resource identifier. It is structured as \"`project_id`,`region`,`server_id`,`update_schedule_id`\".",

--- a/stackit/internal/services/serverupdate/schedule/schedules_datasource.go
+++ b/stackit/internal/services/serverupdate/schedule/schedules_datasource.go
@@ -74,8 +74,8 @@ func (r *schedulesDataSource) Configure(ctx context.Context, req datasource.Conf
 // Schema defines the schema for the data source.
 func (r *schedulesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "Server update schedules datasource schema. Must have a `region` specified in the provider configuration.",
-		MarkdownDescription: features.AddBetaDescription("Server update schedules datasource schema. Must have a `region` specified in the provider configuration.", core.Datasource),
+		Description:         "Server update schedules datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
+		MarkdownDescription: features.AddBetaDescription("Server update schedules datasource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.", core.Datasource),
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal data source identifier. It is structured as \"`project_id`,`region`,`server_id`\".",

--- a/stackit/internal/services/ske/cluster/datasource.go
+++ b/stackit/internal/services/ske/cluster/datasource.go
@@ -57,7 +57,7 @@ func (r *clusterDataSource) Configure(ctx context.Context, req datasource.Config
 }
 func (r *clusterDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "SKE Cluster data source schema. Must have a `region` specified in the provider configuration.",
+		Description: "SKE Cluster data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: "Terraform's internal data source. ID. It is structured as \"`project_id`,`name`\".",

--- a/stackit/internal/services/ske/cluster/resource.go
+++ b/stackit/internal/services/ske/cluster/resource.go
@@ -316,7 +316,7 @@ func (r *clusterResource) Configure(ctx context.Context, req resource.ConfigureR
 // Schema defines the schema for the resource.
 func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main": "SKE Cluster Resource schema. Must have a `region` specified in the provider configuration.",
+		"main": "SKE Cluster Resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"node_pools_plan_note": "When updating `node_pools` of a `stackit_ske_cluster`, the Terraform plan might appear incorrect as it matches the node pools by index rather than by name. " +
 			"However, the SKE API correctly identifies node pools by name and applies the intended changes. Please review your changes carefully to ensure the correct configuration will be applied.",
 		"max_surge":           "Maximum number of additional VMs that are created during an update.",

--- a/stackit/internal/services/ske/kubeconfig/resource.go
+++ b/stackit/internal/services/ske/kubeconfig/resource.go
@@ -87,7 +87,7 @@ func (r *kubeconfigResource) Configure(ctx context.Context, req resource.Configu
 // Schema defines the schema for the resource.
 func (r *kubeconfigResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":           "SKE kubeconfig resource schema. Must have a `region` specified in the provider configuration.",
+		"main":           "SKE kubeconfig resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":             "Terraform's internal resource ID. It is structured as \"`project_id`,`cluster_name`,`kube_config_id`\".",
 		"kube_config_id": "Internally generated UUID to identify a kubeconfig resource in Terraform, since the SKE API doesnt return a kubeconfig identifier",
 		"cluster_name":   "Name of the SKE cluster.",

--- a/stackit/internal/services/sqlserverflex/instance/datasource.go
+++ b/stackit/internal/services/sqlserverflex/instance/datasource.go
@@ -61,7 +61,7 @@ func (r *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 // Schema defines the schema for the data source.
 func (r *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":            "SQLServer Flex instance data source schema. Must have a `region` specified in the provider configuration.",
+		"main":            "SQLServer Flex instance data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":              "Terraform's internal data source. ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
 		"instance_id":     "ID of the SQLServer Flex instance.",
 		"project_id":      "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/sqlserverflex/instance/resource.go
+++ b/stackit/internal/services/sqlserverflex/instance/resource.go
@@ -165,7 +165,7 @@ func (r *instanceResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":            "SQLServer Flex instance resource schema. Must have a `region` specified in the provider configuration.",
+		"main":            "SQLServer Flex instance resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":              "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
 		"instance_id":     "ID of the SQLServer Flex instance.",
 		"project_id":      "STACKIT project ID to which the instance is associated.",

--- a/stackit/internal/services/sqlserverflex/user/datasource.go
+++ b/stackit/internal/services/sqlserverflex/user/datasource.go
@@ -73,7 +73,7 @@ func (r *userDataSource) Configure(ctx context.Context, req datasource.Configure
 // Schema defines the schema for the data source.
 func (r *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "SQLServer Flex user data source schema. Must have a `region` specified in the provider configuration.",
+		"main":        "SQLServer Flex user data source schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal data source. ID. It is structured as \"`project_id`,`region`,`instance_id`,`user_id`\".",
 		"user_id":     "User ID.",
 		"instance_id": "ID of the SQLServer Flex instance.",

--- a/stackit/internal/services/sqlserverflex/user/resource.go
+++ b/stackit/internal/services/sqlserverflex/user/resource.go
@@ -113,7 +113,7 @@ func (r *userResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRe
 // Schema defines the schema for the resource.
 func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "SQLServer Flex user resource schema. Must have a `region` specified in the provider configuration.",
+		"main":        "SQLServer Flex user resource schema. Uses the `default_region` specified in the provider configuration as a fallback in case no `region` is defined on resource level.",
 		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`,`user_id`\".",
 		"user_id":     "User ID.",
 		"instance_id": "ID of the SQLServer Flex instance.",


### PR DESCRIPTION
## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
