### PR TITLE
feat(sfs): Improve acc tests with min/max config

### DIFF
--- a/docs/data-sources/sfs_share.md
+++ b/docs/data-sources/sfs_share.md
@@ -39,12 +39,12 @@ data "stackit_sfs_share" "example" {
 ### Read-Only
 
 - `export_policy` (String) Name of the Share Export Policy to use in the Share.
-Note that if this is not set, the Share can only be mounted in read only by 
-clients with IPs matching the IP ACL of the Resource Pool hosting this Share. 
+Note that if this is not set, the Share can only be mounted in read only by
+clients with IPs matching the IP ACL of the Resource Pool hosting this Share.
 You can also assign a Share Export Policy after creating the Share
 - `id` (String) Terraform's internal resource ID. It is structured as "`project_id`,`share_id`".
 - `mount_path` (String) Mount path of the Share, used to mount the Share
 - `name` (String) Name of the Share
-- `space_hard_limit_gigabytes` (Number) Space hard limit for the Share. 
+- `space_hard_limit_gigabytes` (Number) Space hard limit for the Share.
 				If zero, the Share will have access to the full space of the Resource Pool it lives in.
 				(unit: gigabytes)

--- a/docs/resources/sfs_share.md
+++ b/docs/resources/sfs_share.md
@@ -36,19 +36,19 @@ import {
 
 ### Required
 
-- `export_policy` (String) Name of the Share Export Policy to use in the Share.
-Note that if this is set to an empty string, the Share can only be mounted in read only by 
-clients with IPs matching the IP ACL of the Resource Pool hosting this Share. 
-You can also assign a Share Export Policy after creating the Share
 - `name` (String) Name of the share.
 - `project_id` (String) STACKIT project ID to which the share is associated.
 - `resource_pool_id` (String) The ID of the resource pool for the SFS share.
-- `space_hard_limit_gigabytes` (Number) Space hard limit for the Share. 
+- `space_hard_limit_gigabytes` (Number) Space hard limit for the Share.
 				If zero, the Share will have access to the full space of the Resource Pool it lives in.
 				(unit: gigabytes)
 
 ### Optional
 
+- `export_policy` (String) Name of the Share Export Policy to use in the Share.
+Note that if this is set to an empty string, the Share can only be mounted in read only by
+clients with IPs matching the IP ACL of the Resource Pool hosting this Share.
+You can also assign a Share Export Policy after creating the Share
 - `region` (String) The resource region. If not defined, the provider region is used.
 
 ### Read-Only

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	sfs "github.com/stackitcloud/stackit-sdk-go/services/sfs/v1api"
@@ -262,6 +263,11 @@ func TestAccExportPolicyMin(t *testing.T) {
 			{
 				ConfigVariables: testConfigExportPolicyVarsMinUpdated(),
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMinConfig),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("stackit_sfs_export_policy.exportpolicy", plancheck.ResourceActionReplace),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "region", testutil.Region),
@@ -358,6 +364,11 @@ func TestAccExportPolicyMax(t *testing.T) {
 			{
 				ConfigVariables: testConfigExportPolicyVarsMaxUpdated(),
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMaxConfig),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("stackit_sfs_export_policy.exportpolicy", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "region", testutil.Region),
@@ -465,6 +476,11 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 			{
 				ConfigVariables: testConfigResourcePoolVarsMinUpdated(),
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMinConfig),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("stackit_sfs_resource_pool.resourcepool", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "region", testutil.Region),
@@ -560,6 +576,11 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 			{
 				ConfigVariables: testConfigResourcePoolVarsMaxUpdated(),
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMaxConfig),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("stackit_sfs_resource_pool.resourcepool", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "region", testutil.Region),
@@ -660,6 +681,11 @@ func TestAccShareResourceMin(t *testing.T) {
 			{
 				ConfigVariables: testConfigShareVarsMinUpdated(),
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMinConfig),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("stackit_sfs_share.share", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "region", testutil.Region),
@@ -766,6 +792,11 @@ func TestAccShareResourceMax(t *testing.T) {
 			{
 				ConfigVariables: testConfigShareVarsMaxUpdated(),
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMaxConfig),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction("stackit_sfs_share.share", plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "region", testutil.Region),

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -68,10 +68,12 @@ var testConfigExportPolicyVarsMax = config.Variables{
 	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
 	"rules": config.ListVariable(
 		config.ObjectVariable(map[string]config.Variable{
-			"ip_acl": config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1), config.StringVariable(exportPolicyMaxIpAcl2)),
-			"order":  config.IntegerVariable(1),
+			"description": config.StringVariable("Some description"),
+			"ip_acl":      config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1), config.StringVariable(exportPolicyMaxIpAcl2)),
+			"order":       config.IntegerVariable(1),
 		}),
 	),
+	"region": config.StringVariable(testutil.Region),
 }
 
 var testConfigExportPolicyVarsMaxUpdated = func() config.Variables {
@@ -79,12 +81,16 @@ var testConfigExportPolicyVarsMaxUpdated = func() config.Variables {
 	maps.Copy(updatedConfig, testConfigExportPolicyVarsMax)
 	updatedConfig["rules"] = config.ListVariable(
 		config.ObjectVariable(map[string]config.Variable{
-			"ip_acl": config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1), config.StringVariable(exportPolicyMaxIpAcl2)),
-			"order":  config.IntegerVariable(1),
+			"description": config.StringVariable("Some description"),
+			"ip_acl":      config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1Update), config.StringVariable(exportPolicyMaxIpAcl2Update)),
+			"order":       config.IntegerVariable(1),
 		}),
 		config.ObjectVariable(map[string]config.Variable{
-			"ip_acl": config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1Update), config.StringVariable(exportPolicyMaxIpAcl2Update)),
-			"order":  config.IntegerVariable(2),
+			"ip_acl":     config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1Update), config.StringVariable(exportPolicyMaxIpAcl2Update)),
+			"order":      config.IntegerVariable(2),
+			"read_only":  config.BoolVariable(true),
+			"set_uuid":   config.BoolVariable(true),
+			"super_user": config.BoolVariable(false),
 		}),
 	)
 	return updatedConfig
@@ -138,6 +144,7 @@ var testConfigResourcePoolVarsMax = config.Variables{
 		config.StringVariable(resourcePoolMaxIpAcl1),
 		config.StringVariable(resourcePoolMaxIpAcl2),
 	),
+	"region":                config.StringVariable(testutil.Region),
 	"availability_zone":     config.StringVariable("eu01-m"),
 	"performance_class":     config.StringVariable("Standard"),
 	"size_gigabytes":        config.IntegerVariable(500),
@@ -161,7 +168,6 @@ var testConfigResourcePoolVarsMaxUpdated = func() config.Variables {
 var testConfigShareVarsMin = config.Variables{
 	"project_id":                 config.StringVariable(testutil.ProjectId),
 	"name":                       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
-	"region":                     config.StringVariable("eu01"),
 	"resource_pool_name":         config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
 	"space_hard_limit_gigabytes": config.IntegerVariable(42),
 }
@@ -178,7 +184,7 @@ var testConfigShareVarsMinUpdated = func() config.Variables {
 var testConfigShareVarsMax = config.Variables{
 	"project_id":                 config.StringVariable(testutil.ProjectId),
 	"name":                       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
-	"region":                     config.StringVariable("eu01"),
+	"region":                     config.StringVariable(testutil.Region),
 	"resource_pool_name":         config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
 	"space_hard_limit_gigabytes": config.IntegerVariable(42),
 	"export_policy_name":         config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
@@ -202,7 +208,9 @@ func TestAccExportPolicyMin(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "region", testutil.Region),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "policy_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "0"),
@@ -223,14 +231,13 @@ func TestAccExportPolicyMin(t *testing.T) {
 					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMinConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
-
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "0"),
-					// data source
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "id"),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
+
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.#", "0"),
 				),
 			},
 			// Import
@@ -257,7 +264,9 @@ func TestAccExportPolicyMin(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "region", testutil.Region),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "policy_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMinUpdated()["name"])),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "0"),
@@ -279,15 +288,17 @@ func TestAccExportPolicyMax(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "region", testutil.Region),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "policy_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.description", "Some description"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
-
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
@@ -308,22 +319,21 @@ func TestAccExportPolicyMax(t *testing.T) {
 					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMaxConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
-
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
-
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
-
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "id"),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
+
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.#", "1"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.description", "Some description"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.order", "1"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.read_only", "false"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.set_uuid", "false"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.super_user", "true"),
 				),
 			},
 			// Import
@@ -350,25 +360,29 @@ func TestAccExportPolicyMax(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "region", testutil.Region),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "policy_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["name"])),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.description", "Some description"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1Update),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2Update),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
 
+					resource.TestCheckNoResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.description"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.order", "2"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.#", "2"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", exportPolicyMaxIpAcl1Update),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", exportPolicyMaxIpAcl2Update),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", "true"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", "true"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "true"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", "false"),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -387,6 +401,8 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["availability_zone"])),
@@ -413,19 +429,18 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMinConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["name"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["availability_zone"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["performance_class"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["size_gigabytes"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMinIpAcl1),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMinIpAcl2),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", "false"),
-
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "id"),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["name"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["availability_zone"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["performance_class"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["size_gigabytes"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.0", resourcePoolMinIpAcl1),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.1", resourcePoolMinIpAcl2),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "snapshots_are_visible", "false"),
 				),
 			},
 			// Import
@@ -452,6 +467,8 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["availability_zone"])),
@@ -479,6 +496,8 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["availability_zone"])),
@@ -505,19 +524,18 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMaxConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["name"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["availability_zone"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["performance_class"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["size_gigabytes"])),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMaxIpAcl1),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMaxIpAcl2),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["snapshots_are_visible"])),
-
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "id"),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["name"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["availability_zone"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["performance_class"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["size_gigabytes"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.0", resourcePoolMaxIpAcl1),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.1", resourcePoolMaxIpAcl2),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["snapshots_are_visible"])),
 				),
 			},
 			// Import
@@ -544,6 +562,8 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["availability_zone"])),
@@ -571,11 +591,17 @@ func TestAccShareResourceMin(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sfs_share.share", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMin["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMin["space_hard_limit_gigabytes"])),
 					resource.TestCheckNoResourceAttr("stackit_sfs_share.share", "export_policy"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "mount_path"),
 				),
 			},
 			// Data source
@@ -594,16 +620,18 @@ func TestAccShareResourceMin(t *testing.T) {
 					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMinConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMin["name"])),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMin["space_hard_limit_gigabytes"])),
-					resource.TestCheckNoResourceAttr("stackit_sfs_share.share", "export_policy"),
-
 					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "id"),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_share.share_ds", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "name", testutil.ConvertConfigVariable(testConfigShareVarsMin["name"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMin["space_hard_limit_gigabytes"])),
+					resource.TestCheckNoResourceAttr("data.stackit_sfs_share.share_ds", "export_policy"),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "mount_path"),
 				),
 			},
 			// Import
@@ -634,11 +662,17 @@ func TestAccShareResourceMin(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sfs_share.share", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMinUpdated()["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMinUpdated()["space_hard_limit_gigabytes"])),
 					resource.TestCheckNoResourceAttr("stackit_sfs_share.share", "export_policy"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "mount_path"),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -657,12 +691,20 @@ func TestAccShareResourceMax(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sfs_share.share", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMax["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMax["space_hard_limit_gigabytes"])),
-					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
-						"stackit_sfs_export_policy.exportpolicy", "name"),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sfs_share.share", "export_policy",
+						"stackit_sfs_export_policy.exportpolicy", "name",
+					),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "mount_path"),
 				),
 			},
 			// Data source
