### PR TITLE
docs(iaas): remove hint to experimental "network"

### DIFF
--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -29,8 +29,7 @@ data "stackit_network" "example" {
 
 ### Optional
 
-- `region` (String) Can only be used when experimental "network" is set. This is likely going to undergo significant changes or be removed in the future.
-The resource region. If not defined, the provider region is used.
+- `region` (String) The resource region. If not defined, the provider region is used.
 
 ### Read-Only
 
@@ -51,5 +50,4 @@ The resource region. If not defined, the provider region is used.
 - `prefixes` (List of String, Deprecated) The prefixes of the network. This field is deprecated and will be removed soon, use `ipv4_prefixes` to read the prefixes of the IPv4 networks.
 - `public_ip` (String) The public IP of the network.
 - `routed` (Boolean) Shows if the network is routed and therefore accessible from other networks.
-- `routing_table_id` (String) Can only be used when experimental "network" is set. This is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
-The ID of the routing table associated with the network.
+- `routing_table_id` (String) The ID of the routing table associated with the network.

--- a/stackit/internal/services/iaas/network/datasource.go
+++ b/stackit/internal/services/iaas/network/datasource.go
@@ -188,10 +188,10 @@ func (d *networkDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			"region": schema.StringAttribute{
 				// the region cannot be found, so it has to be passed
 				Optional:    true,
-				Description: "Can only be used when experimental \"network\" is set. This is likely going to undergo significant changes or be removed in the future.\nThe resource region. If not defined, the provider region is used.",
+				Description: "The resource region. If not defined, the provider region is used.",
 			},
 			"routing_table_id": schema.StringAttribute{
-				Description: "Can only be used when experimental \"network\" is set. This is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.\nThe ID of the routing table associated with the network.",
+				Description: "The ID of the routing table associated with the network.",
 				Computed:    true,
 				Validators: []validator.String{
 					validate.UUID(),


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

with the iaas v2 migration #1070 the experimental behavior was removed

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
