### PR TITLE
feat(iam): attribute to query service- accounts by email_regex

### DIFF
--- a/docs/data-sources/service_account.md
+++ b/docs/data-sources/service_account.md
@@ -13,9 +13,16 @@ Service account data source schema.
 ## Example Usage
 
 ```terraform
-data "stackit_service_account" "sa" {
+data "stackit_service_account" "sa_exact" {
   project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  email      = "sa01-8565oq1@sa.stackit.cloud"
+  email      = "foo-vshp19@sa.stackit.cloud"
+}
+
+// Querying the SKE service account using a regular expression for the email
+data "stackit_service_account" "sa_ske" {
+  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  # This regex matches any standard email prefix ending exactly with the SKE domain.
+  email_regex = ".*@ske\\.sa\\.stackit\\.cloud$"
 }
 ```
 
@@ -24,8 +31,12 @@ data "stackit_service_account" "sa" {
 
 ### Required
 
-- `email` (String) Email of the service account.
 - `project_id` (String) STACKIT project ID to which the service account is associated.
+
+### Optional
+
+- `email` (String) Email of the service account. Either email or email_regex must be provided.
+- `email_regex` (String) Regular expression to match the email of the service account. The first service account matching this regex will be used. Either email or email_regex must be provided.
 
 ### Read-Only
 

--- a/examples/data-sources/stackit_service_account/data-source.tf
+++ b/examples/data-sources/stackit_service_account/data-source.tf
@@ -1,4 +1,11 @@
-data "stackit_service_account" "sa" {
+data "stackit_service_account" "sa_exact" {
   project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  email      = "sa01-8565oq1@sa.stackit.cloud"
+  email      = "foo-vshp19@sa.stackit.cloud"
+}
+
+// Querying the SKE service account using a regular expression for the email
+data "stackit_service_account" "sa_ske" {
+  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  # This regex matches any standard email prefix ending exactly with the SKE domain.
+  email_regex = ".*@ske\\.sa\\.stackit\\.cloud$"
 }

--- a/stackit/internal/services/serviceaccount/account/datasource.go
+++ b/stackit/internal/services/serviceaccount/account/datasource.go
@@ -3,12 +3,15 @@ package account
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	serviceaccountUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/serviceaccount/utils"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -22,6 +25,12 @@ import (
 var (
 	_ datasource.DataSource = &serviceAccountDataSource{}
 )
+
+// DatasourceModel represents the schema for the service account data source.
+type DatasourceModel struct {
+	Model
+	EmailRegex types.String `tfsdk:"email_regex"`
+}
 
 // NewServiceAccountDataSource creates a new instance of the serviceAccountDataSource.
 func NewServiceAccountDataSource() datasource.DataSource {
@@ -56,15 +65,13 @@ func (r *serviceAccountDataSource) Metadata(_ context.Context, req datasource.Me
 // Schema defines the schema for the service account data source.
 func (r *serviceAccountDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	descriptions := map[string]string{
-		"id":         "Terraform's internal resource ID, structured as \"`project_id`,`email`\".",
-		"project_id": "STACKIT project ID to which the service account is associated.",
-		"name":       "Name of the service account.",
-		"email":      "Email of the service account.",
+		"id":          "Terraform's internal resource ID, structured as \"`project_id`,`email`\".",
+		"project_id":  "STACKIT project ID to which the service account is associated.",
+		"name":        "Name of the service account.",
+		"email":       "Email of the service account. Either email or email_regex must be provided.",
+		"email_regex": "Regular expression to match the email of the service account. The first service account matching this regex will be used. Either email or email_regex must be provided.",
 	}
 
-	// Define the schema with validation rules and descriptions for each attribute.
-	// The datasource schema differs slightly from the resource schema.
-	// In this case, the email attribute is required to read the service account data from the API.
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Service account data source schema.",
 		Description:         "Service account data source schema.",
@@ -83,7 +90,18 @@ func (r *serviceAccountDataSource) Schema(_ context.Context, _ datasource.Schema
 			},
 			"email": schema.StringAttribute{
 				Description: descriptions["email"],
-				Required:    true,
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot("email_regex")),
+				},
+			},
+			"email_regex": schema.StringAttribute{
+				Description: descriptions["email_regex"],
+				Optional:    true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.MatchRoot("email")),
+				},
 			},
 			"name": schema.StringAttribute{
 				Description: descriptions["name"],
@@ -95,7 +113,7 @@ func (r *serviceAccountDataSource) Schema(_ context.Context, _ datasource.Schema
 
 // Read reads all service accounts from the API and updates the state with the latest information.
 func (r *serviceAccountDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) { // nolint:gocritic // function signature required by Terraform
-	var model Model
+	var model DatasourceModel
 	diags := req.Config.Get(ctx, &model)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -106,6 +124,17 @@ func (r *serviceAccountDataSource) Read(ctx context.Context, req datasource.Read
 
 	// Extract the project ID from the model configuration
 	projectId := model.ProjectId.ValueString()
+
+	// Compile the regex if provided
+	var compiledRegex *regexp.Regexp
+	var err error
+	if !model.EmailRegex.IsNull() && model.EmailRegex.ValueString() != "" {
+		compiledRegex, err = regexp.Compile(model.EmailRegex.ValueString())
+		if err != nil {
+			core.LogAndAddError(ctx, &resp.Diagnostics, "Invalid email_regex", err.Error())
+			return
+		}
+	}
 
 	// Call the API to list service accounts in the specified project
 	listSaResp, err := r.client.ListServiceAccounts(ctx, projectId).Execute()
@@ -124,23 +153,36 @@ func (r *serviceAccountDataSource) Read(ctx context.Context, req datasource.Read
 
 	ctx = core.LogResponse(ctx)
 
-	// Iterate over the service accounts returned by the API to find the one matching the email
+	// Iterate over the service accounts returned by the API to find the one matching the email or regex
 	serviceAccounts := *listSaResp.Items
 	for i := range serviceAccounts {
-		// Skip if the service account email does not match
-		if *serviceAccounts[i].Email != model.Email.ValueString() {
+		saEmail := *serviceAccounts[i].Email
+		match := false
+
+		// Determine if the current service account matches the criteria
+		if !model.Email.IsNull() && model.Email.ValueString() != "" {
+			match = saEmail == model.Email.ValueString()
+		} else if compiledRegex != nil {
+			match = compiledRegex.MatchString(saEmail)
+		}
+
+		// Skip if it doesn't match
+		if !match {
 			continue
 		}
 
 		// Map the API response to the model, updating its fields with the service account data
-		err = mapFields(&serviceAccounts[i], &model)
+		err = mapFields(&serviceAccounts[i], &model.Model)
 		if err != nil {
 			core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading service account", fmt.Sprintf("Error processing API response: %v", err))
 			return
 		}
 
+		// If matched by regex, ensure the exact email is saved back to the state for downstream references
+		model.Email = types.StringValue(saEmail)
+
 		// Try to parse the name from the provided email address
-		name, err := parseNameFromEmail(model.Email.ValueString())
+		name, err := parseNameFromEmail(saEmail)
 		if name != "" && err == nil {
 			model.Name = types.StringValue(name)
 		}
@@ -151,7 +193,12 @@ func (r *serviceAccountDataSource) Read(ctx context.Context, req datasource.Read
 		return
 	}
 
-	// If no matching service account is found, remove the resource from the state
-	core.LogAndAddError(ctx, &resp.Diagnostics, "Reading service account", "Service account not found")
+	// If no matching service account is found, data sources must return an error
+	core.LogAndAddError(
+		ctx,
+		&resp.Diagnostics,
+		"Service Account not found",
+		"No service account matching the provided email or email_regex was found in the project.",
+	)
 	resp.State.RemoveResource(ctx)
 }

--- a/stackit/internal/services/serviceaccount/account/resource.go
+++ b/stackit/internal/services/serviceaccount/account/resource.go
@@ -323,10 +323,11 @@ func mapFields(resp *serviceaccount.ServiceAccount, model *Model) error {
 	return nil
 }
 
-// parseNameFromEmail extracts the name component from an email address.
-// The email format must be `name-<random7characters>@sa.stackit.cloud`.
+// parseNameFromEmail extracts the name component from a service account email address.
+// The expected email format is `name-<random7to10characters>@sa.stackit.cloud`
+// or `name-<random7to10characters>@ske.sa.stackit.cloud`.
 func parseNameFromEmail(email string) (string, error) {
-	namePattern := `^([a-z][a-z0-9]*(?:-[a-z0-9]+)*)-\w{7}@sa\.stackit\.cloud$`
+	namePattern := `^([a-z][a-z0-9]*(?:-[a-z0-9]+)*)-\w{7,10}@(?:ske\.)?sa\.stackit\.cloud$`
 	re := regexp.MustCompile(namePattern)
 	match := re.FindStringSubmatch(email)
 

--- a/stackit/internal/services/serviceaccount/account/resource_test.go
+++ b/stackit/internal/services/serviceaccount/account/resource_test.go
@@ -130,15 +130,34 @@ func TestParseNameFromEmail(t *testing.T) {
 		expected    string
 		shouldError bool
 	}{
-		{"test03-8565oq1@sa.stackit.cloud", "test03", false},
-		{"import-test-vshp191@sa.stackit.cloud", "import-test", false},
-		{"sa-test-01-acfj2s1@sa.stackit.cloud", "sa-test-01", false},
+		// Standard SA domain (Positive: 7 to 10 random characters)
+		{"foo-vshp191@sa.stackit.cloud", "foo", false},           // 7 chars
+		{"bar-8565oq12@sa.stackit.cloud", "bar", false},          // 8 chars
+		{"foo-bar-acfj2s123@sa.stackit.cloud", "foo-bar", false}, // 9 chars
+		{"baz-abcdefghij@sa.stackit.cloud", "baz", false},        // 10 chars
+
+		// Standard SA domain (Negative: 6 and 11 random characters)
+		{"foo-vshp19@sa.stackit.cloud", "", true},      // 6 chars (Too short)
+		{"bar-8565oq12345@sa.stackit.cloud", "", true}, // 11 chars (Too long)
+
+		// SKE SA domain (Positive: 7 to 10 random characters)
+		{"foo-qnmbwo1@ske.sa.stackit.cloud", "foo", false},           // 7 chars
+		{"bar-qnmbwo12@ske.sa.stackit.cloud", "bar", false},          // 8 chars
+		{"foo-bar-qnmbwo123@ske.sa.stackit.cloud", "foo-bar", false}, // 9 chars
+		{"baz-abcdefghij@ske.sa.stackit.cloud", "baz", false},        // 10 chars
+
+		// SKE SA domain (Negative: 6 and 11 random characters)
+		{"foo-qnmbwo@ske.sa.stackit.cloud", "", true},      // 6 chars (Too short)
+		{"bar-qnmbwo12345@ske.sa.stackit.cloud", "", true}, // 11 chars (Too long)
+
+		// Invalid cases (Formatting & Unknown Domains)
 		{"invalid-email@sa.stackit.cloud", "", true},
 		{"missingcode-@sa.stackit.cloud", "", true},
 		{"nohyphen8565oq1@sa.stackit.cloud", "", true},
 		{"eu01-qnmbwo1@unknown.stackit.cloud", "", true},
-		{"eu01-qnmbwo1@ske.stackit.com", "", true},
+		{"eu01-qnmbwo1@ske.stackit.com", "", true}, // Missing .sa. and ends in .com
 		{"someotherformat@sa.stackit.cloud", "", true},
+		{"invalid-format@ske.sa.stackit.cloud", "", true}, // SKE domain but missing the character suffix completely
 	}
 
 	for _, tc := range testCases {

--- a/stackit/internal/services/serviceaccount/serviceaccount_acc_test.go
+++ b/stackit/internal/services/serviceaccount/serviceaccount_acc_test.go
@@ -2,63 +2,53 @@ package serviceaccount
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	stackitSdkConfig "github.com/stackitcloud/stackit-sdk-go/core/config"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceaccount"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
 
-// Service Account resource data
-var serviceAccountResource = map[string]string{
-	"project_id": testutil.ProjectId,
-	"name01":     "sa-test-01",
-	"name02":     "sa-test-02",
+var (
+	//go:embed testdata/resource-service-account.tf
+	resourceServiceAccount string
+
+	//go:embed testdata/datasource-service-account.tf
+	datasourceServiceAccount string
+
+	//go:embed testdata/datasource-service-account-regex.tf
+	datasourceServiceAccountRegex string
+)
+
+var testConfigVars = config.Variables{
+	"project_id": config.StringVariable(testutil.ProjectId),
+	"name":       config.StringVariable("satest01"),
 }
 
-func inputServiceAccountResourceConfig(name string) string {
-	return fmt.Sprintf(`
-				%s
-			
-				resource "stackit_service_account" "sa" {
-					project_id = "%s"
-					name = "%s"
-				}
-
-				resource "stackit_service_account_access_token" "token" {
-					project_id = stackit_service_account.sa.project_id
-  					service_account_email = stackit_service_account.sa.email
-				}
-
-				resource "stackit_service_account_key" "key" {
-					project_id            = stackit_service_account.sa.project_id
-					service_account_email = stackit_service_account.sa.email
-					ttl_days              = 90
-				}
-				`,
-		testutil.ServiceAccountProviderConfig(),
-		serviceAccountResource["project_id"],
-		name,
-	)
+var testConfigVarsUpdate = config.Variables{
+	"project_id": config.StringVariable(testutil.ProjectId),
+	"name":       config.StringVariable("satest02"),
 }
 
-func inputServiceAccountDataSourceConfig() string {
-	return fmt.Sprintf(`
-					%s
+var testConfigVarsRegex = config.Variables{
+	"project_id":  config.StringVariable(testutil.ProjectId),
+	"name":        config.StringVariable("satest02"),
+	"email_regex": config.StringVariable(`^satest02-\w{7,10}@(?:ske\.)?sa\.stackit\.cloud$`),
+}
 
-					data "stackit_service_account" "sa" {
-						project_id  = stackit_service_account.sa.project_id
-						email = stackit_service_account.sa.email
-					}
-					`,
-		inputServiceAccountResourceConfig(serviceAccountResource["name01"]),
-	)
+var testConfigVarsRegexNotFound = config.Variables{
+	"project_id":  config.StringVariable(testutil.ProjectId),
+	"name":        config.StringVariable("satest02"),
+	"email_regex": config.StringVariable("not-found"),
 }
 
 func TestServiceAccount(t *testing.T) {
@@ -68,10 +58,11 @@ func TestServiceAccount(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Creation
 			{
-				Config: inputServiceAccountResourceConfig(serviceAccountResource["name01"]),
+				ConfigVariables: testConfigVars,
+				Config:          testutil.ServiceAccountProviderConfig() + "\n" + resourceServiceAccount,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_service_account.sa", "project_id", serviceAccountResource["project_id"]),
-					resource.TestCheckResourceAttr("stackit_service_account.sa", "name", serviceAccountResource["name01"]),
+					resource.TestCheckResourceAttr("stackit_service_account.sa", "project_id", testutil.ConvertConfigVariable(testConfigVars["project_id"])),
+					resource.TestCheckResourceAttr("stackit_service_account.sa", "name", testutil.ConvertConfigVariable(testConfigVars["name"])),
 					resource.TestCheckResourceAttrSet("stackit_service_account.sa", "email"),
 					resource.TestCheckResourceAttrSet("stackit_service_account_access_token.token", "token"),
 					resource.TestCheckResourceAttrSet("stackit_service_account_access_token.token", "created_at"),
@@ -86,10 +77,11 @@ func TestServiceAccount(t *testing.T) {
 			},
 			// Update
 			{
-				Config: inputServiceAccountResourceConfig(serviceAccountResource["name02"]),
+				ConfigVariables: testConfigVarsUpdate,
+				Config:          testutil.ServiceAccountProviderConfig() + "\n" + resourceServiceAccount,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("stackit_service_account.sa", "project_id", serviceAccountResource["project_id"]),
-					resource.TestCheckResourceAttr("stackit_service_account.sa", "name", serviceAccountResource["name02"]),
+					resource.TestCheckResourceAttr("stackit_service_account.sa", "project_id", testutil.ConvertConfigVariable(testConfigVarsUpdate["project_id"])),
+					resource.TestCheckResourceAttr("stackit_service_account.sa", "name", testutil.ConvertConfigVariable(testConfigVarsUpdate["name"])),
 					resource.TestCheckResourceAttrSet("stackit_service_account.sa", "email"),
 					resource.TestCheckResourceAttrSet("stackit_service_account_access_token.token", "token"),
 					resource.TestCheckResourceAttrSet("stackit_service_account_access_token.token", "created_at"),
@@ -102,12 +94,12 @@ func TestServiceAccount(t *testing.T) {
 					resource.TestCheckResourceAttrPair("stackit_service_account.sa", "email", "stackit_service_account_key.key", "service_account_email"),
 				),
 			},
-			// Data source
+			// Data source (Using exact email)
 			{
-				Config: inputServiceAccountDataSourceConfig(),
+				ConfigVariables: testConfigVarsUpdate,
+				Config:          testutil.ServiceAccountProviderConfig() + "\n" + resourceServiceAccount + "\n" + datasourceServiceAccount,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// Instance
-					resource.TestCheckResourceAttr("data.stackit_service_account.sa", "project_id", serviceAccountResource["project_id"]),
+					resource.TestCheckResourceAttr("data.stackit_service_account.sa", "project_id", testutil.ConvertConfigVariable(testConfigVarsUpdate["project_id"])),
 					resource.TestCheckResourceAttrPair(
 						"stackit_service_account.sa", "project_id",
 						"data.stackit_service_account.sa", "project_id",
@@ -122,9 +114,37 @@ func TestServiceAccount(t *testing.T) {
 					),
 				),
 			},
+			// Data source (Using email_regex)
+			{
+				ConfigVariables: testConfigVarsRegex,
+				Config:          testutil.ServiceAccountProviderConfig() + "\n" + resourceServiceAccount + "\n" + datasourceServiceAccountRegex,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.stackit_service_account.sa_regex", "project_id", testutil.ConvertConfigVariable(testConfigVarsRegex["project_id"])),
+					resource.TestCheckResourceAttrPair(
+						"stackit_service_account.sa", "project_id",
+						"data.stackit_service_account.sa_regex", "project_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_service_account.sa", "name",
+						"data.stackit_service_account.sa_regex", "name",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_service_account.sa", "email",
+						"data.stackit_service_account.sa_regex", "email",
+					),
+				),
+			},
+			// Data source (Using email_regex - Not Found Expectation)
+			{
+				ConfigVariables: testConfigVarsRegexNotFound,
+				Config:          testutil.ServiceAccountProviderConfig() + "\n" + resourceServiceAccount + "\n" + datasourceServiceAccountRegex,
+				ExpectError:     regexp.MustCompile(`Service Account not found`),
+			},
 			// Import
 			{
-				ResourceName: "stackit_service_account.sa",
+				ConfigVariables: testConfigVarsUpdate,
+				Config:          testutil.ServiceAccountProviderConfig() + "\n" + resourceServiceAccount,
+				ResourceName:    "stackit_service_account.sa",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					r, ok := s.RootModule().Resources["stackit_service_account.sa"]
 					if !ok {
@@ -153,7 +173,7 @@ func testAccCheckServiceAccountDestroy(s *terraform.State) error {
 		client, err = serviceaccount.NewAPIClient()
 	} else {
 		client, err = serviceaccount.NewAPIClient(
-			config.WithEndpoint(testutil.ServiceAccountCustomEndpoint),
+			stackitSdkConfig.WithEndpoint(testutil.ServiceAccountCustomEndpoint),
 		)
 	}
 

--- a/stackit/internal/services/serviceaccount/testdata/datasource-service-account-regex.tf
+++ b/stackit/internal/services/serviceaccount/testdata/datasource-service-account-regex.tf
@@ -1,0 +1,8 @@
+variable "email_regex" {
+  type = string
+}
+
+data "stackit_service_account" "sa_regex" {
+  project_id  = stackit_service_account.sa.project_id
+  email_regex = var.email_regex
+}

--- a/stackit/internal/services/serviceaccount/testdata/datasource-service-account.tf
+++ b/stackit/internal/services/serviceaccount/testdata/datasource-service-account.tf
@@ -1,0 +1,4 @@
+data "stackit_service_account" "sa" {
+  project_id = stackit_service_account.sa.project_id
+  email      = stackit_service_account.sa.email
+}

--- a/stackit/internal/services/serviceaccount/testdata/resource-service-account.tf
+++ b/stackit/internal/services/serviceaccount/testdata/resource-service-account.tf
@@ -1,0 +1,23 @@
+variable "project_id" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+resource "stackit_service_account" "sa" {
+  project_id = var.project_id
+  name       = var.name
+}
+
+resource "stackit_service_account_access_token" "token" {
+  project_id            = stackit_service_account.sa.project_id
+  service_account_email = stackit_service_account.sa.email
+}
+
+resource "stackit_service_account_key" "key" {
+  project_id            = stackit_service_account.sa.project_id
+  service_account_email = stackit_service_account.sa.email
+  ttl_days              = 90
+}


### PR DESCRIPTION
## Description

This PR adds the capability to query service accounts by `email_regex`. This feature addresses the following use case:

Each project with ske enabled has a service account named `eu01-<random-identifier-7-to-10-chars>@ske.sa.stackit.cloud`. When rolling out volume encryption storage classes across a large number of clusters, you need an automated way to retrieve the email address of this service account. This is the immediate use case we need to support. However, additional use cases may arise in the future, as internal STACKIT services also rely on service account creation. The SKE API does not expose the service account email and currently there is no priority to export this as a attribute.

While implementing this PR, I also improved the test coverage for the `parseNameFromEmail` functionality and updated our acceptance tests to follow the latest format. Below is the code I used to test this feature:

```hcl
resource "stackit_service_account" "sa" {
  project_id = "xxx"
  name       = "satest01"
}

data "stackit_service_account" "sa" {
  project_id  = "xxx"
  email_regex = ".*@sa\\.stackit\\.cloud$"
}

data "stackit_service_account" "sa_ske" {
  project_id  = "xxx"
  email_regex = ".*@ske\\.sa\\.stackit\\.cloud$"
}

data "stackit_service_account" "sa_email" {
  project_id = "xxx"
  email      = stackit_service_account.sa.email
}
```

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
<img width="560" height="250" alt="Screenshot 2026-02-23 at 10 53 51" src="https://github.com/user-attachments/assets/790452ba-7c1a-4751-a02a-4dc33b1c2927" />

- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
