### PR TITLE
chore(postgresflex): add more descriptions

### DIFF
--- a/docs/resources/postgresflex_instance.md
+++ b/docs/resources/postgresflex_instance.md
@@ -43,11 +43,11 @@ import {
 ### Required
 
 - `acl` (List of String) The Access Control List (ACL) for the PostgresFlex instance.
-- `backup_schedule` (String)
+- `backup_schedule` (String) The schedule for on what time and how often the database backup will be created. Must be a valid cron expression using numeric minute and hour values, e.g: '0 2 * * *'.
 - `flavor` (Attributes) (see [below for nested schema](#nestedatt--flavor))
 - `name` (String) Instance name.
 - `project_id` (String) STACKIT project ID to which the instance is associated.
-- `replicas` (Number)
+- `replicas` (Number) How many replicas the instance should have. Valid values are 1 for single mode or 3 for replication.
 - `storage` (Attributes) (see [below for nested schema](#nestedatt--storage))
 - `version` (String)
 

--- a/stackit/internal/services/postgresflex/instance/resource.go
+++ b/stackit/internal/services/postgresflex/instance/resource.go
@@ -147,13 +147,15 @@ func (r *instanceResource) Configure(ctx context.Context, req resource.Configure
 // Schema defines the schema for the resource.
 func (r *instanceResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	descriptions := map[string]string{
-		"main":        "Postgres Flex instance resource schema. Must have a `region` specified in the provider configuration.",
-		"id":          "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
-		"instance_id": "ID of the PostgresFlex instance.",
-		"project_id":  "STACKIT project ID to which the instance is associated.",
-		"name":        "Instance name.",
-		"acl":         "The Access Control List (ACL) for the PostgresFlex instance.",
-		"region":      "The resource region. If not defined, the provider region is used.",
+		"main":            "Postgres Flex instance resource schema. Must have a `region` specified in the provider configuration.",
+		"id":              "Terraform's internal resource ID. It is structured as \"`project_id`,`region`,`instance_id`\".",
+		"instance_id":     "ID of the PostgresFlex instance.",
+		"project_id":      "STACKIT project ID to which the instance is associated.",
+		"name":            "Instance name.",
+		"acl":             "The Access Control List (ACL) for the PostgresFlex instance.",
+		"region":          "The resource region. If not defined, the provider region is used.",
+		"backup_schedule": "The schedule for on what time and how often the database backup will be created. Must be a valid cron expression using numeric minute and hour values, e.g: '0 2 * * *'.",
+		"replicas":        "How many replicas the instance should have. Valid values are 1 for single mode or 3 for replication.",
 	}
 
 	resp.Schema = schema.Schema{
@@ -206,7 +208,8 @@ func (r *instanceResource) Schema(_ context.Context, req resource.SchemaRequest,
 				Required:    true,
 			},
 			"backup_schedule": schema.StringAttribute{
-				Required: true,
+				Description: descriptions["backup_schedule"],
+				Required:    true,
 			},
 			"flavor": schema.SingleNestedAttribute{
 				Required: true,
@@ -232,7 +235,8 @@ func (r *instanceResource) Schema(_ context.Context, req resource.SchemaRequest,
 				},
 			},
 			"replicas": schema.Int64Attribute{
-				Required: true,
+				Description: descriptions["replicas"],
+				Required:    true,
 			},
 			"storage": schema.SingleNestedAttribute{
 				Required: true,


### PR DESCRIPTION
## Description

Added descriptions for the replicas and the backup_schedule parameters, the content is derived from the errors you receive when using the wrong values
```
│ Calling API: 400 Bad Request, status code 400, Body: {"message":"failed to validate
│ body","code":400,"type":"Validation","fields":{"backupSchedule":["the backupSchedule field is
│ not valid: invalid backup schedule syntax. Must be a valid cron expression using numeric
│ minute and hour values, e.g: '0 2 * * *'"],"replicas":["the replicas field is not valid:
│ postgres instance replicas not supported, supported replicas are '1' and '3'"]}}
```


## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
