### PR TITLE
fix(server): update network example to use "ipv4_nameservers" instead of "nameservers"

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -73,7 +73,7 @@ description: |-
   resource "stackit_network" "network" {
     project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     name               = "example-network"
-    nameservers        = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
+    ipv4_nameservers   = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
     ipv4_prefix_length = 24
   }
   


### PR DESCRIPTION
## Description

The stackit_servers network example uses argument "nameservers", but stackit_network requires "ipv4_nameservers" instead

<img width="563" height="117" alt="image" src="https://github.com/user-attachments/assets/ef0604f8-fcb2-47d6-aa09-25105d951edd" />

https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/resources/network
<img width="648" height="94" alt="image" src="https://github.com/user-attachments/assets/bbd01408-2895-40ed-9c6b-77d7c340ed46" />


