### PR TITLE
fix(secretsmanager): Allow inplace update of user description

### DIFF
--- a/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
+++ b/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
@@ -53,6 +53,7 @@ func configVarsMinUpdated() config.Variables {
 	tempConfig := maps.Clone(testConfigVarsMin)
 	tempConfig["instance_name"] = config.StringVariable(testutil.ConvertConfigVariable(tempConfig["instance_name"]) + "-updated")
 	tempConfig["write_enabled"] = config.BoolVariable(false)
+	tempConfig["description"] = config.StringVariable(testutil.ConvertConfigVariable(tempConfig["description"]) + "-updated")
 	return tempConfig
 }
 
@@ -62,6 +63,7 @@ func configVarsMaxUpdated() config.Variables {
 	tempConfig["write_enabled"] = config.BoolVariable(false)
 	tempConfig["use_kms_key"] = config.BoolVariable(false)
 	tempConfig["acl2"] = config.StringVariable("10.100.2.0/24")
+	tempConfig["description"] = config.StringVariable(testutil.ConvertConfigVariable(tempConfig["description"]) + "-updated")
 	return tempConfig
 }
 

--- a/stackit/internal/services/secretsmanager/user/resource.go
+++ b/stackit/internal/services/secretsmanager/user/resource.go
@@ -135,9 +135,6 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"description": schema.StringAttribute{
 				Description: descriptions["description"],
 				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"write_enabled": schema.BoolAttribute{
 				Description: descriptions["write_enabled"],
@@ -396,7 +393,8 @@ func toUpdatePayload(model *Model) (*secretsmanager.UpdateUserPayload, error) {
 		return nil, fmt.Errorf("nil model")
 	}
 	return &secretsmanager.UpdateUserPayload{
-		Write: conversion.BoolValueToPointer(model.WriteEnabled),
+		Description: conversion.StringValueToPointer(model.Description),
+		Write:       conversion.BoolValueToPointer(model.WriteEnabled),
 	}, nil
 }
 

--- a/stackit/internal/services/secretsmanager/user/resource_test.go
+++ b/stackit/internal/services/secretsmanager/user/resource_test.go
@@ -229,17 +229,20 @@ func TestToUpdatePayload(t *testing.T) {
 			"default_values",
 			&Model{},
 			&secretsmanager.UpdateUserPayload{
-				Write: nil,
+				Description: nil,
+				Write:       nil,
 			},
 			true,
 		},
 		{
 			"simple_values",
 			&Model{
+				Description:  types.StringValue("description"),
 				WriteEnabled: types.BoolValue(false),
 			},
 			&secretsmanager.UpdateUserPayload{
-				Write: new(false),
+				Description: new("description"),
+				Write:       new(false),
 			},
 			true,
 		},


### PR DESCRIPTION
## Description

A bug was found where the API definition suggests an in place update of the user description of a secrets manager user but the TFP replaces the secrets manager instance instead. See https://github.com/stackitcloud/terraform-provider-stackit/issues/882 

relates to STACKITTPR-649

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