@@ -681,17 +723,21 @@ func TestAccShareResourceMax(t *testing.T) {
 					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMaxConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMax["name"])),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMax["space_hard_limit_gigabytes"])),
-					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
-						"stackit_sfs_export_policy.exportpolicy", "name"),
-
 					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "id"),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_share.share_ds", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "name", testutil.ConvertConfigVariable(testConfigShareVarsMax["name"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMax["space_hard_limit_gigabytes"])),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_share.share_ds", "export_policy",
+						"stackit_sfs_export_policy.exportpolicy", "name",
+					),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "mount_path"),
 				),
 			},
 			// Import
@@ -722,12 +768,20 @@ func TestAccShareResourceMax(t *testing.T) {
 				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "region", testutil.Region),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "id"),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sfs_share.share", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMaxUpdated()["name"])),
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMaxUpdated()["space_hard_limit_gigabytes"])),
-					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
-						"stackit_sfs_export_policy.exportpolicy", "name"),
+					resource.TestCheckResourceAttrPair(
+						"stackit_sfs_share.share", "export_policy",
+						"stackit_sfs_export_policy.exportpolicy", "name",
+					),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "mount_path"),
 				),
 			},
 			// Deletion is done by the framework implicitly

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -51,68 +51,44 @@ var testConfigExportPolicyVarsMin = config.Variables{
 var testConfigExportPolicyVarsMinUpdated = func() config.Variables {
 	updatedConfig := config.Variables{}
 	maps.Copy(updatedConfig, testConfigExportPolicyVarsMin)
-	updatedConfig["name"] = config.StringVariable("tf-acc-updated")
+	updatedConfig["name"] = config.StringVariable(fmt.Sprintf("%s-updated", testutil.ConvertConfigVariable(updatedConfig["name"])))
 	return updatedConfig
 }
 
 // EXPORT POLICY - MAX
 
-const (
-	exportPolicyMaxIpAcl1       = "172.16.0.0/24"
-	exportPolicyMaxIpAcl2       = "172.16.0.250/32"
-	exportPolicyMaxIpAcl1Update = "172.17.0.0/24"
-	exportPolicyMaxIpAcl2Update = "172.17.0.250/32"
-)
-
 var testConfigExportPolicyVarsMax = config.Variables{
-	"project_id": config.StringVariable(testutil.ProjectId),
-	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
-	"rules": config.ListVariable(
-		config.ObjectVariable(map[string]config.Variable{
-			"description": config.StringVariable("Some description"),
-			"ip_acl":      config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1), config.StringVariable(exportPolicyMaxIpAcl2)),
-			"order":       config.IntegerVariable(1),
-		}),
-	),
-	"region": config.StringVariable(testutil.Region),
+	"project_id":             config.StringVariable(testutil.ProjectId),
+	"region":                 config.StringVariable(testutil.Region),
+	"name":                   config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"first_rule_description": config.StringVariable("Some description"),
+	"first_rule_ip_acl_1":    config.StringVariable("172.16.0.0/24"),
+	"first_rule_ip_acl_2":    config.StringVariable("172.16.0.250/32"),
+	"first_rule_set_uuid":    config.BoolVariable(true),
+	"second_rule_ip_acl_1":   config.StringVariable("172.16.0.0/24"),
+	"second_rule_ip_acl_2":   config.StringVariable("172.16.0.250/32"),
+	"second_rule_read_only":  config.BoolVariable(true),
+	"second_rule_super_user": config.BoolVariable(false),
 }
 
 var testConfigExportPolicyVarsMaxUpdated = func() config.Variables {
 	updatedConfig := config.Variables{}
 	maps.Copy(updatedConfig, testConfigExportPolicyVarsMax)
-	updatedConfig["rules"] = config.ListVariable(
-		config.ObjectVariable(map[string]config.Variable{
-			"description": config.StringVariable("Some description"),
-			"ip_acl":      config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1Update), config.StringVariable(exportPolicyMaxIpAcl2Update)),
-			"order":       config.IntegerVariable(1),
-		}),
-		config.ObjectVariable(map[string]config.Variable{
-			"ip_acl":     config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1Update), config.StringVariable(exportPolicyMaxIpAcl2Update)),
-			"order":      config.IntegerVariable(2),
-			"read_only":  config.BoolVariable(true),
-			"set_uuid":   config.BoolVariable(true),
-			"super_user": config.BoolVariable(false),
-		}),
-	)
+
+	updatedConfig["first_rule_description"] = config.StringVariable("Some other description")
+	updatedConfig["first_rule_ip_acl_1"] = config.StringVariable("172.17.0.0/24")
+	updatedConfig["first_rule_ip_acl_2"] = config.StringVariable("172.17.0.250/32")
+
 	return updatedConfig
 }
 
 // Resource Pool - MIN
 
-const (
-	resourcePoolMinIpAcl1       = "192.168.42.1/32"
-	resourcePoolMinIpAcl2       = "192.168.42.2/32"
-	resourcePoolMinIpAcl1Update = "172.17.0.0/24"
-	resourcePoolMinIpAcl2Update = "172.17.0.250/32"
-)
-
 var testConfigResourcePoolVarsMin = config.Variables{
-	"project_id": config.StringVariable(testutil.ProjectId),
-	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
-	"acl": config.ListVariable(
-		config.StringVariable(resourcePoolMinIpAcl1),
-		config.StringVariable(resourcePoolMinIpAcl2),
-	),
+	"project_id":        config.StringVariable(testutil.ProjectId),
+	"name":              config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"ip_acl_1":          config.StringVariable("192.168.42.1/32"),
+	"ip_acl_2":          config.StringVariable("192.168.42.2/32"),
 	"availability_zone": config.StringVariable("eu01-m"),
 	"performance_class": config.StringVariable("Standard"),
 	"size_gigabytes":    config.IntegerVariable(500),
@@ -122,33 +98,23 @@ var testConfigResourcePoolVarsMinUpdated = func() config.Variables {
 	updatedConfig := config.Variables{}
 	maps.Copy(updatedConfig, testConfigResourcePoolVarsMin)
 	updatedConfig["performance_class"] = config.StringVariable("Premium")
-	updatedConfig["acl"] = config.ListVariable(
-		config.StringVariable(resourcePoolMinIpAcl1Update),
-		config.StringVariable(resourcePoolMinIpAcl2Update),
-	)
+	updatedConfig["size_gigabytes"] = config.IntegerVariable(512)
+	updatedConfig["ip_acl_1"] = config.StringVariable("172.17.0.0/24")
+	updatedConfig["ip_acl_2"] = config.StringVariable("172.17.0.250/32")
 	return updatedConfig
 }
 
 // Resource Pool - MAX
 
-const (
-	resourcePoolMaxIpAcl1       = "192.168.42.1/32"
-	resourcePoolMaxIpAcl2       = "192.168.42.2/32"
-	resourcePoolMaxIpAcl1Update = "172.17.0.0/24"
-	resourcePoolMaxIpAcl2Update = "172.17.0.250/32"
-)
-
 var testConfigResourcePoolVarsMax = config.Variables{
-	"project_id": config.StringVariable(testutil.ProjectId),
-	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
-	"acl": config.ListVariable(
-		config.StringVariable(resourcePoolMaxIpAcl1),
-		config.StringVariable(resourcePoolMaxIpAcl2),
-	),
+	"project_id":            config.StringVariable(testutil.ProjectId),
+	"name":                  config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"ip_acl_1":              config.StringVariable("192.168.42.1/32"),
+	"ip_acl_2":              config.StringVariable("192.168.42.2/32"),
 	"region":                config.StringVariable(testutil.Region),
 	"availability_zone":     config.StringVariable("eu01-m"),
 	"performance_class":     config.StringVariable("Standard"),
-	"size_gigabytes":        config.IntegerVariable(500),
+	"size_gigabytes":        config.IntegerVariable(512),
 	"snapshots_are_visible": config.BoolVariable(true),
 }
 
@@ -157,10 +123,9 @@ var testConfigResourcePoolVarsMaxUpdated = func() config.Variables {
 	maps.Copy(updatedConfig, testConfigResourcePoolVarsMax)
 	updatedConfig["performance_class"] = config.StringVariable("Premium")
 	updatedConfig["snapshots_are_visible"] = config.BoolVariable(false)
-	updatedConfig["acl"] = config.ListVariable(
-		config.StringVariable(resourcePoolMaxIpAcl1Update),
-		config.StringVariable(resourcePoolMaxIpAcl2Update),
-	)
+	updatedConfig["size_gigabytes"] = config.IntegerVariable(1024)
+	updatedConfig["ip_acl_1"] = config.StringVariable("172.17.0.0/24")
+	updatedConfig["ip_acl_2"] = config.StringVariable("172.17.0.250/32")
 	return updatedConfig
 }
 
@@ -305,15 +270,24 @@ func TestAccExportPolicyMax(t *testing.T) {
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "policy_id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
 
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.description", "Some description"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.description", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_description"])),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_ip_acl_2"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"), // default value
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_set_uuid"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"), // default value
+
+					resource.TestCheckNoResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.description"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.order", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_ip_acl_2"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_read_only"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "false"), // default value
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_super_user"])),
 				),
 			},
 			// Data source
@@ -343,15 +317,24 @@ func TestAccExportPolicyMax(t *testing.T) {
 					),
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
 
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.#", "1"),
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.description", "Some description"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.#", "2"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.description", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_description"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.read_only", "false"),
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.set_uuid", "false"),
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.super_user", "true"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.0", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_ip_acl_1"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.ip_acl.1", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_ip_acl_2"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.read_only", "false"), // default value
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.set_uuid", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["first_rule_set_uuid"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.0.super_user", "true"), // default value
+
+					resource.TestCheckNoResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.description"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.order", "2"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.ip_acl.0", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_ip_acl_1"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.ip_acl.1", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_ip_acl_2"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.read_only", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_read_only"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.set_uuid", "false"), // default value
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.1.super_user", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["second_rule_super_user"])),
 				),
 			},
 			// Import
@@ -389,23 +372,23 @@ func TestAccExportPolicyMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["name"])),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.description", "Some description"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.description", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["first_rule_description"])),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1Update),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2Update),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["first_rule_ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["first_rule_ip_acl_2"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"), // default value
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["first_rule_set_uuid"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"), // default value
 
 					resource.TestCheckNoResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.description"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.order", "2"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", exportPolicyMaxIpAcl1Update),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", exportPolicyMaxIpAcl2Update),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", "true"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "true"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["second_rule_ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["second_rule_ip_acl_2"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["second_rule_read_only"])),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "false"), // default value
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["second_rule_super_user"])),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -432,8 +415,8 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["performance_class"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["size_gigabytes"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMinIpAcl1),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMinIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["ip_acl_2"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", "false"),
 				),
 			},
@@ -467,8 +450,8 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["performance_class"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["size_gigabytes"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.0", resourcePoolMinIpAcl1),
-					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.1", resourcePoolMinIpAcl2),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.0", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["ip_acl_1"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.1", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["ip_acl_2"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "snapshots_are_visible", "false"),
 				),
 			},
@@ -509,8 +492,8 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["performance_class"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["size_gigabytes"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMinIpAcl1Update),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMinIpAcl2Update),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["ip_acl_2"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", "false"),
 				),
 			},
@@ -538,8 +521,8 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["performance_class"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["size_gigabytes"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMaxIpAcl1),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMaxIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["ip_acl_2"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["snapshots_are_visible"])),
 				),
 			},
@@ -573,8 +556,8 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["performance_class"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["size_gigabytes"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.0", resourcePoolMaxIpAcl1),
-					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.1", resourcePoolMaxIpAcl2),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.0", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["ip_acl_1"])),
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "ip_acl.1", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["ip_acl_2"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["snapshots_are_visible"])),
 				),
 			},
