### PR TITLE
fix(iaas): prevent replace in server_volume_attach

### DIFF
--- a/stackit/internal/services/iaas/volumeattach/resource.go
+++ b/stackit/internal/services/iaas/volumeattach/resource.go
@@ -205,6 +205,7 @@ func (r *volumeAttachResource) Create(ctx context.Context, req resource.CreateRe
 	}
 
 	model.Id = utils.BuildInternalTerraformId(projectId, region, serverId, volumeId)
+	model.Region = types.StringValue(region)
 
 	// Set state to fully populated data
 	diags = resp.State.Set(ctx, model)
@@ -247,6 +248,10 @@ func (r *volumeAttachResource) Read(ctx context.Context, req resource.ReadReques
 	}
 
 	ctx = core.LogResponse(ctx)
+
+	// Update region in model
+	model.Region = types.StringValue(region)
+	model.Id = utils.BuildInternalTerraformId(projectId, region, serverId, volumeId)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, model)


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

prevent replace in server_volume_attach when migrating to iaas v2.

## Testing instructions

__Testing previous behavior__
- Checkout the git tag **v0.74.0** and run `$ make build` (It's last version before iaas v2 was integrated)
- Configure your .terraformrc, to use the local build
- Use the following terraform config:
```hcl
variable "project_id" {
  type    = string
  default = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
}

resource "stackit_volume" "example" {
  project_id = var.project_id
  name = "test"
  availability_zone = "eu01-1"
  size = 16
}

resource "stackit_server_volume_attach" "attach" {
  project_id = var.project_id
  volume_id = stackit_volume.example.volume_id
  server_id = stackit_server.server-01.server_id
}

resource "stackit_server" "server-01" {
  project_id = var.project_id
  name       = "test-server"
  boot_volume = {
    source_type           = "image"
    size                  = 32
    source_id             = "a2c127b2-b1b5-4aee-986f-41cd11b41279"
    delete_on_termination = true
  }
  machine_type       = "t1.1"
  availability_zone  = "eu01-1"
}
```

- Apply this config with `$ terraform apply`

- Checkout the **main** branch and run `$ make build`
- Run `$ terrafom plan`
  - Terraform wants to recreate the server_volume_attachements. This can cause issues on running servers. Don't execute it

__Testing the fix__
- Checkout this PR branch **fix/prevent-replace-in-volume-attach** and run `$ make build`
- Run again `$ terraform plan`
  - This time terraform doesn't want to replace resources
- Run `$ terraform apply`, to refresh the state
  - Should run without any issues

__Cleanup__
- Run `$ terraform destroy`

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
