### PR TITLE
fix set Version on ProviderData before copying to response

### DIFF
--- a/stackit/provider.go
+++ b/stackit/provider.go
@@ -483,6 +483,9 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	// Make round tripper and custom endpoints available during DataSource and Resource
 	// type Configure methods.
 	providerData.RoundTripper = roundTripper
+
+	providerData.Version = p.version
+
 	resp.DataSourceData = providerData
 	resp.ResourceData = providerData
 
@@ -495,8 +498,6 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	setStringField(providerConfig.PrivateKeyPath, func(v string) { ephemeralProviderData.PrivateKeyPath = v })
 	setStringField(providerConfig.TokenCustomEndpoint, func(v string) { ephemeralProviderData.TokenCustomEndpoint = v })
 	resp.EphemeralResourceData = ephemeralProviderData
-
-	providerData.Version = p.version
 }
 
 // DataSources defines the data sources implemented in the provider.


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to [STACKITTPR-349](https://jira.schwarz/browse/STACKITTPR-349)

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
