### PR TITLE
fix(observability): Set contribute attribute for main route to read only

### DIFF
--- a/docs/data-sources/observability_instance.md
+++ b/docs/data-sources/observability_instance.md
@@ -136,6 +136,7 @@ Read-Only:
 
 Read-Only:
 
+- `continue` (Boolean) Whether an alert should continue matching subsequent sibling nodes.
 - `group_by` (List of String) The labels by which incoming alerts are grouped together. For example, multiple alerts coming in for cluster=A and alertname=LatencyHigh would be batched into a single group. To aggregate by all possible labels use the special value '...' as the sole label name, for example: group_by: ['...']. This effectively disables aggregation entirely, passing through all alerts as-is. This is unlikely to be what you want, unless you have a very low alert volume or your upstream notification system performs its own grouping.
 - `group_interval` (String) How long to wait before sending a notification about new alerts that are added to a group of alerts for which an initial notification has already been sent. (Usually ~5m or more.)
 - `group_wait` (String) How long to initially wait to send a notification for a group of alerts. Allows to wait for an inhibiting alert to arrive or collect more initial alerts for the same group. (Usually ~0s to few minutes.) .

--- a/docs/resources/observability_instance.md
+++ b/docs/resources/observability_instance.md
@@ -153,6 +153,10 @@ Optional:
 - `repeat_interval` (String) How long to wait before sending a notification again if it has already been sent successfully for an alert. (Usually ~3h or more).
 - `routes` (Attributes List) List of child routes. (see [below for nested schema](#nestedatt--alert_config--route--routes))
 
+Read-Only:
+
+- `continue` (Boolean) Whether an alert should continue matching subsequent sibling nodes.
+
 <a id="nestedatt--alert_config--route--routes"></a>
 ### Nested Schema for `alert_config.route.routes`
 

--- a/stackit/internal/services/observability/instance/datasource.go
+++ b/stackit/internal/services/observability/instance/datasource.go
@@ -309,6 +309,10 @@ func (d *instanceDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 						Description: "The route for the alert.",
 						Computed:    true,
 						Attributes: map[string]schema.Attribute{
+							"continue": schema.BoolAttribute{
+								Description: routeDescriptions["continue"],
+								Computed:    true,
+							},
 							"group_by": schema.ListAttribute{
 								Description: "The labels by which incoming alerts are grouped together. For example, multiple alerts coming in for cluster=A and alertname=LatencyHigh would be batched into a single group. To aggregate by all possible labels use the special value '...' as the sole label name, for example: group_by: ['...']. This effectively disables aggregation entirely, passing through all alerts as-is. This is unlikely to be what you want, unless you have a very low alert volume or your upstream notification system performs its own grouping.",
 								Computed:    true,

--- a/stackit/internal/services/observability/instance/resource.go
+++ b/stackit/internal/services/observability/instance/resource.go
@@ -125,6 +125,7 @@ var globalConfigurationTypes = map[string]attr.Type{
 
 // Struct corresponding to Model.AlertConfig.route
 type mainRouteModel struct {
+	Continue       types.Bool   `tfsdk:"continue"`
 	GroupBy        types.List   `tfsdk:"group_by"`
 	GroupInterval  types.String `tfsdk:"group_interval"`
 	GroupWait      types.String `tfsdk:"group_wait"`
@@ -167,6 +168,7 @@ type routeModelNoRoutes struct {
 }
 
 var mainRouteTypes = map[string]attr.Type{
+	"continue":        types.BoolType,
 	"group_by":        types.ListType{ElemType: types.StringType},
 	"group_interval":  types.StringType,
 	"group_wait":      types.StringType,
@@ -771,6 +773,11 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						Description: "Route configuration for the alerts.",
 						Required:    true,
 						Attributes: map[string]schema.Attribute{
+							"continue": schema.BoolAttribute{
+								Description: routeDescriptions["continue"],
+								Computed:    true,
+								Default:     booldefault.StaticBool(false),
+							},
 							"group_by": schema.ListAttribute{
 								Description: routeDescriptions["group_by"],
 								Optional:    true,
@@ -1826,6 +1833,7 @@ func getMockAlertConfig(ctx context.Context) (alertConfigModel, error) {
 	}
 
 	mockRoute, diags := types.ObjectValue(mainRouteTypes, map[string]attr.Value{
+		"continue":        types.BoolValue(false),
 		"receiver":        types.StringValue("email-me"),
 		"group_by":        mockGroupByList,
 		"group_wait":      types.StringValue("30s"),
@@ -2057,6 +2065,7 @@ func mapRouteToAttributes(ctx context.Context, route *observability.Route) (attr
 	}
 
 	routeMap := map[string]attr.Value{
+		"continue":        types.BoolPointerValue(route.Continue),
 		"group_by":        groupByModel,
 		"group_interval":  types.StringPointerValue(route.GroupInterval),
 		"group_wait":      types.StringPointerValue(route.GroupWait),
@@ -2397,6 +2406,7 @@ func toRoutePayload(ctx context.Context, routeTF *mainRouteModel) (*observabilit
 	}
 
 	return &observability.UpdateAlertConfigsPayloadRoute{
+		Continue:       conversion.BoolValueToPointer(routeTF.Continue),
 		GroupBy:        groupByPayload,
 		GroupInterval:  conversion.StringValueToPointer(routeTF.GroupInterval),
 		GroupWait:      conversion.StringValueToPointer(routeTF.GroupWait),

--- a/stackit/internal/services/observability/instance/resource_test.go
+++ b/stackit/internal/services/observability/instance/resource_test.go
@@ -65,6 +65,7 @@ func fixtureReceiverModel(emailConfigs, opsGenieConfigs, webHooksConfigs basetyp
 
 func fixtureRouteModel() basetypes.ObjectValue {
 	return types.ObjectValueMust(mainRouteTypes, map[string]attr.Value{
+		"continue": types.BoolValue(false),
 		"group_by": types.ListValueMust(types.StringType, []attr.Value{
 			types.StringValue("label1"),
 			types.StringValue("label2"),
@@ -98,6 +99,7 @@ func fixtureRouteModel() basetypes.ObjectValue {
 
 func fixtureNullRouteModel() basetypes.ObjectValue {
 	return types.ObjectValueMust(mainRouteTypes, map[string]attr.Value{
+		"continue":        types.BoolNull(),
 		"group_by":        types.ListNull(types.StringType),
 		"group_interval":  types.StringNull(),
 		"group_wait":      types.StringNull(),
@@ -175,7 +177,7 @@ func fixtureReceiverPayload(emailConfigs *[]observability.CreateAlertConfigRecei
 
 func fixtureRoutePayload() *observability.UpdateAlertConfigsPayloadRoute {
 	return &observability.UpdateAlertConfigsPayloadRoute{
-		Continue:       nil,
+		Continue:       utils.Ptr(false),
 		GroupBy:        utils.Ptr([]string{"label1", "label2"}),
 		GroupInterval:  utils.Ptr("1m"),
 		GroupWait:      utils.Ptr("1m"),
@@ -252,7 +254,7 @@ func fixtureWebHooksConfigsResponse() observability.WebHook {
 
 func fixtureRouteResponse() *observability.Route {
 	return &observability.Route{
-		Continue:       nil,
+		Continue:       utils.Ptr(false),
 		GroupBy:        utils.Ptr([]string{"label1", "label2"}),
 		GroupInterval:  utils.Ptr("1m"),
 		GroupWait:      utils.Ptr("1m"),

--- a/stackit/internal/services/observability/observability_acc_test.go
+++ b/stackit/internal/services/observability/observability_acc_test.go
@@ -110,7 +110,7 @@ var testConfigVarsMax = config.Variables{
 	"match":                                  config.StringVariable("alert1"),
 	"match_regex":                            config.StringVariable("alert1"),
 	"matchers":                               config.StringVariable("instance =~ \".*\""),
-	"continue":                               config.StringVariable("true"),
+	"continue":                               config.StringVariable("false"),
 	// credential
 	"credential_description": config.StringVariable("This is a description for the test credential."),
 	// logalertgroup
@@ -549,6 +549,7 @@ func TestAccResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.group_wait", testutil.ConvertConfigVariable(testConfigVarsMax["group_wait"])),
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.receiver", testutil.ConvertConfigVariable(testConfigVarsMax["receiver_name"])),
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.repeat_interval", testutil.ConvertConfigVariable(testConfigVarsMax["repeat_interval"])),
+					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.continue", testutil.ConvertConfigVariable(testConfigVarsMax["continue"])),
 
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.routes.0.group_by.0", testutil.ConvertConfigVariable(testConfigVarsMax["group_by"])),
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.routes.0.group_interval", testutil.ConvertConfigVariable(testConfigVarsMax["group_interval"])),
@@ -955,6 +956,7 @@ func TestAccResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.group_wait", testutil.ConvertConfigVariable(testConfigVarsMax["group_wait"])),
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.receiver", testutil.ConvertConfigVariable(testConfigVarsMax["receiver_name"])),
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.repeat_interval", testutil.ConvertConfigVariable(testConfigVarsMax["repeat_interval"])),
+					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.continue", testutil.ConvertConfigVariable(testConfigVarsMax["continue"])),
 
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.routes.0.group_by.0", testutil.ConvertConfigVariable(testConfigVarsMax["group_by"])),
 					resource.TestCheckResourceAttr("stackit_observability_instance.instance", "alert_config.route.routes.0.group_interval", testutil.ConvertConfigVariable(testConfigVarsMax["group_interval"])),


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