@@ -615,8 +598,8 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["performance_class"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["size_gigabytes"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMaxIpAcl1Update),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMaxIpAcl2Update),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["ip_acl_1"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["ip_acl_2"])),
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["snapshots_are_visible"])),
 				),
 			},

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -199,7 +199,7 @@ func TestAccExportPolicyMin(t *testing.T) {
 			// Creation
 			{
 				ConfigVariables: testConfigExportPolicyVarsMin,
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMinConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
@@ -220,7 +220,7 @@ func TestAccExportPolicyMin(t *testing.T) {
 					  policy_id  = stackit_sfs_export_policy.exportpolicy.policy_id
 					}
 					`,
-					testutil.SFSProviderConfig(), resourceExportPolicyMinConfig,
+					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMinConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
@@ -254,7 +254,7 @@ func TestAccExportPolicyMin(t *testing.T) {
 			// Update
 			{
 				ConfigVariables: testConfigExportPolicyVarsMinUpdated(),
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMinConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
@@ -276,7 +276,7 @@ func TestAccExportPolicyMax(t *testing.T) {
 			// Creation
 			{
 				ConfigVariables: testConfigExportPolicyVarsMax,
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
@@ -305,7 +305,7 @@ func TestAccExportPolicyMax(t *testing.T) {
 					  policy_id  = stackit_sfs_export_policy.exportpolicy.policy_id
 					}
 					`,
-					testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig,
+					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMaxConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
@@ -347,7 +347,7 @@ func TestAccExportPolicyMax(t *testing.T) {
 			// Update
 			{
 				ConfigVariables: testConfigExportPolicyVarsMaxUpdated(),
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceExportPolicyMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
@@ -384,7 +384,7 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 			// Creation
 			{
 				ConfigVariables: testConfigResourcePoolVarsMin,
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMinConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
@@ -410,7 +410,7 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 					  resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
 					}
 					`,
-					testutil.SFSProviderConfig(), resourceResourcePoolMinConfig,
+					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMinConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
@@ -449,7 +449,7 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 			// Update
 			{
 				ConfigVariables: testConfigResourcePoolVarsMinUpdated(),
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMinConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
@@ -476,7 +476,7 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 			// Creation
 			{
 				ConfigVariables: testConfigResourcePoolVarsMax,
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMaxConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
@@ -502,7 +502,7 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 					  resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
 					}
 					`,
-					testutil.SFSProviderConfig(), resourceResourcePoolMaxConfig,
+					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMaxConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
@@ -541,7 +541,7 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 			// Update
 			{
 				ConfigVariables: testConfigResourcePoolVarsMaxUpdated(),
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMaxConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceResourcePoolMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
@@ -568,7 +568,7 @@ func TestAccShareResourceMin(t *testing.T) {
 			// Creation
 			{
 				ConfigVariables: testConfigShareVarsMin,
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMinConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
@@ -591,7 +591,7 @@ func TestAccShareResourceMin(t *testing.T) {
 					  share_id         = stackit_sfs_share.share.share_id
 					}
 					`,
-					testutil.SFSProviderConfig(), resourceShareMinConfig,
+					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMinConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
@@ -631,7 +631,7 @@ func TestAccShareResourceMin(t *testing.T) {
 			// Update
 			{
 				ConfigVariables: testConfigShareVarsMinUpdated(),
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMinConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
@@ -654,7 +654,7 @@ func TestAccShareResourceMax(t *testing.T) {
 			// Creation
 			{
 				ConfigVariables: testConfigShareVarsMax,
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMaxConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
@@ -678,7 +678,7 @@ func TestAccShareResourceMax(t *testing.T) {
 					  share_id         = stackit_sfs_share.share.share_id
 					}
 					`,
-					testutil.SFSProviderConfig(), resourceShareMaxConfig,
+					testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMaxConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
@@ -719,7 +719,7 @@ func TestAccShareResourceMax(t *testing.T) {
 			// Update
 			{
 				ConfigVariables: testConfigShareVarsMaxUpdated(),
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMaxConfig),
+				Config:          fmt.Sprintf("%s\n%s", testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(), resourceShareMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -3,6 +3,7 @@ package sfs_test
 import (
 	"context"
 	_ "embed"
+	"errors"
 	"fmt"
 	"maps"
 	"strings"
@@ -20,48 +21,24 @@ import (
 )
 
 var (
+	//go:embed testdata/export-policy-min.tf
+	resourceExportPolicyMinConfig string
+
 	//go:embed testdata/export-policy-max.tf
 	resourceExportPolicyMaxConfig string
 
-	//go:embed testdata/export-policy-min.tf
-	resourceExportPolicyMinConfig string
+	//go:embed testdata/resource-pool-min.tf
+	resourceResourcePoolMinConfig string
+
+	//go:embed testdata/resource-pool-max.tf
+	resourceResourcePoolMaxConfig string
+
+	//go:embed testdata/share-min.tf
+	resourceShareMinConfig string
+
+	//go:embed testdata/share-max.tf
+	resourceShareMaxConfig string
 )
-
-// EXPORT POLICY - MAX
-
-var (
-	ip_acl_1        = "172.16.0.0/24"
-	ip_acl_2        = "172.16.0.250/32"
-	ip_acl_1_update = "172.17.0.0/24"
-	ip_acl_2_update = "172.17.0.250/32"
-)
-
-var testConfigExportPolicyVarsMax = config.Variables{
-	"project_id": config.StringVariable(testutil.ProjectId),
-	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
-	"rules": config.ListVariable(
-		config.ObjectVariable(map[string]config.Variable{
-			"ip_acl": config.ListVariable(config.StringVariable(ip_acl_1), config.StringVariable(ip_acl_2)),
-			"order":  config.IntegerVariable(1),
-		}),
-	),
-}
-
-var testConfigExportPolicyVarsMaxUpdated = func() config.Variables {
-	updatedConfig := config.Variables{}
-	maps.Copy(updatedConfig, testConfigExportPolicyVarsMax)
-	updatedConfig["rules"] = config.ListVariable(
-		config.ObjectVariable(map[string]config.Variable{
-			"ip_acl": config.ListVariable(config.StringVariable(ip_acl_1), config.StringVariable(ip_acl_2)),
-			"order":  config.IntegerVariable(1),
-		}),
-		config.ObjectVariable(map[string]config.Variable{
-			"ip_acl": config.ListVariable(config.StringVariable(ip_acl_1_update), config.StringVariable(ip_acl_2_update)),
-			"order":  config.IntegerVariable(2),
-		}),
-	)
-	return updatedConfig
-}
 
 // EXPORT POLICY - MIN
 
@@ -77,119 +54,147 @@ var testConfigExportPolicyVarsMinUpdated = func() config.Variables {
 	return updatedConfig
 }
 
-func TestAccExportPolicyMax(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccExportPolicyDestroy,
-		Steps: []resource.TestStep{
-			// Creation
-			{
-				ConfigVariables: testConfigExportPolicyVarsMax,
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
-					// check rule
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", ip_acl_1),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", ip_acl_2),
+// EXPORT POLICY - MAX
 
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
-				),
-			},
-			// data source
-			{
-				ConfigVariables: testConfigExportPolicyVarsMax,
-				Config: fmt.Sprintf(`
-					%s
-					%s
+const (
+	exportPolicyMaxIpAcl1       = "172.16.0.0/24"
+	exportPolicyMaxIpAcl2       = "172.16.0.250/32"
+	exportPolicyMaxIpAcl1Update = "172.17.0.0/24"
+	exportPolicyMaxIpAcl2Update = "172.17.0.250/32"
+)
 
-					data "stackit_sfs_export_policy" "policy_data_test" {
-					  project_id = stackit_sfs_export_policy.exportpolicy.project_id
-					  policy_id  = stackit_sfs_export_policy.exportpolicy.policy_id
-					}
-					`,
-					testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig,
-				),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
-					// check rule
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", ip_acl_1),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", ip_acl_2),
+var testConfigExportPolicyVarsMax = config.Variables{
+	"project_id": config.StringVariable(testutil.ProjectId),
+	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"rules": config.ListVariable(
+		config.ObjectVariable(map[string]config.Variable{
+			"ip_acl": config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1), config.StringVariable(exportPolicyMaxIpAcl2)),
+			"order":  config.IntegerVariable(1),
+		}),
+	),
+}
 
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
+var testConfigExportPolicyVarsMaxUpdated = func() config.Variables {
+	updatedConfig := config.Variables{}
+	maps.Copy(updatedConfig, testConfigExportPolicyVarsMax)
+	updatedConfig["rules"] = config.ListVariable(
+		config.ObjectVariable(map[string]config.Variable{
+			"ip_acl": config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1), config.StringVariable(exportPolicyMaxIpAcl2)),
+			"order":  config.IntegerVariable(1),
+		}),
+		config.ObjectVariable(map[string]config.Variable{
+			"ip_acl": config.ListVariable(config.StringVariable(exportPolicyMaxIpAcl1Update), config.StringVariable(exportPolicyMaxIpAcl2Update)),
+			"order":  config.IntegerVariable(2),
+		}),
+	)
+	return updatedConfig
+}
 
-					// data source
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
-				),
-			},
-			// Import
-			{
-				ConfigVariables: testConfigExportPolicyVarsMax,
-				ResourceName:    "stackit_sfs_export_policy.exportpolicy",
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					r, ok := s.RootModule().Resources["stackit_sfs_export_policy.exportpolicy"]
-					if !ok {
-						return "", fmt.Errorf("couldn't find resource stackit_sfs_export_policy.exportpolicy")
-					}
-					policyId, ok := r.Primary.Attributes["policy_id"]
-					if !ok {
-						return "", fmt.Errorf("couldn't find attribute policy_id")
-					}
-					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, testutil.Region, policyId), nil
-				},
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// Update
-			{
-				ConfigVariables: testConfigExportPolicyVarsMaxUpdated(),
-				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
-					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["name"])),
-					// check rules
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", ip_acl_1),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", ip_acl_2),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
+// Resource Pool - MIN
 
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.order", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", ip_acl_1_update),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", ip_acl_2_update),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "false"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", "true"),
-				),
-			},
-			// Deletion is done by the framework implicitly
-		},
-	})
+const (
+	resourcePoolMinIpAcl1       = "192.168.42.1/32"
+	resourcePoolMinIpAcl2       = "192.168.42.2/32"
+	resourcePoolMinIpAcl1Update = "172.17.0.0/24"
+	resourcePoolMinIpAcl2Update = "172.17.0.250/32"
+)
+
+var testConfigResourcePoolVarsMin = config.Variables{
+	"project_id": config.StringVariable(testutil.ProjectId),
+	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"acl": config.ListVariable(
+		config.StringVariable(resourcePoolMinIpAcl1),
+		config.StringVariable(resourcePoolMinIpAcl2),
+	),
+	"availability_zone": config.StringVariable("eu01-m"),
+	"performance_class": config.StringVariable("Standard"),
+	"size_gigabytes":    config.IntegerVariable(500),
+}
+
+var testConfigResourcePoolVarsMinUpdated = func() config.Variables {
+	updatedConfig := config.Variables{}
+	maps.Copy(updatedConfig, testConfigResourcePoolVarsMin)
+	updatedConfig["performance_class"] = config.StringVariable("Premium")
+	updatedConfig["acl"] = config.ListVariable(
+		config.StringVariable(resourcePoolMinIpAcl1Update),
+		config.StringVariable(resourcePoolMinIpAcl2Update),
+	)
+	return updatedConfig
+}
+
+// Resource Pool - MAX
+
+const (
+	resourcePoolMaxIpAcl1       = "192.168.42.1/32"
+	resourcePoolMaxIpAcl2       = "192.168.42.2/32"
+	resourcePoolMaxIpAcl1Update = "172.17.0.0/24"
+	resourcePoolMaxIpAcl2Update = "172.17.0.250/32"
+)
+
+var testConfigResourcePoolVarsMax = config.Variables{
+	"project_id": config.StringVariable(testutil.ProjectId),
+	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"acl": config.ListVariable(
+		config.StringVariable(resourcePoolMaxIpAcl1),
+		config.StringVariable(resourcePoolMaxIpAcl2),
+	),
+	"availability_zone":     config.StringVariable("eu01-m"),
+	"performance_class":     config.StringVariable("Standard"),
+	"size_gigabytes":        config.IntegerVariable(500),
+	"snapshots_are_visible": config.BoolVariable(true),
+}
+
+var testConfigResourcePoolVarsMaxUpdated = func() config.Variables {
+	updatedConfig := config.Variables{}
+	maps.Copy(updatedConfig, testConfigResourcePoolVarsMax)
+	updatedConfig["performance_class"] = config.StringVariable("Premium")
+	updatedConfig["snapshots_are_visible"] = config.BoolVariable(false)
+	updatedConfig["acl"] = config.ListVariable(
+		config.StringVariable(resourcePoolMaxIpAcl1Update),
+		config.StringVariable(resourcePoolMaxIpAcl2Update),
+	)
+	return updatedConfig
+}
+
+// Share - MIN
+
+var testConfigShareVarsMin = config.Variables{
+	"project_id":                 config.StringVariable(testutil.ProjectId),
+	"name":                       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"region":                     config.StringVariable("eu01"),
+	"resource_pool_name":         config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"space_hard_limit_gigabytes": config.IntegerVariable(42),
+}
+
+var testConfigShareVarsMinUpdated = func() config.Variables {
+	updatedConfig := config.Variables{}
+	maps.Copy(updatedConfig, testConfigShareVarsMin)
+	updatedConfig["space_hard_limit_gigabytes"] = config.IntegerVariable(50)
+	return updatedConfig
+}
+
+// Share - MAX
+
+var testConfigShareVarsMax = config.Variables{
+	"project_id":                 config.StringVariable(testutil.ProjectId),
+	"name":                       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"region":                     config.StringVariable("eu01"),
+	"resource_pool_name":         config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"space_hard_limit_gigabytes": config.IntegerVariable(42),
+	"export_policy_name":         config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+}
+
+var testConfigShareVarsMaxUpdated = func() config.Variables {
+	updatedConfig := config.Variables{}
+	maps.Copy(updatedConfig, testConfigShareVarsMax)
+	updatedConfig["space_hard_limit_gigabytes"] = config.IntegerVariable(50)
+	return updatedConfig
 }
 
 func TestAccExportPolicyMin(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccExportPolicyDestroy,
+		CheckDestroy:             testAccCheckDestroy,
 		Steps: []resource.TestStep{
 			// Creation
 			{
@@ -199,9 +204,11 @@ func TestAccExportPolicyMin(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "0"),
 				),
 			},
-			// data source
+			// Data source
 			{
 				ConfigVariables: testConfigExportPolicyVarsMin,
 				Config: fmt.Sprintf(`
@@ -220,6 +227,7 @@ func TestAccExportPolicyMin(t *testing.T) {
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
 
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "0"),
 					// data source
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
@@ -251,6 +259,475 @@ func TestAccExportPolicyMin(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMinUpdated()["name"])),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "0"),
+				),
+			},
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccExportPolicyMax(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy,
+		Steps: []resource.TestStep{
+			// Creation
+			{
+				ConfigVariables: testConfigExportPolicyVarsMax,
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
+				),
+			},
+			// Data source
+			{
+				ConfigVariables: testConfigExportPolicyVarsMax,
+				Config: fmt.Sprintf(`
+					%s
+					%s
+
+					data "stackit_sfs_export_policy" "policy_data_test" {
+					  project_id = stackit_sfs_export_policy.exportpolicy.project_id
+					  policy_id  = stackit_sfs_export_policy.exportpolicy.policy_id
+					}
+					`,
+					testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
+
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigExportPolicyVarsMax,
+				ResourceName:    "stackit_sfs_export_policy.exportpolicy",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					r, ok := s.RootModule().Resources["stackit_sfs_export_policy.exportpolicy"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find resource stackit_sfs_export_policy.exportpolicy")
+					}
+					policyId, ok := r.Primary.Attributes["policy_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute policy_id")
+					}
+					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, testutil.Region, policyId), nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update
+			{
+				ConfigVariables: testConfigExportPolicyVarsMaxUpdated(),
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["name"])),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyMaxIpAcl1),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyMaxIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
+
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.order", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", exportPolicyMaxIpAcl1Update),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", exportPolicyMaxIpAcl2Update),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "false"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", "true"),
+				),
+			},
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccResourcePoolResourceMin(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy,
+		Steps: []resource.TestStep{
+			// Creation
+			{
+				ConfigVariables: testConfigResourcePoolVarsMin,
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMinConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["availability_zone"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["performance_class"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["size_gigabytes"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMinIpAcl1),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMinIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", "false"),
+				),
+			},
+			// Data source
+			{
+				ConfigVariables: testConfigResourcePoolVarsMin,
+				Config: fmt.Sprintf(`
+					%s
+					%s
+
+					data "stackit_sfs_resource_pool" "resource_pool_ds" {
+					  project_id       = stackit_sfs_resource_pool.resourcepool.project_id
+					  resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
+					}
+					`,
+					testutil.SFSProviderConfig(), resourceResourcePoolMinConfig,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["availability_zone"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["performance_class"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["size_gigabytes"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMinIpAcl1),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMinIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", "false"),
+
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id"),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigResourcePoolVarsMin,
+				ResourceName:    "stackit_sfs_resource_pool.resourcepool",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					res, found := s.RootModule().Resources["stackit_sfs_resource_pool.resourcepool"]
+					if !found {
+						return "", fmt.Errorf("could not find resource stackit_sfs_resource_pool.resourcepool")
+					}
+					resourcepoolId, ok := res.Primary.Attributes["resource_pool_id"]
+					if !ok {
+						return "", fmt.Errorf("resource pool id attribute not found")
+					}
+					return testutil.ProjectId + "," + testutil.Region + "," + resourcepoolId, nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update
+			{
+				ConfigVariables: testConfigResourcePoolVarsMinUpdated(),
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMinConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["availability_zone"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["performance_class"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMinUpdated()["size_gigabytes"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMinIpAcl1Update),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMinIpAcl2Update),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", "false"),
+				),
+			},
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccResourcePoolResourceMax(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy,
+		Steps: []resource.TestStep{
+			// Creation
+			{
+				ConfigVariables: testConfigResourcePoolVarsMax,
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMaxConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["availability_zone"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["performance_class"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["size_gigabytes"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMaxIpAcl1),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMaxIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["snapshots_are_visible"])),
+				),
+			},
+			// Data source
+			{
+				ConfigVariables: testConfigResourcePoolVarsMax,
+				Config: fmt.Sprintf(`
+					%s
+					%s
+
+					data "stackit_sfs_resource_pool" "resource_pool_ds" {
+					  project_id       = stackit_sfs_resource_pool.resourcepool.project_id
+					  resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
+					}
+					`,
+					testutil.SFSProviderConfig(), resourceResourcePoolMaxConfig,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["availability_zone"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["performance_class"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["size_gigabytes"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMaxIpAcl1),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMaxIpAcl2),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["snapshots_are_visible"])),
+
+					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id"),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigResourcePoolVarsMax,
+				ResourceName:    "stackit_sfs_resource_pool.resourcepool",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					res, found := s.RootModule().Resources["stackit_sfs_resource_pool.resourcepool"]
+					if !found {
+						return "", fmt.Errorf("could not find resource stackit_sfs_resource_pool.resourcepool")
+					}
+					resourcepoolId, ok := res.Primary.Attributes["resource_pool_id"]
+					if !ok {
+						return "", fmt.Errorf("resource pool id attribute not found")
+					}
+					return testutil.ProjectId + "," + testutil.Region + "," + resourcepoolId, nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update
+			{
+				ConfigVariables: testConfigResourcePoolVarsMaxUpdated(),
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceResourcePoolMaxConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["availability_zone"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["performance_class"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["size_gigabytes"])),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", resourcePoolMaxIpAcl1Update),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", resourcePoolMaxIpAcl2Update),
+					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMaxUpdated()["snapshots_are_visible"])),
+				),
+			},
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccShareResourceMin(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy,
+		Steps: []resource.TestStep{
+			// Creation
+			{
+				ConfigVariables: testConfigShareVarsMin,
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMinConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMin["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMin["space_hard_limit_gigabytes"])),
+					resource.TestCheckNoResourceAttr("stackit_sfs_share.share", "export_policy"),
+				),
+			},
+			// Data source
+			{
+				ConfigVariables: testConfigShareVarsMin,
+				Config: fmt.Sprintf(`
+					%s
+					%s
+
+					data "stackit_sfs_share" "share_ds" {
+					  project_id       = stackit_sfs_resource_pool.resourcepool.project_id
+					  resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
+					  share_id         = stackit_sfs_share.share.share_id
+					}
+					`,
+					testutil.SFSProviderConfig(), resourceShareMinConfig,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMin["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMin["space_hard_limit_gigabytes"])),
+					resource.TestCheckNoResourceAttr("stackit_sfs_share.share", "export_policy"),
+
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "share_id"),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigShareVarsMin,
+				ResourceName:    "stackit_sfs_share.share",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					res, found := s.RootModule().Resources["stackit_sfs_share.share"]
+					if !found {
+						return "", fmt.Errorf("could not find resource stackit_sfs_share.share")
+					}
+					resourcepoolId, ok := res.Primary.Attributes["resource_pool_id"]
+					if !ok {
+						return "", fmt.Errorf("resource pool id attribute not found")
+					}
+					shareId, ok := res.Primary.Attributes["share_id"]
+					if !ok {
+						return "", fmt.Errorf("share id attribute not found")
+					}
+					return testutil.ProjectId + "," + testutil.Region + "," + resourcepoolId + "," + shareId, nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update
+			{
+				ConfigVariables: testConfigShareVarsMinUpdated(),
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMinConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMinUpdated()["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMinUpdated()["space_hard_limit_gigabytes"])),
+					resource.TestCheckNoResourceAttr("stackit_sfs_share.share", "export_policy"),
+				),
+			},
+			// Deletion is done by the framework implicitly
+		},
+	})
+}
+
+func TestAccShareResourceMax(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		CheckDestroy:             testAccCheckDestroy,
+		Steps: []resource.TestStep{
+			// Creation
+			{
+				ConfigVariables: testConfigShareVarsMax,
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMaxConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMax["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMax["space_hard_limit_gigabytes"])),
+					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
+						"stackit_sfs_export_policy.exportpolicy", "name"),
+				),
+			},
+			// Data source
+			{
+				ConfigVariables: testConfigShareVarsMax,
+				Config: fmt.Sprintf(`
+					%s
+					%s
+
+					data "stackit_sfs_share" "share_ds" {
+					  project_id       = stackit_sfs_resource_pool.resourcepool.project_id
+					  resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
+					  share_id         = stackit_sfs_share.share.share_id
+					}
+					`,
+					testutil.SFSProviderConfig(), resourceShareMaxConfig,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMax["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMax["space_hard_limit_gigabytes"])),
+					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
+						"stackit_sfs_export_policy.exportpolicy", "name"),
+
+					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "share_id"),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigShareVarsMax,
+				ResourceName:    "stackit_sfs_share.share",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					res, found := s.RootModule().Resources["stackit_sfs_share.share"]
+					if !found {
+						return "", fmt.Errorf("could not find resource stackit_sfs_share.share")
+					}
+					resourcepoolId, ok := res.Primary.Attributes["resource_pool_id"]
+					if !ok {
+						return "", fmt.Errorf("resource pool id attribute not found")
+					}
+					shareId, ok := res.Primary.Attributes["share_id"]
+					if !ok {
+						return "", fmt.Errorf("share id attribute not found")
+					}
+					return testutil.ProjectId + "," + testutil.Region + "," + resourcepoolId + "," + shareId, nil
+				},
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update
+			{
+				ConfigVariables: testConfigShareVarsMaxUpdated(),
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceShareMaxConfig),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
+					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testutil.ConvertConfigVariable(testConfigShareVarsMaxUpdated()["name"])),
+					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testutil.ConvertConfigVariable(testConfigShareVarsMaxUpdated()["space_hard_limit_gigabytes"])),
+					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
+						"stackit_sfs_export_policy.exportpolicy", "name"),
 				),
 			},
 			// Deletion is done by the framework implicitly
@@ -265,6 +742,24 @@ func createClient() (*sfs.APIClient, error) {
 	}
 
 	return client, nil
+}
+
+func testAccCheckDestroy(s *terraform.State) error {
+	checkFunctions := []func(s *terraform.State) error{
+		testAccExportPolicyDestroy,
+		testAccResourcePoolDestroyed,
+	}
+	var errs []error
+
+	for _, f := range checkFunctions {
+		func() {
+			err := f(s)
+			if err != nil {
+				errs = append(errs, err)
+			}
+		}()
+	}
+	return errors.Join(errs...)
 }
 
 func testAccExportPolicyDestroy(s *terraform.State) error {
@@ -297,6 +792,56 @@ func testAccExportPolicyDestroy(s *terraform.State) error {
 			_, err := client.DefaultAPI.DeleteShareExportPolicy(ctx, testutil.ProjectId, testutil.Region, id).Execute()
 			if err != nil {
 				return fmt.Errorf("deleting policy %s during CheckDestroy: %w", *policies[i].Id, err)
+			}
+		}
+	}
+	return nil
+}
+
+func testAccResourcePoolDestroyed(s *terraform.State) error {
+	ctx := context.Background()
+	client, err := createClient()
+	if err != nil {
+		return err
+	}
+
+	resourcePoolsToDestroy := []string{}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "stackit_sfs_resource_pool" {
+			continue
+		}
+		// export policy transform id: "[projectId],[resource_pool_id]"
+		resourcePoolId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		resourcePoolsToDestroy = append(resourcePoolsToDestroy, resourcePoolId)
+	}
+
+	resourcePoolsResp, err := client.ListResourcePoolsExecute(ctx, testutil.ProjectId, testutil.Region)
+	if err != nil {
+		return fmt.Errorf("getting resource pools: %w", err)
+	}
+
+	// iterate over policiesResp
+	for _, pool := range resourcePoolsResp.GetResourcePools() {
+		id := pool.Id
+
+		if utils.Contains(resourcePoolsToDestroy, *id) {
+			shares, err := client.ListSharesExecute(ctx, testutil.ProjectId, testutil.Region, *id)
+			if err != nil {
+				return fmt.Errorf("cannot list shares: %w", err)
+			}
+			if shares.Shares != nil {
+				for _, share := range *shares.Shares {
+					_, err := client.DeleteShareExecute(ctx, testutil.ProjectId, testutil.Region, *id, *share.Id)
+					if err != nil {
+						return fmt.Errorf("cannot delete share %q in pool %q: %w", *share.Id, *id, err)
+					}
+				}
+			}
+
+			_, err = client.DeleteResourcePool(ctx, testutil.ProjectId, testutil.Region, *id).
+				Execute()
+			if err != nil {
+				return fmt.Errorf("deleting resourcepool %s during CheckDestroy: %w", *pool.Id, err)
 			}
 		}
 	}

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -234,8 +234,14 @@ func TestAccExportPolicyMin(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "region", testutil.Region),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "id"),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_export_policy.policy_data_test", "id",
+						"stackit_sfs_export_policy.exportpolicy", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_export_policy.policy_data_test", "policy_id",
+						"stackit_sfs_export_policy.exportpolicy", "policy_id",
+					),
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
 
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.#", "0"),
@@ -327,8 +333,14 @@ func TestAccExportPolicyMax(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "region", testutil.Region),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "id"),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_export_policy.policy_data_test", "id",
+						"stackit_sfs_export_policy.exportpolicy", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_export_policy.policy_data_test", "policy_id",
+						"stackit_sfs_export_policy.exportpolicy", "policy_id",
+					),
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
 
 					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "rules.#", "1"),
@@ -442,8 +454,14 @@ func TestAccResourcePoolResourceMin(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "region", testutil.Region),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "id"),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_resource_pool.resource_pool_ds", "id",
+						"stackit_sfs_resource_pool.resourcepool", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["name"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["availability_zone"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMin["performance_class"])),
@@ -542,8 +560,14 @@ func TestAccResourcePoolResourceMax(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "region", testutil.Region),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "id"),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_resource_pool.resource_pool_ds", "id",
+						"stackit_sfs_resource_pool.resourcepool", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id",
+						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
+					),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "name", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["name"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "availability_zone", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["availability_zone"])),
 					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "performance_class", testutil.ConvertConfigVariable(testConfigResourcePoolVarsMax["performance_class"])),
@@ -643,8 +667,14 @@ func TestAccShareResourceMin(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "region", testutil.Region),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "id"),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_share.share_ds", "id",
+						"stackit_sfs_share.share", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_share.share_ds", "share_id",
+						"stackit_sfs_share.share", "share_id",
+					),
 					resource.TestCheckResourceAttrPair(
 						"data.stackit_sfs_share.share_ds", "resource_pool_id",
 						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",
@@ -751,8 +781,14 @@ func TestAccShareResourceMax(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "region", testutil.Region),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "id"),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "share_id"),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_share.share_ds", "id",
+						"stackit_sfs_share.share", "id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"data.stackit_sfs_share.share_ds", "share_id",
+						"stackit_sfs_share.share", "share_id",
+					),
 					resource.TestCheckResourceAttrPair(
 						"data.stackit_sfs_share.share_ds", "resource_pool_id",
 						"stackit_sfs_resource_pool.resourcepool", "resource_pool_id",

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -2,11 +2,13 @@ package sfs_test
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
+	"maps"
 	"strings"
 	"testing"
-	"text/template"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -17,206 +19,83 @@ import (
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
 
-var exportPolicyResource = map[string]string{
-	"name":            fmt.Sprintf("acc-sfs-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-	"project_id":      testutil.ProjectId,
-	"region":          "eu01",
-	"ip_acl_1":        "172.16.0.0/24",
-	"ip_acl_2":        "172.16.0.250/32",
-	"ip_acl_1_update": "172.17.0.0/24",
-	"ip_acl_2_update": "172.17.0.250/32",
-}
-
-func resourceConfigExportPolicy() string {
-	return fmt.Sprintf(`
-		%s
-
-		resource "stackit_sfs_export_policy" "exportpolicy" {
-		project_id        = "%s"
-		name              = "%s"
-		rules = [
-			{
-			ip_acl = [%q, %q]
-			order = 1
-			}
-		]
-		}
-	`,
-		testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(),
-		exportPolicyResource["project_id"],
-		exportPolicyResource["name"],
-		exportPolicyResource["ip_acl_1"],
-		exportPolicyResource["ip_acl_2"],
-	)
-}
-
-func resourceConfigUpdateExportPolicy() string {
-	return fmt.Sprintf(`
-		%s
-
-		resource "stackit_sfs_export_policy" "exportpolicy" {
-		project_id        = "%s"
-		name              = "%s"
-		rules = [
-			{
-			ip_acl = [%q, %q]
-			order = 1
-			},
-			{
-			ip_acl = [%q, %q]
-			order = 2
-			}
-		]
-		}
-	`,
-		testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(),
-		exportPolicyResource["project_id"],
-		exportPolicyResource["name"],
-		exportPolicyResource["ip_acl_1"],
-		exportPolicyResource["ip_acl_2"],
-		exportPolicyResource["ip_acl_1_update"],
-		exportPolicyResource["ip_acl_2_update"],
-	)
-}
-
 var (
-	testCreateResourcePool = map[string]string{
-		"providerConfig":        testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(),
-		"name":                  fmt.Sprintf("acc-sfs-resource-pool-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-		"project_id":            testutil.ProjectId,
-		"availability_zone":     "eu01-m",
-		"performance_class":     "Standard",
-		"acl":                   `["192.168.42.1/32", "192.168.42.2/32"]`,
-		"size_gigabytes":        "500",
-		"snapshots_are_visible": "true",
-	}
+	//go:embed testdata/export-policy-max.tf
+	resourceExportPolicyMaxConfig string
 
-	testUpdateResourcePool = map[string]string{
-		"providerConfig":        testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(),
-		"name":                  fmt.Sprintf("acc-sfs-resource-pool-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-		"project_id":            testutil.ProjectId,
-		"availability_zone":     "eu01-m",
-		"performance_class":     "Premium",
-		"acl":                   `["192.168.52.1/32", "192.168.52.2/32"]`,
-		"size_gigabytes":        "500",
-		"snapshots_are_visible": "false",
-	}
+	//go:embed testdata/export-policy-min.tf
+	resourceExportPolicyMinConfig string
 )
 
-func resourcePoolConfig(configParams map[string]string) string {
-	tmpl := template.Must(template.New("config").
-		Parse(`
-		{{.providerConfig}}
-
-		resource "stackit_sfs_resource_pool" "resourcepool" {
-			project_id        =  "{{.project_id}}"
-			name              = "{{.name}}"
-			availability_zone = "{{.availability_zone}}"
-			performance_class = "{{.performance_class}}"
-			size_gigabytes = {{.size_gigabytes}}
-			ip_acl = {{.acl}}
-			snapshots_are_visible = {{.snapshots_are_visible}}
-		}
-		
-		data "stackit_sfs_resource_pool" "resource_pool_ds" {
-			project_id      = stackit_sfs_resource_pool.resourcepool.project_id
-			resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
-		}
-	`))
-	var buffer strings.Builder
-	if err := tmpl.ExecuteTemplate(&buffer, "config", configParams); err != nil {
-		panic(fmt.Sprintf("cannot render template: %v", err))
-	}
-	return buffer.String()
-}
+// EXPORT POLICY - MAX
 
 var (
-	testCreateShare = map[string]string{
-		"providerConfig":             testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(),
-		"resource_pool_name":         fmt.Sprintf("acc-sfs-resource-pool-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-		"name":                       fmt.Sprintf("acc-sfs-share-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-		"project_id":                 testutil.ProjectId,
-		"region":                     "eu01",
-		"space_hard_limit_gigabytes": "42",
-	}
-
-	testUpdateShare = map[string]string{
-		"providerConfig":             testutil.NewConfigBuilder().EnableBetaResources(true).BuildProviderConfig(),
-		"resource_pool_name":         fmt.Sprintf("acc-sfs-resource-pool-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-		"name":                       fmt.Sprintf("acc-sfs-share-%s", acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)),
-		"project_id":                 testutil.ProjectId,
-		"region":                     "eu02",
-		"space_hard_limit_gigabytes": "42",
-	}
+	ip_acl_1        = "172.16.0.0/24"
+	ip_acl_2        = "172.16.0.250/32"
+	ip_acl_1_update = "172.17.0.0/24"
+	ip_acl_2_update = "172.17.0.250/32"
 )
 
-func nsfShareConfig(configParams map[string]string) string {
-	tmpl := template.Must(template.New("config").
-		Parse(`
-		{{.providerConfig}}
-
-
-		resource "stackit_sfs_resource_pool" "resourcepool" {
-			project_id        =  "{{.project_id}}"
-			name              = "{{.resource_pool_name}}"
-			availability_zone = "eu01-m"
-			performance_class = "Standard"
-			size_gigabytes = 512
-			ip_acl = ["192.168.42.1/32"]
-			region = "eu01"
-		}
-
-		resource "stackit_sfs_export_policy" "exportpolicy" {
-			project_id        = "{{.project_id}}"
-			name              = "{{.name}}"
-			rules = [
-				{
-					ip_acl = ["192.168.2.0/24"]
-					order = 1
-				}
-			]
-		}
-
-		resource "stackit_sfs_share" "share" {
-			project_id                 =  "{{.project_id}}"
-			resource_pool_id            = stackit_sfs_resource_pool.resourcepool.resource_pool_id
-			name                       = "{{.name}}"
-			export_policy              = stackit_sfs_export_policy.exportpolicy.name
-			space_hard_limit_gigabytes = {{.space_hard_limit_gigabytes}}
-		}
-
-		data "stackit_sfs_share" "share_ds" {
-			project_id        =  "{{.project_id}}"
-			resource_pool_id = stackit_sfs_resource_pool.resourcepool.resource_pool_id
-			share_id     = stackit_sfs_share.share.share_id
-		}
-
-	`))
-	var buffer strings.Builder
-	if err := tmpl.ExecuteTemplate(&buffer, "config", configParams); err != nil {
-		panic(fmt.Sprintf("cannot render template: %v", err))
-	}
-	return buffer.String()
+var testConfigExportPolicyVarsMax = config.Variables{
+	"project_id": config.StringVariable(testutil.ProjectId),
+	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+	"rules": config.ListVariable(
+		config.ObjectVariable(map[string]config.Variable{
+			"ip_acl": config.ListVariable(config.StringVariable(ip_acl_1), config.StringVariable(ip_acl_2)),
+			"order":  config.IntegerVariable(1),
+		}),
+	),
 }
 
-func TestAccExportPolicyResource(t *testing.T) {
+var testConfigExportPolicyVarsMaxUpdated = func() config.Variables {
+	updatedConfig := config.Variables{}
+	maps.Copy(updatedConfig, testConfigExportPolicyVarsMax)
+	updatedConfig["rules"] = config.ListVariable(
+		config.ObjectVariable(map[string]config.Variable{
+			"ip_acl": config.ListVariable(config.StringVariable(ip_acl_1), config.StringVariable(ip_acl_2)),
+			"order":  config.IntegerVariable(1),
+		}),
+		config.ObjectVariable(map[string]config.Variable{
+			"ip_acl": config.ListVariable(config.StringVariable(ip_acl_1_update), config.StringVariable(ip_acl_2_update)),
+			"order":  config.IntegerVariable(2),
+		}),
+	)
+	return updatedConfig
+}
+
+// EXPORT POLICY - MIN
+
+var testConfigExportPolicyVarsMin = config.Variables{
+	"project_id": config.StringVariable(testutil.ProjectId),
+	"name":       config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha)),
+}
+
+var testConfigExportPolicyVarsMinUpdated = func() config.Variables {
+	updatedConfig := config.Variables{}
+	maps.Copy(updatedConfig, testConfigExportPolicyVarsMin)
+	updatedConfig["name"] = config.StringVariable("tf-acc-updated")
+	return updatedConfig
+}
+
+func TestAccExportPolicyMax(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
 		CheckDestroy:             testAccExportPolicyDestroy,
 		Steps: []resource.TestStep{
 			// Creation
 			{
-				Config: resourceConfigExportPolicy(),
+				ConfigVariables: testConfigExportPolicyVarsMax,
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", exportPolicyResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", exportPolicyResource["name"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
 					// check rule
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyResource["ip_acl_1"]),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyResource["ip_acl_2"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", ip_acl_1),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", ip_acl_2),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
@@ -225,40 +104,42 @@ func TestAccExportPolicyResource(t *testing.T) {
 			},
 			// data source
 			{
+				ConfigVariables: testConfigExportPolicyVarsMax,
 				Config: fmt.Sprintf(`
-									%s
+					%s
+					%s
 
-									data "stackit_sfs_export_policy" "policy_data_test" {
-										project_id  = stackit_sfs_export_policy.exportpolicy.project_id
-										policy_id  = stackit_sfs_export_policy.exportpolicy.policy_id
-									}
-
-									`,
-					resourceConfigExportPolicy(),
+					data "stackit_sfs_export_policy" "policy_data_test" {
+					  project_id = stackit_sfs_export_policy.exportpolicy.project_id
+					  policy_id  = stackit_sfs_export_policy.exportpolicy.policy_id
+					}
+					`,
+					testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", exportPolicyResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", exportPolicyResource["name"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMax["name"])),
 					// check rule
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyResource["ip_acl_1"]),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyResource["ip_acl_2"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", ip_acl_1),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", ip_acl_2),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
 
 					// data source
-					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", exportPolicyResource["project_id"]),
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
 				),
 			},
 			// Import
 			{
-				ResourceName: "stackit_sfs_export_policy.exportpolicy",
+				ConfigVariables: testConfigExportPolicyVarsMax,
+				ResourceName:    "stackit_sfs_export_policy.exportpolicy",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_sfs_export_policy.exportpolicy"]
 					if !ok {
@@ -275,25 +156,26 @@ func TestAccExportPolicyResource(t *testing.T) {
 			},
 			// Update
 			{
-				Config: resourceConfigUpdateExportPolicy(),
+				ConfigVariables: testConfigExportPolicyVarsMaxUpdated(),
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMaxConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", exportPolicyResource["project_id"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
 					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", exportPolicyResource["name"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMaxUpdated()["name"])),
 					// check rules
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.#", "2"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.order", "1"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", exportPolicyResource["ip_acl_1"]),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", exportPolicyResource["ip_acl_2"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.0", ip_acl_1),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.ip_acl.1", ip_acl_2),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.read_only", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.set_uuid", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.0.super_user", "true"),
 
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.order", "2"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", exportPolicyResource["ip_acl_1_update"]),
-					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", exportPolicyResource["ip_acl_2_update"]),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.0", ip_acl_1_update),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.ip_acl.1", ip_acl_2_update),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.read_only", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.set_uuid", "false"),
 					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "rules.1.super_user", "true"),
