### PR TITLE
feat(ske): migrate acc test to new sdk structure

### DIFF
--- a/stackit/internal/services/ske/ske_acc_test.go
+++ b/stackit/internal/services/ske/ske_acc_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/ske"
-	"github.com/stackitcloud/stackit-sdk-go/services/ske/wait"
+	ske "github.com/stackitcloud/stackit-sdk-go/services/ske/v2api"
+	"github.com/stackitcloud/stackit-sdk-go/services/ske/v2api/wait"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
@@ -540,22 +540,22 @@ func testAccCheckSKEDestroy(s *terraform.State) error {
 		clustersToDestroy = append(clustersToDestroy, clusterName)
 	}
 
-	clustersResp, err := client.ListClusters(ctx, testutil.ProjectId, testutil.Region).Execute()
+	clustersResp, err := client.DefaultAPI.ListClusters(ctx, testutil.ProjectId, testutil.Region).Execute()
 	if err != nil {
 		return fmt.Errorf("getting clustersResp: %w", err)
 	}
 
-	items := *clustersResp.Items
+	items := clustersResp.Items
 	for i := range items {
 		if items[i].Name == nil {
 			continue
 		}
 		if utils.Contains(clustersToDestroy, *items[i].Name) {
-			_, err := client.DeleteClusterExecute(ctx, testutil.ProjectId, testutil.Region, *items[i].Name)
+			_, err := client.DefaultAPI.DeleteCluster(ctx, testutil.ProjectId, testutil.Region, *items[i].Name).Execute()
 			if err != nil {
 				return fmt.Errorf("destroying cluster %s during CheckDestroy: %w", *items[i].Name, err)
 			}
-			_, err = wait.DeleteClusterWaitHandler(ctx, client, testutil.ProjectId, testutil.Region, *items[i].Name).WaitWithContext(ctx)
+			_, err = wait.DeleteClusterWaitHandler(ctx, client.DefaultAPI, testutil.ProjectId, testutil.Region, *items[i].Name).WaitWithContext(ctx)
 			if err != nil {
 				return fmt.Errorf("destroying cluster %s during CheckDestroy: waiting for deletion %w", *items[i].Name, err)
 			}
@@ -586,7 +586,7 @@ func NewSkeProviderOptions(nodePoolOs string) *SkeProviderOptions {
 		panic("failed to create SKE client: " + err.Error())
 	}
 
-	options, err := client.ListProviderOptions(ctx, testutil.Region).Execute()
+	options, err := client.DefaultAPI.ListProviderOptions(ctx, testutil.Region).Execute()
 	if err != nil {
 		panic("failed to fetch SKE provider options: " + err.Error())
 	}
@@ -608,10 +608,10 @@ func (s *SkeProviderOptions) getMachineVersionAt(position int) string {
 		panic(fmt.Sprintf("no supported machine version found at position %d", position))
 	}
 
-	for _, mi := range *s.options.MachineImages {
+	for _, mi := range s.options.MachineImages {
 		if mi.Name != nil && *mi.Name == s.nodePoolOsName && mi.Versions != nil {
 			count := 0
-			for _, v := range *mi.Versions {
+			for _, v := range mi.Versions {
 				if v.State != nil && v.Version != nil {
 					if count == position {
 						return *v.Version
@@ -637,7 +637,7 @@ func (s *SkeProviderOptions) getK8sVersionAt(position int) string {
 	}
 
 	count := 0
-	for _, v := range *s.options.KubernetesVersions {
+	for _, v := range s.options.KubernetesVersions {
 		if v.State != nil && *v.State == "supported" && v.Version != nil {
 			if count == position {
 				return *v.Version

--- a/stackit/internal/services/ske/ske_test.go
+++ b/stackit/internal/services/ske/ske_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
-	"github.com/stackitcloud/stackit-sdk-go/services/ske"
+	legacySke "github.com/stackitcloud/stackit-sdk-go/services/ske"
+	ske "github.com/stackitcloud/stackit-sdk-go/services/ske/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
@@ -75,41 +76,41 @@ resource "stackit_ske_cluster" "cluster" {
 						testutil.MockResponse{
 							Description: "kubernetes versions",
 							ToJsonBody: ske.ProviderOptions{
-								MachineImages: new([]ske.MachineImage{
+								MachineImages: []ske.MachineImage{
 									{
 										Name: new("flatcar"),
-										Versions: new([]ske.MachineImageVersion{
+										Versions: []ske.MachineImageVersion{
 											{
 												State:          new("supported"),
 												Version:        new("1.0.0"),
 												ExpirationDate: nil,
-												Cri: new([]ske.CRI{
+												Cri: []ske.CRI{
 													{
-														Name: new(ske.CRINAME_CONTAINERD),
+														Name: new(string(legacySke.CRINAME_CONTAINERD)),
 													},
-												}),
+												},
 											},
-										}),
+										},
 									},
-								}),
-								MachineTypes: new([]ske.MachineType{
+								},
+								MachineTypes: []ske.MachineType{
 									{
 										Name: new(machineType),
 									},
-								}),
-								KubernetesVersions: new([]ske.KubernetesVersion{
+								},
+								KubernetesVersions: []ske.KubernetesVersion{
 									{
 										State:          new("supported"),
 										ExpirationDate: nil,
 										Version:        new(kubernetesVersionMin),
 									},
-								}),
+								},
 							},
 						},
 						testutil.MockResponse{
 							Description: "create",
 							ToJsonBody: ske.Cluster{
-								Name: new(string(clusterName)),
+								Name: new(clusterName),
 							},
 						},
 						testutil.MockResponse{
@@ -137,7 +138,7 @@ resource "stackit_ske_cluster" "cluster" {
 						testutil.MockResponse{Description: "delete", StatusCode: http.StatusAccepted},
 						testutil.MockResponse{Description: "ListClusterResponse is called for checking removal",
 							ToJsonBody: ske.ListClustersResponse{
-								Items: &[]ske.Cluster{},
+								Items: []ske.Cluster{},
 							},
 						},
 					)
@@ -194,35 +195,35 @@ resource "stackit_ske_cluster" "cluster" {
 
 	skeCluster := ske.Cluster{
 		Name: new(clusterName),
-		Nodepools: new([]ske.Nodepool{
+		Nodepools: []ske.Nodepool{
 			{
 				AllowSystemComponents: new(true),
-				AvailabilityZones:     new([]string{"eu01-1"}),
-				Name:                  new(nodeName),
+				AvailabilityZones:     []string{"eu01-1"},
+				Name:                  nodeName,
 				Cri: new(ske.CRI{
-					Name: new(ske.CRINAME_CONTAINERD),
+					Name: new(string(legacySke.CRINAME_CONTAINERD)),
 				}),
-				Machine: new(ske.Machine{
-					Image: new(ske.Image{
-						Name:    new("flatcar"),
-						Version: new("1.0.0"),
-					}),
-					Type: new(machineType),
-				}),
-				MaxSurge:       new(int64(1)),
-				MaxUnavailable: new(int64(0)),
-				Maximum:        new(int64(2)),
-				Minimum:        new(int64(1)),
-				Volume: new(ske.Volume{
-					Size: new(int64(50)),
+				Machine: ske.Machine{
+					Image: ske.Image{
+						Name:    "flatcar",
+						Version: "1.0.0",
+					},
+					Type: machineType,
+				},
+				MaxSurge:       new(int32(1)),
+				MaxUnavailable: new(int32(0)),
+				Maximum:        2,
+				Minimum:        1,
+				Volume: ske.Volume{
+					Size: 50,
 					Type: new("storage_premium_perf4"),
-				}),
+				},
 				Labels: new(map[string]string{}),
 			},
-		}),
-		Kubernetes: new(ske.Kubernetes{
-			Version: new(kubernetesVersionMin),
-		}),
+		},
+		Kubernetes: ske.Kubernetes{
+			Version: kubernetesVersionMin,
+		},
 		Network: &ske.Network{
 			Id: nil,
 			ControlPlane: new(ske.V2ControlPlaneNetwork{
@@ -230,18 +231,18 @@ resource "stackit_ske_cluster" "cluster" {
 			}),
 		},
 		Maintenance: new(ske.Maintenance{
-			AutoUpdate: new(ske.MaintenanceAutoUpdate{
+			AutoUpdate: ske.MaintenanceAutoUpdate{
 				KubernetesVersion:   new(true),
 				MachineImageVersion: new(true),
-			}),
-			TimeWindow: new(ske.TimeWindow{
-				Start: new(time.Now()),
-				End:   new(time.Now()),
-			}),
+			},
+			TimeWindow: ske.TimeWindow{
+				Start: time.Now(),
+				End:   time.Now(),
+			},
 		}),
 		Status: new(ske.ClusterStatus{
-			Aggregated:       new(ske.CLUSTERSTATUSSTATE_HEALTHY),
-			PodAddressRanges: new([]string{"100.64.0.0/10"}),
+			Aggregated:       new(ske.CLUSTERSTATUSSTATE_STATE_HEALTHY),
+			PodAddressRanges: []string{"100.64.0.0/10"},
 		}),
 		Extensions: new(ske.Extension{}),
 	}
@@ -270,35 +271,35 @@ resource "stackit_ske_cluster" "cluster" {
 						testutil.MockResponse{
 							Description: "kubernetes versions",
 							ToJsonBody: ske.ProviderOptions{
-								MachineImages: new([]ske.MachineImage{
+								MachineImages: []ske.MachineImage{
 									{
 										Name: new("flatcar"),
-										Versions: new([]ske.MachineImageVersion{
+										Versions: []ske.MachineImageVersion{
 											{
 												State:          new("supported"),
 												Version:        new("1.0.0"),
 												ExpirationDate: nil,
-												Cri: new([]ske.CRI{
+												Cri: []ske.CRI{
 													{
-														Name: new(ske.CRINAME_CONTAINERD),
+														Name: new(string(legacySke.CRINAME_CONTAINERD)),
 													},
-												}),
+												},
 											},
-										}),
+										},
 									},
-								}),
-								MachineTypes: new([]ske.MachineType{
+								},
+								MachineTypes: []ske.MachineType{
 									{
 										Name: new(machineType),
 									},
-								}),
-								KubernetesVersions: new([]ske.KubernetesVersion{
+								},
+								KubernetesVersions: []ske.KubernetesVersion{
 									{
 										State:          new("supported"),
 										ExpirationDate: nil,
 										Version:        new(kubernetesVersionMin),
 									},
-								}),
+								},
 							},
 						},
 						testutil.MockResponse{
@@ -316,7 +317,7 @@ resource "stackit_ske_cluster" "cluster" {
 						testutil.MockResponse{Description: "delete", StatusCode: http.StatusAccepted},
 						testutil.MockResponse{Description: "ListClusterResponse is called for checking removal",
 							ToJsonBody: ske.ListClustersResponse{
-								Items: &[]ske.Cluster{},
+								Items: []ske.Cluster{},
 							},
 						},
 					)
@@ -344,7 +345,7 @@ resource "stackit_ske_cluster" "cluster" {
 						testutil.MockResponse{Description: "delete", StatusCode: http.StatusAccepted},
 						testutil.MockResponse{Description: "ListClusterResponse is called for checking removal",
 							ToJsonBody: ske.ListClustersResponse{
-								Items: &[]ske.Cluster{},
+								Items: []ske.Cluster{},
 							},
 						},
 					)


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1397

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
