### PR TITLE
fix(observability/alertgroup): for_each

### DIFF
--- a/stackit/internal/services/observability/alertgroup/resource.go
+++ b/stackit/internal/services/observability/alertgroup/resource.go
@@ -118,7 +118,7 @@ func (a *alertGroupResource) ValidateConfig(ctx context.Context, req resource.Va
 	}
 
 	rules := &[]rule{}
-	diags := resourceModel.Rules.ElementsAs(ctx, rules, false)
+	diags := resourceModel.Rules.ElementsAs(ctx, rules, true)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
## Description

Using for_each with the stackit_observability_alertgroup broke with the version v0.81.0.

Error:
```
Error: Value Conversion Error
│ 
│   with stackit_observability_alertgroup.alert_rule_debug,
│ An unexpected error was encountered trying to build a value. This is always an error in the provider. Please report the following to the provider developer:
│ 
│ Received unknown value, however the target type cannot handle unknown values. Use the corresponding `types` package type or a custom type that handles unknown values.
│ 
│ Path: 
│ Target Type: []alertgroup.rule
│ Suggested Type: basetypes.ListValue`
```

OpenTofu:
OpenTofu v1.11.5
on darwin_arm64


Example:
```
resource "stackit_observability_instance" "test" {
  name       = "test"
  plan_name  = "Observability-Starter-EU01"
  project_id = "xxxx"
}

locals {
  alert_rule = {
    example1 = {
      name     = "debug-alert-group"
      interval = "60s"
      rules = [
        {
          alert      = "debug-alert-name"
          expression = "kube_node_status_condition{condition=\"Ready\", status=\"false\"} > 0"
          for        = "60s"
          labels = {
            severity = "critical"
          },
          annotations = {
            summary : "example summary"
            description : "example description"
          }
        },
        {
          expression = "kube_node_status_condition{condition=\"Ready\", status=\"false\"} > 0"
          labels = {
            severity = "critical"
          },
          record = "abc"
        },
      ]
    }
  }

}

resource "stackit_observability_alertgroup" "alert_rule_debug" {
  for_each    = local.alert_rule
  instance_id = stackit_observability_instance.test.instance_id
  name        = each.value.name
  project_id  = "xxx"
  rules       = each.value.rules
  interval    = each.value.interval
}
```


## Checklist

- [ ] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
