### PR TITLE
fix(observability) do not fail plan phase when project ID not yet known

### DIFF
--- a/stackit/internal/services/observability/instance/resource.go
+++ b/stackit/internal/services/observability/instance/resource.go
@@ -904,6 +904,11 @@ func (r *instanceResource) ModifyPlan(ctx context.Context, req resource.ModifyPl
 		return
 	}
 
+	if configModel.ProjectId.IsUnknown() {
+		core.LogAndAddWarning(ctx, &resp.Diagnostics, "Validating plan: project ID not yet known", "The resource references a project ID, which is not yet known but needed for plan validation. Skipping plan validation, apply may fail.")
+		return
+	}
+
 	plan, err := loadPlanId(ctx, *r.client, &configModel)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error validating plan", fmt.Sprintf("Loading service plan: %v", err))


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
