### PR TITLE
STACKITSBM-463 - update docs - rrule,maintenance_window

### DIFF
--- a/docs/data-sources/server_backup_schedule.md
+++ b/docs/data-sources/server_backup_schedule.md
@@ -42,7 +42,7 @@ data "stackit_server_backup_schedule" "example" {
 - `enabled` (Boolean) Is the backup schedule enabled or disabled.
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`server_id`,`backup_schedule_id`".
 - `name` (String) The schedule name.
-- `rrule` (String) Backup schedule described in `rrule` (recurrence rule) format.
+- `rrule` (String) An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.
 
 <a id="nestedatt--backup_properties"></a>
 ### Nested Schema for `backup_properties`

--- a/docs/data-sources/server_backup_schedules.md
+++ b/docs/data-sources/server_backup_schedules.md
@@ -48,7 +48,7 @@ Read-Only:
 - `backup_schedule_id` (Number)
 - `enabled` (Boolean) Is the backup schedule enabled or disabled.
 - `name` (String) The backup schedule name.
-- `rrule` (String) Backup schedule described in `rrule` (recurrence rule) format.
+- `rrule` (String) An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.
 
 <a id="nestedatt--items--backup_properties"></a>
 ### Nested Schema for `items.backup_properties`

--- a/docs/data-sources/server_update_schedule.md
+++ b/docs/data-sources/server_update_schedule.md
@@ -40,6 +40,6 @@ data "stackit_server_update_schedule" "example" {
 
 - `enabled` (Boolean) Is the update schedule enabled or disabled.
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`region`,`server_id`,`update_schedule_id`".
-- `maintenance_window` (Number) Maintenance window [1..24].
+- `maintenance_window` (Number) Maintenance window [1..24]. Updates start within the defined hourly window. Depending on the updates, the process may exceed this timeframe and require an automatic restart.
 - `name` (String) The schedule name.
-- `rrule` (String) Update schedule described in `rrule` (recurrence rule) format.
+- `rrule` (String) An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.

--- a/docs/data-sources/server_update_schedules.md
+++ b/docs/data-sources/server_update_schedules.md
@@ -45,7 +45,7 @@ data "stackit_server_update_schedules" "example" {
 Read-Only:
 
 - `enabled` (Boolean) Is the update schedule enabled or disabled.
-- `maintenance_window` (Number) Maintenance window [1..24].
+- `maintenance_window` (Number) Maintenance window [1..24]. Updates start within the defined hourly window. Depending on the updates, the process may exceed this timeframe and require an automatic restart.
 - `name` (String) The update schedule name.
-- `rrule` (String) Update schedule described in `rrule` (recurrence rule) format.
+- `rrule` (String) An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.
 - `update_schedule_id` (Number)

--- a/docs/resources/server_backup_schedule.md
+++ b/docs/resources/server_backup_schedule.md
@@ -45,7 +45,7 @@ import {
 - `enabled` (Boolean) Is the backup schedule enabled or disabled.
 - `name` (String) The schedule name.
 - `project_id` (String) STACKIT Project ID to which the server is associated.
-- `rrule` (String) Backup schedule described in `rrule` (recurrence rule) format.
+- `rrule` (String) An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.
 - `server_id` (String) Server ID for the backup schedule.
 
 ### Optional

--- a/docs/resources/server_update_schedule.md
+++ b/docs/resources/server_update_schedule.md
@@ -38,10 +38,10 @@ import {
 ### Required
 
 - `enabled` (Boolean) Is the update schedule enabled or disabled.
-- `maintenance_window` (Number) Maintenance window [1..24].
+- `maintenance_window` (Number) Maintenance window [1..24]. Updates start within the defined hourly window. Depending on the updates, the process may exceed this timeframe and require an automatic restart.
 - `name` (String) The schedule name.
 - `project_id` (String) STACKIT Project ID to which the server is associated.
-- `rrule` (String) Update schedule described in `rrule` (recurrence rule) format.
+- `rrule` (String) An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.
 - `server_id` (String) Server ID for the update schedule.
 
 ### Optional

--- a/stackit/internal/services/serverbackup/schedule/resource.go
+++ b/stackit/internal/services/serverbackup/schedule/resource.go
@@ -186,7 +186,7 @@ func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 			},
 			"rrule": schema.StringAttribute{
-				Description: "Backup schedule described in `rrule` (recurrence rule) format.",
+				Description: "An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),

--- a/stackit/internal/services/serverbackup/schedule/schedule_datasource.go
+++ b/stackit/internal/services/serverbackup/schedule/schedule_datasource.go
@@ -108,7 +108,7 @@ func (r *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				},
 			},
 			"rrule": schema.StringAttribute{
-				Description: "Backup schedule described in `rrule` (recurrence rule) format.",
+				Description: "An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.",
 				Computed:    true,
 			},
 			"enabled": schema.BoolAttribute{

--- a/stackit/internal/services/serverbackup/schedule/schedules_datasource.go
+++ b/stackit/internal/services/serverbackup/schedule/schedules_datasource.go
@@ -110,7 +110,7 @@ func (r *schedulesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 							Computed:    true,
 						},
 						"rrule": schema.StringAttribute{
-							Description: "Backup schedule described in `rrule` (recurrence rule) format.",
+							Description: "An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.",
 							Computed:    true,
 						},
 						"enabled": schema.BoolAttribute{

--- a/stackit/internal/services/serverupdate/schedule/resource.go
+++ b/stackit/internal/services/serverupdate/schedule/resource.go
@@ -177,7 +177,7 @@ func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 			},
 			"rrule": schema.StringAttribute{
-				Description: "Update schedule described in `rrule` (recurrence rule) format.",
+				Description: "An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -193,7 +193,7 @@ func (r *scheduleResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Required:    true,
 			},
 			"maintenance_window": schema.Int64Attribute{
-				Description: "Maintenance window [1..24].",
+				Description: "Maintenance window [1..24]. Updates start within the defined hourly window. Depending on the updates, the process may exceed this timeframe and require an automatic restart.",
 				Required:    true,
 				Validators: []validator.Int64{
 					int64validator.AtLeast(1),

--- a/stackit/internal/services/serverupdate/schedule/schedule_datasource.go
+++ b/stackit/internal/services/serverupdate/schedule/schedule_datasource.go
@@ -107,7 +107,7 @@ func (r *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				},
 			},
 			"rrule": schema.StringAttribute{
-				Description: "Update schedule described in `rrule` (recurrence rule) format.",
+				Description: "An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.",
 				Computed:    true,
 			},
 			"enabled": schema.BoolAttribute{
@@ -115,7 +115,7 @@ func (r *scheduleDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 				Computed:    true,
 			},
 			"maintenance_window": schema.Int64Attribute{
-				Description: "Maintenance window [1..24].",
+				Description: "Maintenance window [1..24]. Updates start within the defined hourly window. Depending on the updates, the process may exceed this timeframe and require an automatic restart.",
 				Computed:    true,
 			},
 			"region": schema.StringAttribute{

--- a/stackit/internal/services/serverupdate/schedule/schedules_datasource.go
+++ b/stackit/internal/services/serverupdate/schedule/schedules_datasource.go
@@ -109,7 +109,7 @@ func (r *schedulesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 							Computed:    true,
 						},
 						"rrule": schema.StringAttribute{
-							Description: "Update schedule described in `rrule` (recurrence rule) format.",
+							Description: "An `rrule` (Recurrence Rule) is a standardized string format used in iCalendar (RFC 5545) to define repeating events, and you can generate one by using a dedicated library or by using online generator tools to specify parameters like frequency, interval, and end dates.",
 							Computed:    true,
 						},
 						"enabled": schema.BoolAttribute{
@@ -117,7 +117,7 @@ func (r *schedulesDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 							Computed:    true,
 						},
 						"maintenance_window": schema.Int64Attribute{
-							Description: "Maintenance window [1..24].",
+							Description: "Maintenance window [1..24]. Updates start within the defined hourly window. Depending on the updates, the process may exceed this timeframe and require an automatic restart.",
 							Computed:    true,
 						},
 					},


### PR DESCRIPTION
New `rrule` and `maintenance_window` docstrings for serverbackup and serverupdate schedules.

ref STACKITSBM-463

---

Tests:

```
[~/terraform-provider-stackit] make project-tools
[~/terraform-provider-stackit] make generate-docs
...
[~/terraform-provider-stackit] make fmt
[~/terraform-provider-stackit] golangci-lint run --allow-parallel-runners --timeout=5m --config=./golang-ci.yaml stackit/internal/services/serverbackup/schedule/*.go
[~/terraform-provider-stackit] golangci-lint run --allow-parallel-runners --timeout=5m --config=./golang-ci.yaml stackit/internal/services/serverupdate/schedule/*.go
[~/terraform-provider-stackit] go test stackit/internal/services/serverbackup/schedule/*
ok      command-line-arguments  0.005s
[~/terraform-provider-stackit] go test stackit/internal/services/serverupdate/schedule/*
ok      command-line-arguments  0.004s
```

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to  STACKITSBM-463

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
