### PR TITLE
fix(iaas/network): ipv6_prefix triggers always recreate

### DIFF
--- a/stackit/internal/services/iaas/network/resource.go
+++ b/stackit/internal/services/iaas/network/resource.go
@@ -320,7 +320,7 @@ func (r *networkResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					validate.CIDR(),
 				},
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"ipv6_prefix_length": schema.Int64Attribute{


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

since #1031 every update in the network resource triggers a recreate, because ipv6_prefix detects an change even if it hasn't changed.

## Steps to reproduce

- Use the stackit terraform provider with version v0.70.0 or newer
- Create a new network
```hcl
resource "stackit_network" "network" {
  project_id         = var.project_id
  name               = "my-test-network"
  ipv4_nameservers   = ["8.8.8.8", "8.8.4.4"]
  ipv4_prefix_length = 24
  routed             = true
}
```
- Run terraform apply
- Update the name of the network
```hcl
resource "stackit_network" "network" {
  project_id         = var.project_id
  name               = "my-test-network-update"
  ipv4_nameservers   = ["8.8.8.8", "8.8.4.4"]
  ipv4_prefix_length = 24
  routed             = true
}
```
- Run again terraform apply
  -> Terraform want to do a recreate because of the ipv6_prefix
```bash
# stackit_network.network must be replaced
-/+ resource "stackit_network" "network" {
      ~ id                 = "******" -> (known after apply)
      ~ ipv4_gateway       = "10.0.3.1" -> (known after apply)
      ~ ipv4_prefix        = "10.0.3.0/24" -> (known after apply)
      ~ ipv4_prefixes      = [
          - "10.0.3.0/24",
        ] -> (known after apply)
      + ipv6_gateway       = (known after apply)
      ~ ipv6_nameservers   = [] -> (known after apply)
      + ipv6_prefix        = (known after apply) # forces replacement
      + ipv6_prefix_length = (known after apply)
      ~ ipv6_prefixes      = [] -> (known after apply)
      ~ name               = "my-test-network" -> "my-test-network-update"
      ~ nameservers        = [
          - "8.8.8.8",
          - "8.8.4.4",
        ] -> (known after apply)
      ~ network_id         = "8ea2866f-0d23-40b9-a9c3-6bc795b2f8fb" -> (known after apply)
      ~ prefixes           = [
          - "10.0.3.0/24",
        ] -> (known after apply)
      ~ public_ip          = "188.34.101.72" -> (known after apply)
      + routing_table_id   = (known after apply)
        # (5 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
```

## Testing instructions
- Checkout this PR and run `$ make build`
- Edit your ~/.terraformrc, to use the local build ([Guide](https://github.com/stackitcloud/terraform-provider-stackit/blob/main/CONTRIBUTION.md#local-development))
- Run the steps to reproduce, but use the build of this PR
  -> This time it should trigger a patch update and not trigger a recreate


## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
