### PR TITLE
fix(mongodbflex): fixed wrong dailySnapshotRetentionDays parameter

### DIFF
--- a/stackit/internal/services/mongodbflex/mongodbflex_acc_test.go
+++ b/stackit/internal/services/mongodbflex/mongodbflex_acc_test.go
@@ -38,7 +38,7 @@ var instanceResource = map[string]string{
 	"backup_schedule_read":            "0 6 * * *",
 	"snapshot_retention_days":         "4",
 	"snapshot_retention_days_updated": "3",
-	"daily_snapshot_retention_days":   "1",
+	"daily_snapshot_retention_days":   "3",
 	"point_in_time_window_hours":      "30",
 }
 


### PR DESCRIPTION
## Description

Acc tests for Mongodbflex are failing:
```sh
➜  terraform-provider-stackit git:(main) ✗ TF_ACC=1 go test -v ./stackit/internal/services/mongodbflex/mongodbflex_acc_test.go
=== RUN   TestAccMongoDBFlexFlexResource
    mongodbflex_acc_test.go:110: Step 1/5 error: Error running apply: exit status 1
        
        Error: Error creating instance
        
          with stackit_mongodbflex_instance.instance,
          on terraform_plugin_test.tf line 17, in resource "stackit_mongodbflex_instance" "instance":
          17:                           resource "stackit_mongodbflex_instance" "instance" {
        
        Updating options: 400 Bad Request, status code 400, Body: {"message":"error
        validating
        parameters","code":400,"type":"Validation","fields":{"dailySnapshotRetentionDays":["daily
        snapshot retention days must be one of: [0 3 4 5 6 7 15 30 60 90]"]}}
        
        
        Trace ID: "adf460d1e13cf723b74d2e2c86ea1e84"
--- FAIL: TestAccMongoDBFlexFlexResource (439.29s)
FAIL
FAIL    command-line-arguments  439.900s
FAIL
```

relates to STACKITTPR-663

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