@@ -304,128 +186,74 @@ func TestAccExportPolicyResource(t *testing.T) {
 	})
 }
 
-func TestAccResourcePoolResource(t *testing.T) {
+func TestAccExportPolicyMin(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccResourcePoolDestroyed,
+		CheckDestroy:             testAccExportPolicyDestroy,
 		Steps: []resource.TestStep{
 			// Creation
 			{
-				Config: resourcePoolConfig(testCreateResourcePool),
+				ConfigVariables: testConfigExportPolicyVarsMin,
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testCreateResourcePool["project_id"]),
-					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testCreateResourcePool["name"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testCreateResourcePool["availability_zone"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testCreateResourcePool["performance_class"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testCreateResourcePool["size_gigabytes"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", "192.168.42.1/32"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", "192.168.42.2/32"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "snapshots_are_visible", testCreateResourcePool["snapshots_are_visible"]),
-
-					// datasource
-					resource.TestCheckResourceAttr("data.stackit_sfs_resource_pool.resource_pool_ds", "project_id", testCreateResourcePool["project_id"]),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_resource_pool.resource_pool_ds", "resource_pool_id"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
 				),
 			},
+			// data source
+			{
+				ConfigVariables: testConfigExportPolicyVarsMin,
+				Config: fmt.Sprintf(`
+					%s
+					%s
 
-			{ // import
-				ResourceName: "stackit_sfs_resource_pool.resourcepool",
+					data "stackit_sfs_export_policy" "policy_data_test" {
+					  project_id = stackit_sfs_export_policy.exportpolicy.project_id
+					  policy_id  = stackit_sfs_export_policy.exportpolicy.policy_id
+					}
+					`,
+					testutil.SFSProviderConfig(), resourceExportPolicyMinConfig,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMin["name"])),
+
+					// data source
+					resource.TestCheckResourceAttr("data.stackit_sfs_export_policy.policy_data_test", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("data.stackit_sfs_export_policy.policy_data_test", "policy_id"),
+				),
+			},
+			// Import
+			{
+				ConfigVariables: testConfigExportPolicyVarsMin,
+				ResourceName:    "stackit_sfs_export_policy.exportpolicy",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					res, found := s.RootModule().Resources["stackit_sfs_resource_pool.resourcepool"]
-					if !found {
-						return "", fmt.Errorf("could not find resource stackit_sfs_resource_pool.resourcepool")
-					}
-					resourcepoolId, ok := res.Primary.Attributes["resource_pool_id"]
+					r, ok := s.RootModule().Resources["stackit_sfs_export_policy.exportpolicy"]
 					if !ok {
-						return "", fmt.Errorf("resource pool id attribute not found")
+						return "", fmt.Errorf("couldn't find resource stackit_sfs_export_policy.exportpolicy")
 					}
-					return testCreateResourcePool["project_id"] + "," + testutil.Region + "," + resourcepoolId, nil
+					policyId, ok := r.Primary.Attributes["policy_id"]
+					if !ok {
+						return "", fmt.Errorf("couldn't find attribute policy_id")
+					}
+					return fmt.Sprintf("%s,%s,%s", testutil.ProjectId, testutil.Region, policyId), nil
 				},
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-
 			// Update
 			{
-				Config: resourcePoolConfig(testUpdateResourcePool),
+				ConfigVariables: testConfigExportPolicyVarsMinUpdated(),
+				Config:          fmt.Sprintf("%s\n%s", testutil.SFSProviderConfig(), resourceExportPolicyMinConfig),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// resource
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "project_id", testUpdateResourcePool["project_id"]),
-					resource.TestCheckResourceAttrSet("stackit_sfs_resource_pool.resourcepool", "resource_pool_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "name", testUpdateResourcePool["name"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "availability_zone", testUpdateResourcePool["availability_zone"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "performance_class", testUpdateResourcePool["performance_class"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "size_gigabytes", testUpdateResourcePool["size_gigabytes"]),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.#", "2"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.0", "192.168.52.1/32"),
-					resource.TestCheckResourceAttr("stackit_sfs_resource_pool.resourcepool", "ip_acl.1", "192.168.52.2/32"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "project_id", testutil.ProjectId),
+					resource.TestCheckResourceAttrSet("stackit_sfs_export_policy.exportpolicy", "id"),
+					resource.TestCheckResourceAttr("stackit_sfs_export_policy.exportpolicy", "name", testutil.ConvertConfigVariable(testConfigExportPolicyVarsMinUpdated()["name"])),
 				),
 			},
-		},
-	})
-}
-
-func TestAccShareResource(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
-		CheckDestroy:             testAccResourcePoolDestroyed,
-		Steps: []resource.TestStep{
-			// Creation
-			{
-				Config: nsfShareConfig(testCreateShare),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testCreateShare["project_id"]),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testCreateShare["name"]),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testCreateShare["space_hard_limit_gigabytes"]),
-					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
-						"stackit_sfs_export_policy.exportpolicy", "name"),
-
-					// datasource
-					resource.TestCheckResourceAttr("data.stackit_sfs_share.share_ds", "project_id", testCreateResourcePool["project_id"]),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "resource_pool_id"),
-					resource.TestCheckResourceAttrSet("data.stackit_sfs_share.share_ds", "share_id"),
-				),
-			},
-
-			{ // import
-				ResourceName: "stackit_sfs_share.share",
-				ImportStateIdFunc: func(s *terraform.State) (string, error) {
-					res, found := s.RootModule().Resources["stackit_sfs_share.share"]
-					if !found {
-						return "", fmt.Errorf("could not find resource stackit_sfs_share.share")
-					}
-					resourcepoolId, ok := res.Primary.Attributes["resource_pool_id"]
-					if !ok {
-						return "", fmt.Errorf("resource pool id attribute not found")
-					}
-					shareId, ok := res.Primary.Attributes["share_id"]
-					if !ok {
-						return "", fmt.Errorf("share id attribute not found")
-					}
-					return testCreateResourcePool["project_id"] + "," + testutil.Region + "," + resourcepoolId + "," + shareId, nil
-				},
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-
-			// Update
-			{
-				Config: nsfShareConfig(testUpdateShare),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// resource
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "project_id", testUpdateShare["project_id"]),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "resource_pool_id"),
-					resource.TestCheckResourceAttrSet("stackit_sfs_share.share", "share_id"),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "name", testUpdateShare["name"]),
-					resource.TestCheckResourceAttr("stackit_sfs_share.share", "space_hard_limit_gigabytes", testUpdateShare["space_hard_limit_gigabytes"]),
-					resource.TestCheckResourceAttrPair("stackit_sfs_share.share", "export_policy",
-						"stackit_sfs_export_policy.exportpolicy", "name"),
-				),
-			},
+			// Deletion is done by the framework implicitly
 		},
 	})
 }
