### PR TITLE
feat(objectstorage): store ids after provisioning

### DIFF
--- a/stackit/internal/services/objectstorage/bucket/resource.go
+++ b/stackit/internal/services/objectstorage/bucket/resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -205,6 +204,16 @@ func (r *bucketResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	ctx = core.LogResponse(ctx)
 
+	// Write id attributes to state before polling via the wait handler - just in case anything goes wrong during the wait handler
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"project_id": projectId,
+		"region":     region,
+		"name":       bucketName,
+	})
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	waitResp, err := wait.CreateBucketWaitHandler(ctx, r.client, projectId, region, bucketName).WaitWithContext(ctx)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating bucket", fmt.Sprintf("Bucket creation waiting: %v", err))
@@ -333,9 +342,12 @@ func (r *bucketResource) ImportState(ctx context.Context, req resource.ImportSta
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("region"), idParts[1])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), idParts[2])...)
+	// Write id attributes to state before polling via the wait handler - just in case anything goes wrong during the wait handler
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"project_id": idParts[0],
+		"region":     idParts[1],
+		"name":       idParts[2],
+	})
 	tflog.Info(ctx, "ObjectStorage bucket state imported")
 }
 

--- a/stackit/internal/services/objectstorage/credential/resource.go
+++ b/stackit/internal/services/objectstorage/credential/resource.go
@@ -286,7 +286,16 @@ func (r *credentialResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 	credentialId := *credentialResp.KeyId
-	ctx = tflog.SetField(ctx, "credential_id", credentialId)
+	// Write id attributes to state before polling via the wait handler - just in case anything goes wrong during the wait handler
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"project_id":           projectId,
+		"region":               region,
+		"credentials_group_id": credentialsGroupId,
+		"credential_id":        credentialId,
+	})
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Map response body to schema
 	err = mapFields(credentialResp, &model, region)
@@ -445,10 +454,12 @@ func (r *credentialResource) ImportState(ctx context.Context, req resource.Impor
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("region"), idParts[1])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_group_id"), idParts[2])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credential_id"), idParts[3])...)
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"project_id":           idParts[0],
+		"region":               idParts[1],
+		"credentials_group_id": idParts[2],
+		"credential_id":        idParts[3],
+	})
 	tflog.Info(ctx, "ObjectStorage credential state imported")
 }
 

--- a/stackit/internal/services/objectstorage/credentialsgroup/resource.go
+++ b/stackit/internal/services/objectstorage/credentialsgroup/resource.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
 
-	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -207,6 +206,21 @@ func (r *credentialsGroupResource) Create(ctx context.Context, req resource.Crea
 
 	ctx = core.LogResponse(ctx)
 
+	if got == nil || got.CredentialsGroup == nil || got.CredentialsGroup.CredentialsGroupId == nil {
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating credentials group", "Got empty credential group id id")
+		return
+	}
+	credentialsGroupId := *got.CredentialsGroup.CredentialsGroupId
+	// Write id attributes to state before polling via the wait handler - just in case anything goes wrong during the wait handler
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"project_id":           projectId,
+		"region":               region,
+		"credentials_group_id": credentialsGroupId,
+	})
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// Map response body to schema
 	err = mapFields(got, &model, region)
 	if err != nil {
@@ -312,9 +326,11 @@ func (r *credentialsGroupResource) ImportState(ctx context.Context, req resource
 		return
 	}
 
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("project_id"), idParts[0])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("region"), idParts[1])...)
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("credentials_group_id"), idParts[2])...)
+	ctx = utils.SetAndLogStateFields(ctx, &resp.Diagnostics, &resp.State, map[string]any{
+		"project_id":           idParts[0],
+		"region":               idParts[1],
+		"credentials_group_id": idParts[2],
+	})
 	tflog.Info(ctx, "ObjectStorage credentials group state imported")
 }
 

--- a/stackit/internal/services/objectstorage/objectstorage_test.go
+++ b/stackit/internal/services/objectstorage/objectstorage_test.go
@@ -1,0 +1,87 @@
+package objectstorage
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/objectstorage"
+	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
+)
+
+func TestObjectStorageBucketSavesIDsOnError(t *testing.T) {
+	projectId := uuid.NewString()
+	const (
+		name   = "bucket-name"
+		region = "eu01"
+	)
+	s := testutil.NewMockServer(t)
+	defer s.Server.Close()
+	tfConfig := fmt.Sprintf(`
+provider "stackit" {
+	default_region = "%s"
+	objectstorage_custom_endpoint = "%s"
+	service_account_token = "mock-server-needs-no-auth"
+}
+resource "stackit_objectstorage_bucket" "instance" {
+  project_id = "%s"
+  name       = "%s"
+}
+`, region, s.Server.URL, projectId, name)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					s.Reset(
+						testutil.MockResponse{
+							Description: "project enable",
+							ToJsonBody: objectstorage.ProjectStatus{
+								Project: utils.Ptr(projectId),
+								Scope:   utils.Ptr(objectstorage.PROJECTSCOPE_PUBLIC),
+							},
+						},
+						testutil.MockResponse{
+							Description: "create bucket",
+							ToJsonBody: objectstorage.Bucket{
+								Name:   utils.Ptr(name),
+								Region: utils.Ptr(region),
+							},
+						},
+						testutil.MockResponse{
+							Description: "failing waiter",
+							StatusCode:  http.StatusInternalServerError,
+						},
+					)
+				},
+				Config:      tfConfig,
+				ExpectError: regexp.MustCompile("Error creating bucket.*"),
+			},
+			{
+				PreConfig: func() {
+					s.Reset(
+						testutil.MockResponse{
+							Description: "refresh",
+							Handler: func(w http.ResponseWriter, req *http.Request) {
+								expected := fmt.Sprintf("/v2/project/%s/regions/%s/bucket/%s", projectId, region, name)
+								if req.URL.Path != expected {
+									t.Errorf("expected request to %s, got %s", expected, req.URL.Path)
+								}
+								w.WriteHeader(http.StatusInternalServerError)
+							},
+						},
+						testutil.MockResponse{Description: "delete", StatusCode: http.StatusAccepted},
+						testutil.MockResponse{Description: "delete waiter", StatusCode: http.StatusNotFound},
+					)
+				},
+				RefreshState: true,
+				ExpectError:  regexp.MustCompile("Error reading bucket*"),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITTPR-386

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
