### PR TITLE
fix(iaas): network_area_region default nameservers reconcile issue

### DIFF
--- a/stackit/internal/services/iaas/networkarearegion/resource_test.go
+++ b/stackit/internal/services/iaas/networkarearegion/resource_test.go
@@ -55,6 +55,7 @@ func Test_mapFields(t *testing.T) {
 				model: &Model{
 					OrganizationId: types.StringValue(organizationId),
 					NetworkAreaId:  types.StringValue(networkAreaId),
+					Ipv4:           &ipv4Model{},
 				},
 				networkAreaRegion: &iaas.RegionalArea{
 					Ipv4: &iaas.RegionalAreaIPv4{
@@ -117,6 +118,28 @@ func Test_mapFields(t *testing.T) {
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "model.Ipv4 is nil",
+			args: args{
+				model: &Model{
+					OrganizationId: types.StringValue(organizationId),
+					NetworkAreaId:  types.StringValue(networkAreaId),
+					Ipv4:           nil,
+				},
+				networkAreaRegion: &iaas.RegionalArea{},
+				region:            "eu01",
+			},
+			want: &Model{
+				Id:             types.StringValue(fmt.Sprintf("%s,%s,eu01", organizationId, networkAreaId)),
+				OrganizationId: types.StringValue(organizationId),
+				NetworkAreaId:  types.StringValue(networkAreaId),
+				Region:         types.StringValue("eu01"),
+				Ipv4: &ipv4Model{
+					DefaultNameservers: types.ListNull(types.StringType),
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "network area region response is nil",


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1178

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
