### PR TITLE
STACKITRCO-187 - Add option iaas API param agent

### DIFF
--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -34,6 +34,7 @@ data "stackit_server" "example" {
 ### Read-Only
 
 - `affinity_group` (String) The affinity group the server is assigned to.
+- `agent` (Attributes) STACKIT Server Agent as setup on the server (see [below for nested schema](#nestedatt--agent))
 - `availability_zone` (String) The availability zone of the server.
 - `boot_volume` (Attributes) The boot volume for the server (see [below for nested schema](#nestedatt--boot_volume))
 - `created_at` (String) Date-time when the server was created
@@ -47,6 +48,14 @@ data "stackit_server" "example" {
 - `network_interfaces` (List of String) The IDs of network interfaces which should be attached to the server. Updating it will recreate the server.
 - `updated_at` (String) Date-time when the server was updated
 - `user_data` (String) User data that is passed via cloud-init to the server.
+
+<a id="nestedatt--agent"></a>
+### Nested Schema for `agent`
+
+Read-Only:
+
+- `provisioned` (Boolean) Whether a STACKIT Server Agent is provisioned at the server
+
 
 <a id="nestedatt--boot_volume"></a>
 ### Nested Schema for `boot_volume`

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -404,6 +404,7 @@ import {
 ### Optional
 
 - `affinity_group` (String) The affinity group the server is assigned to.
+- `agent` (Attributes) The STACKIT Server Agent configured for the server (see [below for nested schema](#nestedatt--agent))
 - `availability_zone` (String) The availability zone of the server.
 - `boot_volume` (Attributes) The boot volume for the server (see [below for nested schema](#nestedatt--boot_volume))
 - `desired_status` (String) The desired status of the server resource. Possible values are: `active`, `inactive`, `deallocated`.
@@ -421,6 +422,18 @@ import {
 - `launched_at` (String) Date-time when the server was launched
 - `server_id` (String) The server ID.
 - `updated_at` (String) Date-time when the server was updated
+
+<a id="nestedatt--agent"></a>
+### Nested Schema for `agent`
+
+Optional:
+
+- `provisioning_policy` (String) Agent provisioning policy: `ALWAYS`, `NEVER`, or `INHERIT`. `INHERIT` follows the image default value.
+
+Read-Only:
+
+- `provisioned` (Boolean) Whether a STACKIT Server Agent is provisioned at the server
+
 
 <a id="nestedatt--boot_volume"></a>
 ### Nested Schema for `boot_volume`

--- a/stackit/internal/services/iaas/iaas_acc_test.go
+++ b/stackit/internal/services/iaas/iaas_acc_test.go
@@ -149,6 +149,7 @@ var testConfigServerVarsMax = config.Variables{
 	"service_account_mail": config.StringVariable(testutil.TestProjectServiceAccountEmail),
 	"public_key":           config.StringVariable(keypairPublicKey),
 	"desired_status":       config.StringVariable("active"),
+	"agent_policy":         config.StringVariable("ALWAYS"),
 }
 
 var testConfigServerVarsMaxUpdated = func() config.Variables {
@@ -158,6 +159,7 @@ var testConfigServerVarsMaxUpdated = func() config.Variables {
 	updatedConfig["machine_type"] = config.StringVariable("t1.2")
 	updatedConfig["label"] = config.StringVariable("updated")
 	updatedConfig["desired_status"] = config.StringVariable("inactive")
+	updatedConfig["agent_policy"] = config.StringVariable("NEVER")
 	return updatedConfig
 }()
 
@@ -2223,6 +2225,8 @@ func TestAccServerMin(t *testing.T) {
 					resource.TestCheckResourceAttrSet("stackit_server.server", "created_at"),
 					resource.TestCheckResourceAttrSet("stackit_server.server", "launched_at"),
 					resource.TestCheckResourceAttrSet("stackit_server.server", "updated_at"),
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioning_policy", "INHERIT"),
+					resource.TestCheckNoResourceAttr("stackit_server.server", "agent.provisioned"),
 				),
 			},
 			// Data source
@@ -2275,6 +2279,7 @@ func TestAccServerMin(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.stackit_server.server", "created_at"),
 					resource.TestCheckResourceAttrSet("data.stackit_server.server", "launched_at"),
 					resource.TestCheckResourceAttrSet("data.stackit_server.server", "updated_at"),
+					resource.TestCheckNoResourceAttr("data.stackit_server.server", "agent.provisioned"),
 				),
 			},
 			// Import
@@ -2328,6 +2333,8 @@ func TestAccServerMin(t *testing.T) {
 					resource.TestCheckResourceAttrSet("stackit_server.server", "created_at"),
 					resource.TestCheckResourceAttrSet("stackit_server.server", "launched_at"),
 					resource.TestCheckResourceAttrSet("stackit_server.server", "updated_at"),
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioning_policy", "INHERIT"),
+					resource.TestCheckNoResourceAttr("stackit_server.server", "agent.provisioned"),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -2351,6 +2358,10 @@ func TestAccServerMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_affinity_group.affinity_group", "name", testutil.ConvertConfigVariable(testConfigServerVarsMax["name_not_updated"])),
 					resource.TestCheckResourceAttr("stackit_affinity_group.affinity_group", "policy", testutil.ConvertConfigVariable(testConfigServerVarsMax["policy"])),
 					resource.TestCheckResourceAttrSet("stackit_affinity_group.affinity_group", "affinity_group_id"),
+
+					// Agent
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioning_policy", testutil.ConvertConfigVariable(testConfigServerVarsMax["agent_policy"])),
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioned", "true"),
 
 					// Volume base
 					resource.TestCheckResourceAttr("stackit_volume.base_volume", "project_id", testutil.ConvertConfigVariable(testConfigServerVarsMax["project_id"])),
@@ -2500,6 +2511,7 @@ func TestAccServerMax(t *testing.T) {
 						"stackit_key_pair.key_pair", "name",
 						"data.stackit_server.server", "keypair_name",
 					),
+					resource.TestCheckResourceAttr("data.stackit_server.server", "agent.provisioned", "true"),
 					// All network interface which was are attached appear here
 					resource.TestCheckResourceAttr("data.stackit_server.server", "network_interfaces.#", "2"),
 					resource.TestCheckTypeSetElemAttrPair(
@@ -2725,7 +2737,7 @@ func TestAccServerMax(t *testing.T) {
 				},
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"boot_volume", "desired_status", "network_interfaces"}, // Field is not mapped as it is only relevant on creation
+				ImportStateVerifyIgnore: []string{"boot_volume", "desired_status", "network_interfaces", "agent"}, // Field is not mapped as it is only relevant on creation
 			},
 			// Update
 			{
@@ -2737,6 +2749,10 @@ func TestAccServerMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_affinity_group.affinity_group", "name", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdated["name_not_updated"])),
 					resource.TestCheckResourceAttr("stackit_affinity_group.affinity_group", "policy", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdated["policy"])),
 					resource.TestCheckResourceAttrSet("stackit_affinity_group.affinity_group", "affinity_group_id"),
+
+					// Agent
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioning_policy", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdated["agent_policy"])),
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioned", "false"),
 
 					// Volume base
 					resource.TestCheckResourceAttr("stackit_volume.base_volume", "project_id", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdated["project_id"])),
@@ -2842,6 +2858,10 @@ func TestAccServerMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_affinity_group.affinity_group", "name", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdatedDesiredStatus["name_not_updated"])),
 					resource.TestCheckResourceAttr("stackit_affinity_group.affinity_group", "policy", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdatedDesiredStatus["policy"])),
 					resource.TestCheckResourceAttrSet("stackit_affinity_group.affinity_group", "affinity_group_id"),
+
+					// Agent
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioning_policy", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdatedDesiredStatus["agent_policy"])),
+					resource.TestCheckResourceAttr("stackit_server.server", "agent.provisioned", "false"),
 
 					// Volume base
 					resource.TestCheckResourceAttr("stackit_volume.base_volume", "project_id", testutil.ConvertConfigVariable(testConfigServerVarsMaxUpdatedDesiredStatus["project_id"])),

--- a/stackit/internal/services/iaas/server/datasource.go
+++ b/stackit/internal/services/iaas/server/datasource.go
@@ -35,6 +35,7 @@ type DataSourceModel struct {
 	ServerId          types.String `tfsdk:"server_id"`
 	MachineType       types.String `tfsdk:"machine_type"`
 	Name              types.String `tfsdk:"name"`
+	Agent             types.Object `tfsdk:"agent"`
 	AvailabilityZone  types.String `tfsdk:"availability_zone"`
 	BootVolume        types.Object `tfsdk:"boot_volume"`
 	ImageId           types.String `tfsdk:"image_id"`
@@ -51,6 +52,10 @@ type DataSourceModel struct {
 var bootVolumeDataTypes = map[string]attr.Type{
 	"id":                    basetypes.StringType{},
 	"delete_on_termination": basetypes.BoolType{},
+}
+
+var agentDataTypes = map[string]attr.Type{
+	"provisioned": basetypes.BoolType{},
 }
 
 // NewServerDataSource is a helper function to simplify the provider implementation.
@@ -123,6 +128,16 @@ func (d *serverDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			"machine_type": schema.StringAttribute{
 				MarkdownDescription: "Name of the type of the machine for the server. Possible values are documented in [Virtual machine flavors](https://docs.stackit.cloud/products/compute-engine/server/basics/machine-types/)",
 				Computed:            true,
+			},
+			"agent": schema.SingleNestedAttribute{
+				Description: "STACKIT Server Agent as setup on the server",
+				Computed:    true,
+				Attributes: map[string]schema.Attribute{
+					"provisioned": schema.BoolAttribute{
+						Description: "Whether a STACKIT Server Agent is provisioned at the server",
+						Computed:    true,
+					},
+				},
 			},
 			"availability_zone": schema.StringAttribute{
 				Description: "The availability zone of the server.",
@@ -304,6 +319,18 @@ func mapDataSourceFields(ctx context.Context, serverResp *iaas.Server, model *Da
 	} else {
 		model.BootVolume = types.ObjectNull(bootVolumeDataTypes)
 	}
+
+	agentProvisioned := types.BoolNull()
+	if serverResp.Agent != nil && serverResp.Agent.Provisioned != nil {
+		agentProvisioned = types.BoolPointerValue(serverResp.Agent.Provisioned)
+	}
+	agent, diags := types.ObjectValue(agentDataTypes, map[string]attr.Value{
+		"provisioned": agentProvisioned,
+	})
+	if diags.HasError() {
+		return fmt.Errorf("failed to map agent: %w", core.DiagsToError(diags))
+	}
+	model.Agent = agent
 
 	if serverResp.UserData != nil && len(*serverResp.UserData) > 0 {
 		model.UserData = types.StringValue(string(*serverResp.UserData))

--- a/stackit/internal/services/iaas/server/datasource_test.go
+++ b/stackit/internal/services/iaas/server/datasource_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
 )
 
+var expectedNullAgentData = types.ObjectValueMust(agentDataTypes, map[string]attr.Value{
+	"provisioned": types.BoolNull(),
+})
+
 func TestMapDataSourceFields(t *testing.T) {
 	type args struct {
 		state  DataSourceModel
@@ -40,6 +44,7 @@ func TestMapDataSourceFields(t *testing.T) {
 				ServerId:          types.StringValue("sid"),
 				Name:              types.StringNull(),
 				AvailabilityZone:  types.StringNull(),
+				Agent:             expectedNullAgentData,
 				Labels:            types.MapNull(types.StringType),
 				ImageId:           types.StringNull(),
 				NetworkInterfaces: types.ListNull(types.StringType),
@@ -77,7 +82,10 @@ func TestMapDataSourceFields(t *testing.T) {
 							NicId: new("nic2"),
 						},
 					},
-					KeypairName:   new("keypair_name"),
+					KeypairName: new("keypair_name"),
+					Agent: &iaas.ServerAgent{
+						Provisioned: new(true),
+					},
 					AffinityGroup: new("group_id"),
 					CreatedAt:     new(testTimestamp()),
 					UpdatedAt:     new(testTimestamp()),
@@ -100,7 +108,10 @@ func TestMapDataSourceFields(t *testing.T) {
 					types.StringValue("nic1"),
 					types.StringValue("nic2"),
 				}),
-				KeypairName:   types.StringValue("keypair_name"),
+				KeypairName: types.StringValue("keypair_name"),
+				Agent: types.ObjectValueMust(agentDataTypes, map[string]attr.Value{
+					"provisioned": types.BoolValue(true),
+				}),
 				AffinityGroup: types.StringValue("group_id"),
 				CreatedAt:     types.StringValue(testTimestampValue),
 				UpdatedAt:     types.StringValue(testTimestampValue),
@@ -131,6 +142,7 @@ func TestMapDataSourceFields(t *testing.T) {
 				Labels:            types.MapValueMust(types.StringType, map[string]attr.Value{}),
 				ImageId:           types.StringNull(),
 				NetworkInterfaces: types.ListNull(types.StringType),
+				Agent:             expectedNullAgentData,
 				KeypairName:       types.StringNull(),
 				AffinityGroup:     types.StringNull(),
 				UserData:          types.StringNull(),

--- a/stackit/internal/services/iaas/server/resource.go
+++ b/stackit/internal/services/iaas/server/resource.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -65,6 +66,7 @@ type Model struct {
 	ServerId          types.String `tfsdk:"server_id"`
 	MachineType       types.String `tfsdk:"machine_type"`
 	Name              types.String `tfsdk:"name"`
+	Agent             types.Object `tfsdk:"agent"`
 	AvailabilityZone  types.String `tfsdk:"availability_zone"`
 	BootVolume        types.Object `tfsdk:"boot_volume"`
 	ImageId           types.String `tfsdk:"image_id"`
@@ -77,6 +79,12 @@ type Model struct {
 	LaunchedAt        types.String `tfsdk:"launched_at"`
 	UpdatedAt         types.String `tfsdk:"updated_at"`
 	DesiredStatus     types.String `tfsdk:"desired_status"`
+}
+
+// Struct corresponding to Model.Agent
+type agentModel struct {
+	Provisioned        types.Bool   `tfsdk:"provisioned"`
+	ProvisioningPolicy types.String `tfsdk:"provisioning_policy"`
 }
 
 // Struct corresponding to Model.BootVolume
@@ -97,6 +105,12 @@ var bootVolumeTypes = map[string]attr.Type{
 	"source_id":             basetypes.StringType{},
 	"delete_on_termination": basetypes.BoolType{},
 	"id":                    basetypes.StringType{},
+}
+
+// Types corresponding to agentModel
+var agentTypes = map[string]attr.Type{
+	"provisioned":         basetypes.BoolType{},
+	"provisioning_policy": basetypes.StringType{},
 }
 
 // NewServerResource is a helper function to simplify the provider implementation.
@@ -276,6 +290,35 @@ func (r *serverResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				},
 				Optional: true,
 				Computed: true,
+			},
+			"agent": schema.SingleNestedAttribute{
+				Description: "The STACKIT Server Agent configured for the server",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.RequiresReplace(),
+				},
+				Attributes: map[string]schema.Attribute{
+					"provisioned": schema.BoolAttribute{
+						Description: "Whether a STACKIT Server Agent is provisioned at the server",
+						Computed:    true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
+					},
+					"provisioning_policy": schema.StringAttribute{
+						Description: "Agent provisioning policy: `ALWAYS`, `NEVER`, or `INHERIT`. `INHERIT` follows the image default value.",
+						Optional:    true,
+						Computed:    true,
+						Default:     stringdefault.StaticString("INHERIT"),
+						Validators: []validator.String{
+							stringvalidator.OneOf("ALWAYS", "NEVER", "INHERIT"),
+						},
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.RequiresReplace(), // trigger recreation on change
+						},
+					},
+				},
 			},
 			"boot_volume": schema.SingleNestedAttribute{
 				Description: "The boot volume for the server",
@@ -993,6 +1036,33 @@ func mapFields(ctx context.Context, serverResp *iaas.Server, model *Model, regio
 		model.NetworkInterfaces = types.ListNull(types.StringType)
 	}
 
+	// agent{...} block, determine the intent policy from Terraform state
+	currentPolicy := types.StringValue("INHERIT")
+	if !(model.Agent.IsNull() || model.Agent.IsUnknown()) {
+		var currentAgent agentModel
+		diags := model.Agent.As(ctx, &currentAgent, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return fmt.Errorf("failed to map agent: %w", core.DiagsToError(diags))
+		}
+		if !currentAgent.ProvisioningPolicy.IsNull() {
+			currentPolicy = currentAgent.ProvisioningPolicy
+		}
+	}
+	// agent{...} block, determine the 'provisioned' field from API response
+	agentProvisioned := types.BoolNull()
+	if serverResp.Agent != nil && serverResp.Agent.Provisioned != nil {
+		agentProvisioned = types.BoolPointerValue(serverResp.Agent.Provisioned)
+	}
+	// agent{...} block, finalizing
+	agent, diags := types.ObjectValue(agentTypes, map[string]attr.Value{
+		"provisioned":         agentProvisioned,
+		"provisioning_policy": currentPolicy,
+	})
+	if diags.HasError() {
+		return fmt.Errorf("failed to map agent: %w", core.DiagsToError(diags))
+	}
+	model.Agent = agent
+
 	if serverResp.BootVolume != nil {
 		// convert boot volume model
 		var bootVolumeModel = &bootVolumeModel{}
@@ -1061,6 +1131,14 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaas.CreateServerPaylo
 		}
 	}
 
+	var agent = &agentModel{}
+	if !(model.Agent.IsNull() || model.Agent.IsUnknown()) {
+		diags := model.Agent.As(ctx, agent, basetypes.ObjectAsOptions{})
+		if diags.HasError() {
+			return nil, fmt.Errorf("convert agent object to struct: %w", core.DiagsToError(diags))
+		}
+	}
+
 	labels, err := conversion.ToStringInterfaceMap(ctx, model.Labels)
 	if err != nil {
 		return nil, fmt.Errorf("converting to Go map: %w", err)
@@ -1080,6 +1158,16 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaas.CreateServerPaylo
 			// it is set and true, adjust payload
 			bootVolumePayload.DeleteOnTermination = conversion.BoolValueToPointer(bootVolume.DeleteOnTermination)
 		}
+	}
+
+	var agentPayload *iaas.ServerAgent
+	switch agent.ProvisioningPolicy.ValueString() {
+	case "ALWAYS":
+		agentPayload = &iaas.ServerAgent{Provisioned: conversion.BoolValueToPointer(types.BoolValue(true))}
+	case "NEVER":
+		agentPayload = &iaas.ServerAgent{Provisioned: conversion.BoolValueToPointer(types.BoolValue(false))}
+	case "INHERIT":
+		agentPayload = nil // "agent" key is omitted from JSON thanks to omitempty
 	}
 
 	var userData *[]byte
@@ -1111,6 +1199,7 @@ func toCreatePayload(ctx context.Context, model *Model) (*iaas.CreateServerPaylo
 	return &iaas.CreateServerPayload{
 		AffinityGroup:    conversion.StringValueToPointer(model.AffinityGroup),
 		AvailabilityZone: conversion.StringValueToPointer(model.AvailabilityZone),
+		Agent:            agentPayload,
 		BootVolume:       bootVolumePayload,
 		ImageId:          conversion.StringValueToPointer(model.ImageId),
 		KeypairName:      conversion.StringValueToPointer(model.KeypairName),

--- a/stackit/internal/services/iaas/server/resource_test.go
+++ b/stackit/internal/services/iaas/server/resource_test.go
@@ -20,6 +20,11 @@ const (
 	testTimestampValue    = "2006-01-02T15:04:05Z"
 )
 
+var expectedNullAgent = types.ObjectValueMust(agentTypes, map[string]attr.Value{
+	"provisioned":         types.BoolNull(),
+	"provisioning_policy": types.StringValue("INHERIT"),
+})
+
 func testTimestamp() time.Time {
 	timestamp, _ := time.Parse(time.RFC3339, testTimestampValue)
 	return timestamp
@@ -59,6 +64,7 @@ func TestMapFields(t *testing.T) {
 				ImageId:           types.StringNull(),
 				NetworkInterfaces: types.ListNull(types.StringType),
 				KeypairName:       types.StringNull(),
+				Agent:             expectedNullAgent,
 				AffinityGroup:     types.StringNull(),
 				UserData:          types.StringNull(),
 				CreatedAt:         types.StringNull(),
@@ -92,6 +98,9 @@ func TestMapFields(t *testing.T) {
 							NicId: new("nic2"),
 						},
 					},
+					Agent: &iaas.ServerAgent{
+						Provisioned: new(true),
+					},
 					KeypairName:   new("keypair_name"),
 					AffinityGroup: new("group_id"),
 					CreatedAt:     new(testTimestamp()),
@@ -113,11 +122,15 @@ func TestMapFields(t *testing.T) {
 				ImageId:           types.StringValue("image_id"),
 				NetworkInterfaces: types.ListNull(types.StringType),
 				KeypairName:       types.StringValue("keypair_name"),
-				AffinityGroup:     types.StringValue("group_id"),
-				CreatedAt:         types.StringValue(testTimestampValue),
-				UpdatedAt:         types.StringValue(testTimestampValue),
-				LaunchedAt:        types.StringValue(testTimestampValue),
-				Region:            types.StringValue("eu02"),
+				Agent: types.ObjectValueMust(agentTypes, map[string]attr.Value{
+					"provisioned":         types.BoolValue(true),
+					"provisioning_policy": types.StringValue("INHERIT"),
+				}),
+				AffinityGroup: types.StringValue("group_id"),
+				CreatedAt:     types.StringValue(testTimestampValue),
+				UpdatedAt:     types.StringValue(testTimestampValue),
+				LaunchedAt:    types.StringValue(testTimestampValue),
+				Region:        types.StringValue("eu02"),
 			},
 			isValid: true,
 		},
@@ -144,6 +157,7 @@ func TestMapFields(t *testing.T) {
 				ImageId:           types.StringNull(),
 				NetworkInterfaces: types.ListNull(types.StringType),
 				KeypairName:       types.StringNull(),
+				Agent:             expectedNullAgent,
 				AffinityGroup:     types.StringNull(),
 				UserData:          types.StringNull(),
 				CreatedAt:         types.StringNull(),
@@ -216,6 +230,10 @@ func TestToCreatePayload(t *testing.T) {
 					types.StringValue("nic1"),
 					types.StringValue("nic2"),
 				}),
+				Agent: types.ObjectValueMust(agentTypes, map[string]attr.Value{
+					"provisioned":         types.BoolValue(true),
+					"provisioning_policy": types.StringValue("ALWAYS"),
+				}),
 			},
 			expected: &iaas.CreateServerPayload{
 				Name:             new("name"),
@@ -239,6 +257,9 @@ func TestToCreatePayload(t *testing.T) {
 					CreateServerNetworkingWithNics: &iaas.CreateServerNetworkingWithNics{
 						NicIds: &[]string{"nic1", "nic2"},
 					},
+				},
+				Agent: &iaas.ServerAgent{
+					Provisioned: new(true),
 				},
 			},
 			isValid: true,
@@ -267,6 +288,10 @@ func TestToCreatePayload(t *testing.T) {
 					types.StringValue("nic1"),
 					types.StringValue("nic2"),
 				}),
+				Agent: types.ObjectValueMust(agentTypes, map[string]attr.Value{
+					"provisioned":         types.BoolValue(false),
+					"provisioning_policy": types.StringValue("NEVER"),
+				}),
 			},
 			expected: &iaas.CreateServerPayload{
 				Name:             new("name"),
@@ -291,6 +316,9 @@ func TestToCreatePayload(t *testing.T) {
 					CreateServerNetworkingWithNics: &iaas.CreateServerNetworkingWithNics{
 						NicIds: &[]string{"nic1", "nic2"},
 					},
+				},
+				Agent: &iaas.ServerAgent{
+					Provisioned: new(false),
 				},
 			},
 			isValid: true,

--- a/stackit/internal/services/iaas/testdata/resource-server-max.tf
+++ b/stackit/internal/services/iaas/testdata/resource-server-max.tf
@@ -12,6 +12,7 @@ variable "policy" {}
 variable "size" {}
 variable "public_key" {}
 variable "service_account_mail" {}
+variable "agent_policy" {}
 
 resource "stackit_affinity_group" "affinity_group" {
   project_id = var.project_id
@@ -78,5 +79,8 @@ resource "stackit_server" "server" {
   }
   labels = {
     "acc-test" : var.label
+  }
+  agent = {
+    provisioning_policy = var.agent_policy
   }
 }


### PR DESCRIPTION
Adds a terraform `stackit_server` option for the iaas ( _create server_ ) API param: `"agent": {"provisioned": true}`

ref STACKITRCO-187

ref: https://github.com/stackitcloud/stackit-cli/pull/1213

---

Tests:
    * ran `make fmt`, `make generate-docs`, `make lint`

    * ran unit tests
    ```
    [~/terraform-provider-stackit] go test stackit/internal/services/iaas/server/*
    ok      command-line-arguments  15.005s
    [~/terraform-provider-stackit] make test
    ...
    ok      github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/iaas/server       15.006s  coverage: 33.0% of statements
    ...
    [~/terraform-provider-stackit]
    ```

    * Tested: with a locally-configured terraform, by adding, changing, deleting `agent`-related parts of a tf config.
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to  STACKITRCO-187

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
