### PR TITLE
fix(resourcemanager): Store IDs immediately after provisioning

### DIFF
--- a/stackit/internal/services/resourcemanager/folder/resource.go
+++ b/stackit/internal/services/resourcemanager/folder/resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	resourcemanagerUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/resourcemanager/utils"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 )
 
@@ -220,6 +221,9 @@ func (r *folderResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	// This sleep is currently needed due to the IAM Cache.
 	time.Sleep(10 * time.Second)
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"container_id": *folderCreateResp.ContainerId,
+	})
 
 	folderGetResponse, err := r.client.GetFolderDetails(ctx, *folderCreateResp.ContainerId).Execute()
 	if err != nil {
@@ -376,9 +380,9 @@ func (r *folderResource) ImportState(ctx context.Context, req resource.ImportSta
 		return
 	}
 
-	ctx = tflog.SetField(ctx, "container_id", req.ID)
-
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("container_id"), req.ID)...)
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"container_id": req.ID,
+	})
 	tflog.Info(ctx, "Resource Manager folder state imported")
 }
 


### PR DESCRIPTION
STACKITTPR-392

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->



## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
