### PR TITLE
fix(server): update network example to use "ipv4_nameservers" instead…

### DIFF
--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -108,7 +108,7 @@ description: |-
     keypair_name = stackit_key_pair.keypair.name
     network_interfaces = [
       stackit_network_interface.nic.network_interface_id
-    ]	
+    ]
   }
   
   resource "stackit_public_ip" "public-ip" {

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -73,7 +73,7 @@ description: |-
   resource "stackit_network" "network" {
     project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     name               = "example-network"
-    nameservers        = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
+    ipv4_nameservers   = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
     ipv4_prefix_length = 24
   }
   
@@ -254,7 +254,7 @@ resource "stackit_server" "boot-from-volume" {
 resource "stackit_network" "network" {
   project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name               = "example-network"
-  nameservers        = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
+  ipv4_nameservers   = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
   ipv4_prefix_length = 24
 }
 
@@ -289,7 +289,7 @@ resource "stackit_server" "server-with-network" {
   keypair_name = stackit_key_pair.keypair.name
   network_interfaces = [
     stackit_network_interface.nic.network_interface_id
-  ]	
+  ]
 }
 
 resource "stackit_public_ip" "public-ip" {

--- a/stackit/internal/services/iaas/server/const.go
+++ b/stackit/internal/services/iaas/server/const.go
@@ -72,7 +72,7 @@ resource "stackit_server" "boot-from-volume" {
 resource "stackit_network" "network" {
   project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   name               = "example-network"
-  nameservers        = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
+  ipv4_nameservers   = ["192.0.2.0", "198.51.100.0", "203.0.113.0"]
   ipv4_prefix_length = 24
 }
 
@@ -107,7 +107,7 @@ resource "stackit_server" "server-with-network" {
   keypair_name = stackit_key_pair.keypair.name
   network_interfaces = [
     stackit_network_interface.nic.network_interface_id
-  ]	
+  ]
 }
 
 resource "stackit_public_ip" "public-ip" {


### PR DESCRIPTION
The stackit_servers network example uses argument "nameservers", but stackit_network requires "ipv4_nameservers" instead

Current:
<img width="693" height="216" alt="image" src="https://github.com/user-attachments/assets/206b984b-3394-46a6-bbe6-847a64f120e8" />

<img width="1126" height="234" alt="image" src="https://github.com/user-attachments/assets/19845e75-4d09-4ed4-a6fe-d5adcd3a2a4a" />

Actual network documentation:
<img width="1296" height="188" alt="image" src="https://github.com/user-attachments/assets/0b6e5b85-0c92-445a-9425-a1e90706a584" />