@@ -456,7 +284,7 @@ func testAccExportPolicyDestroy(s *terraform.State) error {
 		policyToDestroy = append(policyToDestroy, policyId)
 	}
 
-	policiesResp, err := client.DefaultAPI.ListShareExportPolicies(ctx, testutil.ProjectId, exportPolicyResource["region"]).Execute()
+	policiesResp, err := client.DefaultAPI.ListShareExportPolicies(ctx, testutil.ProjectId, testutil.Region).Execute()
 	if err != nil {
 		return fmt.Errorf("getting policiesResp: %w", err)
 	}
@@ -466,60 +294,9 @@ func testAccExportPolicyDestroy(s *terraform.State) error {
 	for i := range policies {
 		id := *policies[i].Id
 		if utils.Contains(policyToDestroy, id) {
-			_, err := client.DefaultAPI.DeleteShareExportPolicy(ctx, testutil.ProjectId, exportPolicyResource["region"], id).Execute()
+			_, err := client.DefaultAPI.DeleteShareExportPolicy(ctx, testutil.ProjectId, testutil.Region, id).Execute()
 			if err != nil {
 				return fmt.Errorf("deleting policy %s during CheckDestroy: %w", *policies[i].Id, err)
-			}
-		}
-	}
-	return nil
-}
-
-func testAccResourcePoolDestroyed(s *terraform.State) error {
-	ctx := context.Background()
-	client, err := createClient()
-	if err != nil {
-		return err
-	}
-
-	resourcePoolsToDestroy := []string{}
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "stackit_sfs_resource_pool" {
-			continue
-		}
-		// export policy transform id: "[projectId],[resource_pool_id]"
-		resourcePoolId := strings.Split(rs.Primary.ID, core.Separator)[1]
-		resourcePoolsToDestroy = append(resourcePoolsToDestroy, resourcePoolId)
-	}
-
-	region := testutil.Region
-	resourcePoolsResp, err := client.DefaultAPI.ListResourcePools(ctx, testutil.ProjectId, region).Execute()
-	if err != nil {
-		return fmt.Errorf("getting resource pools: %w", err)
-	}
-
-	// iterate over policiesResp
-	for _, pool := range resourcePoolsResp.GetResourcePools() {
-		id := pool.Id
-
-		if utils.Contains(resourcePoolsToDestroy, *id) {
-			shares, err := client.DefaultAPI.ListShares(ctx, testutil.ProjectId, region, *id).Execute()
-			if err != nil {
-				return fmt.Errorf("cannot list shares: %w", err)
-			}
-			if shares.Shares != nil {
-				for _, share := range shares.Shares {
-					_, err := client.DefaultAPI.DeleteShare(ctx, testutil.ProjectId, region, *id, *share.Id).Execute()
-					if err != nil {
-						return fmt.Errorf("cannot delete share %q in pool %q: %w", *share.Id, *id, err)
-					}
-				}
-			}
-
-			_, err = client.DefaultAPI.DeleteResourcePool(ctx, testutil.ProjectId, region, *id).
-				Execute()
-			if err != nil {
-				return fmt.Errorf("deleting resourcepool %s during CheckDestroy: %w", *pool.Id, err)
 			}
 		}
 	}

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -919,7 +919,7 @@ func testAccResourcePoolDestroyed(s *terraform.State) error {
 		resourcePoolsToDestroy = append(resourcePoolsToDestroy, resourcePoolId)
 	}
 
