### PR TITLE
docs(resourcemanager): fix small typo

### DIFF
--- a/docs/resources/authorization_project_role_assignment.md
+++ b/docs/resources/authorization_project_role_assignment.md
@@ -24,7 +24,7 @@ resource "stackit_resourcemanager_project" "example" {
 }
 
 resource "stackit_authorization_project_role_assignment" "pra" {
-  resource_id = stackit_resourcemanager_project.example.folder_id
+  resource_id = stackit_resourcemanager_project.example.project_id
   role        = "reader"
   subject     = "foo.bar@stackit.cloud"
 }

--- a/examples/resources/stackit_authorization_project_role_assignment/resource.tf
+++ b/examples/resources/stackit_authorization_project_role_assignment/resource.tf
@@ -6,7 +6,7 @@ resource "stackit_resourcemanager_project" "example" {
 }
 
 resource "stackit_authorization_project_role_assignment" "pra" {
-  resource_id = stackit_resourcemanager_project.example.folder_id
+  resource_id = stackit_resourcemanager_project.example.project_id
   role        = "reader"
   subject     = "foo.bar@stackit.cloud"
 }


### PR DESCRIPTION
## Description

fixes small typo

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