-	resourcePoolsResp, err := client.ListResourcePoolsExecute(ctx, testutil.ProjectId, testutil.Region)
+	resourcePoolsResp, err := client.DefaultAPI.ListResourcePools(ctx, testutil.ProjectId, testutil.Region).Execute()
 	if err != nil {
 		return fmt.Errorf("getting resource pools: %w", err)
 	}
@@ -929,20 +929,20 @@ func testAccResourcePoolDestroyed(s *terraform.State) error {
 		id := pool.Id
 
 		if utils.Contains(resourcePoolsToDestroy, *id) {
-			shares, err := client.ListSharesExecute(ctx, testutil.ProjectId, testutil.Region, *id)
+			shares, err := client.DefaultAPI.ListShares(ctx, testutil.ProjectId, testutil.Region, *id).Execute()
 			if err != nil {
 				return fmt.Errorf("cannot list shares: %w", err)
 			}
 			if shares.Shares != nil {
-				for _, share := range *shares.Shares {
-					_, err := client.DeleteShareExecute(ctx, testutil.ProjectId, testutil.Region, *id, *share.Id)
+				for _, share := range shares.Shares {
+					_, err := client.DefaultAPI.DeleteShare(ctx, testutil.ProjectId, testutil.Region, *id, *share.Id).Execute()
 					if err != nil {
 						return fmt.Errorf("cannot delete share %q in pool %q: %w", *share.Id, *id, err)
 					}
 				}
 			}
 
-			_, err = client.DeleteResourcePool(ctx, testutil.ProjectId, testutil.Region, *id).
+			_, err = client.DefaultAPI.DeleteResourcePool(ctx, testutil.ProjectId, testutil.Region, *id).
 				Execute()
 			if err != nil {
 				return fmt.Errorf("deleting resourcepool %s during CheckDestroy: %w", *pool.Id, err)

--- a/stackit/internal/services/sfs/share/datasource.go
+++ b/stackit/internal/services/sfs/share/datasource.go
@@ -159,14 +159,14 @@ func (r *shareDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 			},
 			"export_policy": schema.StringAttribute{
 				Description: `Name of the Share Export Policy to use in the Share.
-Note that if this is not set, the Share can only be mounted in read only by 
-clients with IPs matching the IP ACL of the Resource Pool hosting this Share. 
+Note that if this is not set, the Share can only be mounted in read only by
+clients with IPs matching the IP ACL of the Resource Pool hosting this Share.
 You can also assign a Share Export Policy after creating the Share`,
 				Computed: true,
 			},
 			"space_hard_limit_gigabytes": schema.Int32Attribute{
 				Computed: true,
-				Description: `Space hard limit for the Share. 
+				Description: `Space hard limit for the Share.
 				If zero, the Share will have access to the full space of the Resource Pool it lives in.
 				(unit: gigabytes)`,
 			},
@@ -208,8 +208,10 @@ func mapDataSourceFields(_ context.Context, region string, share *sfs.Share, mod
 		utils.Coalesce(model.ShareId, types.StringPointerValue(share.Id)).ValueString(),
 	)
 	model.Name = types.StringPointerValue(share.Name)
-	if policy := share.ExportPolicy.Get(); policy != nil {
-		model.ExportPolicyName = types.StringPointerValue(policy.Name)
+	if share.ExportPolicy != nil {
+		if policy := share.ExportPolicy.Get(); policy != nil {
+			model.ExportPolicyName = types.StringPointerValue(policy.Name)
+		}
 	}
 
 	model.SpaceHardLimitGigabytes = types.Int32PointerValue(share.SpaceHardLimitGigabytes)

--- a/stackit/internal/services/sfs/share/datasource.go
+++ b/stackit/internal/services/sfs/share/datasource.go
@@ -208,7 +208,7 @@ func mapDataSourceFields(_ context.Context, region string, share *sfs.Share, mod
 		utils.Coalesce(model.ShareId, types.StringPointerValue(share.Id)).ValueString(),
 	)
 	model.Name = types.StringPointerValue(share.Name)
-	if share.ExportPolicy != nil {
+	if share.ExportPolicy.IsSet() {
 		if policy := share.ExportPolicy.Get(); policy != nil {
 			model.ExportPolicyName = types.StringPointerValue(policy.Name)
 		}

--- a/stackit/internal/services/sfs/share/resource.go
+++ b/stackit/internal/services/sfs/share/resource.go
@@ -496,7 +496,7 @@ func mapFields(_ context.Context, share *sfs.Share, region string, model *Model)
 	)
 	model.Name = types.StringPointerValue(share.Name)
 
-	if share.ExportPolicy != nil {
+	if share.ExportPolicy.IsSet() {
 		if policy := share.ExportPolicy.Get(); policy != nil {
 			model.ExportPolicyName = types.StringPointerValue(policy.Name)
 		}

--- a/stackit/internal/services/sfs/share/resource.go
+++ b/stackit/internal/services/sfs/share/resource.go
@@ -178,14 +178,14 @@ func (r *shareResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"export_policy": schema.StringAttribute{
 				Description: `Name of the Share Export Policy to use in the Share.
-Note that if this is set to an empty string, the Share can only be mounted in read only by 
-clients with IPs matching the IP ACL of the Resource Pool hosting this Share. 
+Note that if this is set to an empty string, the Share can only be mounted in read only by
+clients with IPs matching the IP ACL of the Resource Pool hosting this Share.
 You can also assign a Share Export Policy after creating the Share`,
-				Required: true,
+				Optional: true,
 			},
 			"space_hard_limit_gigabytes": schema.Int32Attribute{
 				Required: true,
-				Description: `Space hard limit for the Share. 
+				Description: `Space hard limit for the Share.
 				If zero, the Share will have access to the full space of the Resource Pool it lives in.
 				(unit: gigabytes)`,
 			},
@@ -496,8 +496,10 @@ func mapFields(_ context.Context, share *sfs.Share, region string, model *Model)
 	)
 	model.Name = types.StringPointerValue(share.Name)
 
-	if policy := share.ExportPolicy.Get(); policy != nil {
-		model.ExportPolicyName = types.StringPointerValue(policy.Name)
+	if share.ExportPolicy != nil {
+		if policy := share.ExportPolicy.Get(); policy != nil {
+			model.ExportPolicyName = types.StringPointerValue(policy.Name)
+		}
 	}
 
 	model.SpaceHardLimitGigabytes = types.Int32PointerValue(share.SpaceHardLimitGigabytes)

--- a/stackit/internal/services/sfs/testdata/export-policy-max.tf
+++ b/stackit/internal/services/sfs/testdata/export-policy-max.tf
@@ -1,0 +1,10 @@
+
+variable "project_id" {}
+variable "name" {}
+variable "rules" {}
+
+resource "stackit_sfs_export_policy" "exportpolicy" {
+  project_id = var.project_id
+  name       = var.name
+  rules      = var.rules
+}

--- a/stackit/internal/services/sfs/testdata/export-policy-max.tf
+++ b/stackit/internal/services/sfs/testdata/export-policy-max.tf
@@ -2,9 +2,11 @@
 variable "project_id" {}
 variable "name" {}
 variable "rules" {}
+variable "region" {}
 
 resource "stackit_sfs_export_policy" "exportpolicy" {
   project_id = var.project_id
   name       = var.name
   rules      = var.rules
+  region     = var.region
 }

--- a/stackit/internal/services/sfs/testdata/export-policy-max.tf
+++ b/stackit/internal/services/sfs/testdata/export-policy-max.tf
@@ -2,11 +2,34 @@
 variable "project_id" {}
 variable "region" {}
 variable "name" {}
-variable "rules" {}
+variable "first_rule_description" {}
+variable "first_rule_ip_acl_1" {}
+variable "first_rule_ip_acl_2" {}
+variable "first_rule_set_uuid" {}
+variable "second_rule_ip_acl_1" {}
+variable "second_rule_ip_acl_2" {}
+variable "second_rule_read_only" {}
+variable "second_rule_super_user" {}
 
 resource "stackit_sfs_export_policy" "exportpolicy" {
   project_id = var.project_id
   region     = var.region
   name       = var.name
-  rules      = var.rules
+  rules = [{
+    order       = 1
+    description = var.first_rule_description
+    ip_acl = [
+      var.first_rule_ip_acl_1,
+      var.first_rule_ip_acl_2
+    ]
+    set_uuid = var.first_rule_set_uuid
+    }, {
+    order = 2
+    ip_acl = [
+      var.second_rule_ip_acl_1,
+      var.second_rule_ip_acl_2
+    ]
+    read_only  = var.second_rule_read_only
+    super_user = var.second_rule_super_user
+  }]
 }

--- a/stackit/internal/services/sfs/testdata/export-policy-max.tf
+++ b/stackit/internal/services/sfs/testdata/export-policy-max.tf
@@ -1,12 +1,12 @@
 
 variable "project_id" {}
+variable "region" {}
 variable "name" {}
 variable "rules" {}
-variable "region" {}
 
 resource "stackit_sfs_export_policy" "exportpolicy" {
   project_id = var.project_id
+  region     = var.region
   name       = var.name
   rules      = var.rules
-  region     = var.region
 }

--- a/stackit/internal/services/sfs/testdata/export-policy-min.tf
+++ b/stackit/internal/services/sfs/testdata/export-policy-min.tf
@@ -1,0 +1,8 @@
+
+variable "project_id" {}
+variable "name" {}
+
+resource "stackit_sfs_export_policy" "exportpolicy" {
+  project_id = var.project_id
+  name       = var.name
+}

--- a/stackit/internal/services/sfs/testdata/resource-pool-max.tf
+++ b/stackit/internal/services/sfs/testdata/resource-pool-max.tf
@@ -1,0 +1,18 @@
+
+variable "project_id" {}
+variable "name" {}
+variable "availability_zone" {}
+variable "performance_class" {}
+variable "size_gigabytes" {}
+variable "acl" {}
+variable "snapshots_are_visible" {}
+
+resource "stackit_sfs_resource_pool" "resourcepool" {
+  project_id            = var.project_id
+  name                  = var.name
+  availability_zone     = var.availability_zone
+  performance_class     = var.performance_class
+  size_gigabytes        = var.size_gigabytes
+  ip_acl                = var.acl
+  snapshots_are_visible = var.snapshots_are_visible
+}

--- a/stackit/internal/services/sfs/testdata/resource-pool-max.tf
+++ b/stackit/internal/services/sfs/testdata/resource-pool-max.tf
@@ -1,12 +1,12 @@
 
 variable "project_id" {}
+variable "region" {}
 variable "name" {}
 variable "availability_zone" {}
 variable "performance_class" {}
 variable "size_gigabytes" {}
 variable "acl" {}
 variable "snapshots_are_visible" {}
-variable "region" {}
 
 resource "stackit_sfs_resource_pool" "resourcepool" {
   project_id            = var.project_id

--- a/stackit/internal/services/sfs/testdata/resource-pool-max.tf
+++ b/stackit/internal/services/sfs/testdata/resource-pool-max.tf
@@ -5,16 +5,20 @@ variable "name" {}
 variable "availability_zone" {}
 variable "performance_class" {}
 variable "size_gigabytes" {}
-variable "acl" {}
+variable "ip_acl_1" {}
+variable "ip_acl_2" {}
 variable "snapshots_are_visible" {}
 
 resource "stackit_sfs_resource_pool" "resourcepool" {
-  project_id            = var.project_id
-  region                = var.region
-  name                  = var.name
-  availability_zone     = var.availability_zone
-  performance_class     = var.performance_class
-  size_gigabytes        = var.size_gigabytes
-  ip_acl                = var.acl
+  project_id        = var.project_id
+  region            = var.region
+  name              = var.name
+  availability_zone = var.availability_zone
+  performance_class = var.performance_class
+  size_gigabytes    = var.size_gigabytes
+  ip_acl = [
+    var.ip_acl_1,
+    var.ip_acl_2
+  ]
   snapshots_are_visible = var.snapshots_are_visible
 }

--- a/stackit/internal/services/sfs/testdata/resource-pool-max.tf
+++ b/stackit/internal/services/sfs/testdata/resource-pool-max.tf
@@ -6,9 +6,11 @@ variable "performance_class" {}
 variable "size_gigabytes" {}
 variable "acl" {}
 variable "snapshots_are_visible" {}
+variable "region" {}
 
 resource "stackit_sfs_resource_pool" "resourcepool" {
   project_id            = var.project_id
+  region                = var.region
   name                  = var.name
   availability_zone     = var.availability_zone
   performance_class     = var.performance_class

--- a/stackit/internal/services/sfs/testdata/resource-pool-min.tf
+++ b/stackit/internal/services/sfs/testdata/resource-pool-min.tf
@@ -1,0 +1,16 @@
+
+variable "project_id" {}
+variable "name" {}
+variable "availability_zone" {}
+variable "performance_class" {}
+variable "size_gigabytes" {}
+variable "acl" {}
+
+resource "stackit_sfs_resource_pool" "resourcepool" {
+  project_id        = var.project_id
+  name              = var.name
+  availability_zone = var.availability_zone
+  performance_class = var.performance_class
+  size_gigabytes    = var.size_gigabytes
+  ip_acl            = var.acl
+}

--- a/stackit/internal/services/sfs/testdata/resource-pool-min.tf
+++ b/stackit/internal/services/sfs/testdata/resource-pool-min.tf
@@ -4,7 +4,8 @@ variable "name" {}
 variable "availability_zone" {}
 variable "performance_class" {}
 variable "size_gigabytes" {}
-variable "acl" {}
+variable "ip_acl_1" {}
+variable "ip_acl_2" {}
 
 resource "stackit_sfs_resource_pool" "resourcepool" {
   project_id        = var.project_id
@@ -12,5 +13,8 @@ resource "stackit_sfs_resource_pool" "resourcepool" {
   availability_zone = var.availability_zone
   performance_class = var.performance_class
   size_gigabytes    = var.size_gigabytes
-  ip_acl            = var.acl
+  ip_acl = [
+    var.ip_acl_1,
+    var.ip_acl_2
+  ]
 }

--- a/stackit/internal/services/sfs/testdata/share-max.tf
+++ b/stackit/internal/services/sfs/testdata/share-max.tf
@@ -1,0 +1,35 @@
+
+variable "project_id" {}
+variable "resource_pool_name" {}
+variable "export_policy_name" {}
+variable "name" {}
+variable "space_hard_limit_gigabytes" {}
+
+resource "stackit_sfs_resource_pool" "resourcepool" {
+  project_id        = var.project_id
+  name              = var.resource_pool_name
+  availability_zone = "eu01-m"
+  performance_class = "Standard"
+  size_gigabytes    = 512
+  ip_acl            = ["192.168.42.1/32"]
+  region            = "eu01"
+}
+
+resource "stackit_sfs_export_policy" "exportpolicy" {
+  project_id = var.project_id
+  name       = var.export_policy_name
+  rules = [
+    {
+      ip_acl = ["192.168.2.0/24"]
+      order  = 1
+    }
+  ]
+}
+
+resource "stackit_sfs_share" "share" {
+  project_id                 = var.project_id
+  resource_pool_id           = stackit_sfs_resource_pool.resourcepool.resource_pool_id
+  name                       = var.name
+  export_policy              = stackit_sfs_export_policy.exportpolicy.name
+  space_hard_limit_gigabytes = var.space_hard_limit_gigabytes
+}

--- a/stackit/internal/services/sfs/testdata/share-max.tf
+++ b/stackit/internal/services/sfs/testdata/share-max.tf
@@ -12,18 +12,11 @@ resource "stackit_sfs_resource_pool" "resourcepool" {
   performance_class = "Standard"
   size_gigabytes    = 512
   ip_acl            = ["192.168.42.1/32"]
-  region            = "eu01"
 }
 
 resource "stackit_sfs_export_policy" "exportpolicy" {
   project_id = var.project_id
   name       = var.export_policy_name
-  rules = [
-    {
-      ip_acl = ["192.168.2.0/24"]
-      order  = 1
-    }
-  ]
 }
 
 resource "stackit_sfs_share" "share" {

--- a/stackit/internal/services/sfs/testdata/share-max.tf
+++ b/stackit/internal/services/sfs/testdata/share-max.tf
@@ -1,5 +1,6 @@
 
 variable "project_id" {}
+variable "region" {}
 variable "resource_pool_name" {}
 variable "export_policy_name" {}
 variable "name" {}
@@ -21,6 +22,7 @@ resource "stackit_sfs_export_policy" "exportpolicy" {
 
 resource "stackit_sfs_share" "share" {
   project_id                 = var.project_id
+  region                     = var.region
   resource_pool_id           = stackit_sfs_resource_pool.resourcepool.resource_pool_id
   name                       = var.name
   export_policy              = stackit_sfs_export_policy.exportpolicy.name

--- a/stackit/internal/services/sfs/testdata/share-min.tf
+++ b/stackit/internal/services/sfs/testdata/share-min.tf
@@ -1,0 +1,22 @@
+
+variable "project_id" {}
+variable "resource_pool_name" {}
+variable "name" {}
+variable "space_hard_limit_gigabytes" {}
+
+resource "stackit_sfs_resource_pool" "resourcepool" {
+  project_id        = var.project_id
+  name              = var.resource_pool_name
+  availability_zone = "eu01-m"
+  performance_class = "Standard"
+  size_gigabytes    = 512
+  ip_acl            = ["192.168.42.1/32"]
+  region            = "eu01"
+}
+
+resource "stackit_sfs_share" "share" {
+  project_id                 = var.project_id
+  resource_pool_id           = stackit_sfs_resource_pool.resourcepool.resource_pool_id
+  name                       = var.name
+  space_hard_limit_gigabytes = var.space_hard_limit_gigabytes
+}

--- a/stackit/internal/services/sfs/testdata/share-min.tf
+++ b/stackit/internal/services/sfs/testdata/share-min.tf
@@ -11,7 +11,6 @@ resource "stackit_sfs_resource_pool" "resourcepool" {
   performance_class = "Standard"
   size_gigabytes    = 512
   ip_acl            = ["192.168.42.1/32"]
-  region            = "eu01"
 }
 
 resource "stackit_sfs_share" "share" {


### PR DESCRIPTION
## Description

relates to STACKITTPR-441

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
