### PR TITLE
chore(authorization): migrate to new SDK structure

### DIFF
--- a/stackit/internal/services/authorization/authorization_acc_test.go
+++ b/stackit/internal/services/authorization/authorization_acc_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
-	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
-	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager/wait"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
+	resourcemanager "github.com/stackitcloud/stackit-sdk-go/services/resourcemanager/v0api"
+	"github.com/stackitcloud/stackit-sdk-go/services/resourcemanager/v0api/wait"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
@@ -803,27 +803,26 @@ func testAccCheckResourceManagerProjectsDestroy(s *terraform.State) error {
 	}
 	containerParentId := testutil.OrganizationId
 
-	projectsResp, err := client.ListProjects(ctx).ContainerParentId(containerParentId).Execute()
+	projectsResp, err := client.DefaultAPI.ListProjects(ctx).ContainerParentId(containerParentId).Execute()
 	if err != nil {
 		return fmt.Errorf("getting projectsResp: %w", err)
 	}
 
-	items := *projectsResp.Items
-	for i := range items {
-		if *items[i].LifecycleState == resourcemanager.LIFECYCLESTATE_DELETING {
+	for _, item := range projectsResp.Items {
+		if item.LifecycleState == resourcemanager.LIFECYCLESTATE_DELETING {
 			continue
 		}
-		if !utils.Contains(projectsToDestroy, *items[i].ContainerId) {
+		if !utils.Contains(projectsToDestroy, item.ContainerId) {
 			continue
 		}
 
-		err := client.DeleteProjectExecute(ctx, *items[i].ContainerId)
+		err := client.DefaultAPI.DeleteProject(ctx, item.ContainerId).Execute()
 		if err != nil {
-			return fmt.Errorf("destroying project %s during CheckDestroy: %w", *items[i].ContainerId, err)
+			return fmt.Errorf("destroying project %s during CheckDestroy: %w", item.ContainerId, err)
 		}
-		_, err = wait.DeleteProjectWaitHandler(ctx, client, *items[i].ContainerId).WaitWithContext(ctx)
+		_, err = wait.DeleteProjectWaitHandler(ctx, client.DefaultAPI, item.ContainerId).WaitWithContext(ctx)
 		if err != nil {
-			return fmt.Errorf("destroying project %s during CheckDestroy: waiting for deletion %w", *items[i].ContainerId, err)
+			return fmt.Errorf("destroying project %s during CheckDestroy: waiting for deletion %w", item.ContainerId, err)
 		}
 	}
 	return nil
@@ -851,20 +850,19 @@ func testAccCheckResourceManagerFoldersDestroy(s *terraform.State) error {
 	}
 	containerParentId := testutil.OrganizationId
 
-	foldersResponse, err := client.ListFolders(ctx).ContainerParentId(containerParentId).Execute()
+	foldersResponse, err := client.DefaultAPI.ListFolders(ctx).ContainerParentId(containerParentId).Execute()
 	if err != nil {
 		return fmt.Errorf("getting foldersResponse: %w", err)
 	}
 
-	items := *foldersResponse.Items
-	for i := range items {
-		if !utils.Contains(foldersToDestroy, *items[i].ContainerId) {
+	for _, item := range foldersResponse.Items {
+		if !utils.Contains(foldersToDestroy, item.ContainerId) {
 			continue
 		}
 
-		err := client.DeleteFolder(ctx, *items[i].ContainerId).Execute()
+		err := client.DefaultAPI.DeleteFolder(ctx, item.ContainerId).Execute()
 		if err != nil {
-			return fmt.Errorf("destroying folder %s during CheckDestroy: %w", *items[i].ContainerId, err)
+			return fmt.Errorf("destroying folder %s during CheckDestroy: %w", item.ContainerId, err)
 		}
 	}
 	return nil
@@ -888,8 +886,8 @@ func testAccCheckOrganizationRoleAssignmentDestroy(s *terraform.State) error {
 		orgRoleAssignmentsToDestroy = append(
 			orgRoleAssignmentsToDestroy,
 			authorization.Member{
-				Role:    new(terraformId[1]),
-				Subject: new(terraformId[2]),
+				Role:    terraformId[1],
+				Subject: terraformId[2],
 			},
 		)
 	}
@@ -900,12 +898,12 @@ func testAccCheckOrganizationRoleAssignmentDestroy(s *terraform.State) error {
 	containerParentId := testutil.OrganizationId
 
 	payload := authorization.RemoveMembersPayload{
-		ResourceType: new("organization"),
-		Members:      &orgRoleAssignmentsToDestroy,
+		ResourceType: "organization",
+		Members:      orgRoleAssignmentsToDestroy,
 	}
 
 	// Ignore error. If this request errors the org role assignment has been successfully deleted by terraform itself.
-	_, _ = client.RemoveMembers(ctx, containerParentId).RemoveMembersPayload(payload).Execute()
+	_, _ = client.DefaultAPI.RemoveMembers(ctx, containerParentId).RemoveMembersPayload(payload).Execute()
 	return nil
 }
 
@@ -928,16 +926,16 @@ func testAccCheckServiceAccountRoleAssignmentDestroy(s *terraform.State) error {
 
 		resourceId := terraformId[0]
 		payload := authorization.RemoveMembersPayload{
-			ResourceType: new("service-account"),
-			Members: &[]authorization.Member{
+			ResourceType: "service-account",
+			Members: []authorization.Member{
 				{
-					Role:    new(terraformId[1]),
-					Subject: new(terraformId[2]),
+					Role:    terraformId[1],
+					Subject: terraformId[2],
 				},
 			},
 		}
 
-		_, err = client.RemoveMembers(ctx, resourceId).RemoveMembersPayload(payload).Execute()
+		_, err = client.DefaultAPI.RemoveMembers(ctx, resourceId).RemoveMembersPayload(payload).Execute()
 		if err != nil && !strings.Contains(err.Error(), "400") {
 			return fmt.Errorf("destroying assignment %s: %w", rs.Primary.ID, err)
 		}

--- a/stackit/internal/services/authorization/customrole/datasource.go
+++ b/stackit/internal/services/authorization/customrole/datasource.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -132,7 +132,7 @@ func (d *customRoleDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	ctx = tflog.SetField(ctx, "resource_id", resourceId)
 	ctx = tflog.SetField(ctx, "role_id", roleId)
 
-	roleResp, err := d.client.GetRole(ctx, d.resourceType, resourceId, roleId).Execute()
+	roleResp, err := d.client.DefaultAPI.GetRole(ctx, d.resourceType, resourceId, roleId).Execute()
 	if err != nil {
 		var oapiErr *oapierror.GenericOpenAPIError
 

--- a/stackit/internal/services/authorization/customrole/resource.go
+++ b/stackit/internal/services/authorization/customrole/resource.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -177,7 +177,7 @@ func (r *customRoleResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	createResp, err := r.client.AddRole(ctx, r.resourceType, model.ResourceId.ValueString()).AddRolePayload(*payload).Execute()
+	createResp, err := r.client.DefaultAPI.AddRole(ctx, r.resourceType, model.ResourceId.ValueString()).AddRolePayload(*payload).Execute()
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating custom role", fmt.Sprintf("Calling API: %v", err))
 		return
@@ -222,7 +222,7 @@ func (r *customRoleResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	roleResp, err := r.client.GetRoleExecute(ctx, r.resourceType, model.ResourceId.ValueString(), roleId)
+	roleResp, err := r.client.DefaultAPI.GetRole(ctx, r.resourceType, model.ResourceId.ValueString(), roleId).Execute()
 	if err != nil {
 		var oapiErr *oapierror.GenericOpenAPIError
 
@@ -273,7 +273,7 @@ func (r *customRoleResource) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Update existing custom role
-	roleResp, err := r.client.UpdateRole(ctx, r.resourceType, model.ResourceId.ValueString(), model.RoleId.ValueString()).UpdateRolePayload(*payload).Execute()
+	roleResp, err := r.client.DefaultAPI.UpdateRole(ctx, r.resourceType, model.ResourceId.ValueString(), model.RoleId.ValueString()).UpdateRolePayload(*payload).Execute()
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating custom role", fmt.Sprintf("Calling API: %v", err))
 		return
@@ -311,7 +311,7 @@ func (r *customRoleResource) Delete(ctx context.Context, req resource.DeleteRequ
 
 	ctx = r.annotateLogger(ctx, &model)
 
-	_, err := r.client.DeleteRoleExecute(ctx, r.resourceType, model.ResourceId.ValueString(), model.RoleId.ValueString())
+	_, err := r.client.DefaultAPI.DeleteRole(ctx, r.resourceType, model.ResourceId.ValueString(), model.RoleId.ValueString()).Execute()
 	if err != nil {
 		var oapiErr *oapierror.GenericOpenAPIError
 		if errors.As(err, &oapiErr) && oapiErr.StatusCode == http.StatusNotFound {
@@ -351,10 +351,6 @@ func mapGetCustomRoleResponse(ctx context.Context, resp *authorization.GetRoleRe
 		return fmt.Errorf("response input is nil")
 	}
 
-	if resp.Role == nil {
-		return fmt.Errorf("response role is nil")
-	}
-
 	if resp.Role.Id == nil {
 		return fmt.Errorf("response role id is nil")
 	}
@@ -372,21 +368,21 @@ func mapGetCustomRoleResponse(ctx context.Context, resp *authorization.GetRoleRe
 		return err
 	}
 
-	model.Id = utils.BuildInternalTerraformId(*resp.ResourceId, *resp.Role.Id)
-	model.ResourceId = types.StringPointerValue(resp.ResourceId)
+	model.Id = utils.BuildInternalTerraformId(resp.ResourceId, *resp.Role.Id)
+	model.ResourceId = types.StringValue(resp.ResourceId)
 	model.RoleId = types.StringPointerValue(resp.Role.Id)
-	model.Name = types.StringPointerValue(resp.Role.Name)
-	model.Description = types.StringPointerValue(resp.Role.Description)
+	model.Name = types.StringValue(resp.Role.Name)
+	model.Description = types.StringValue(resp.Role.Description)
 
-	if len(*resp.Role.Permissions) == 0 {
+	if len(resp.Role.Permissions) == 0 {
 		model.Permissions = types.ListNull(types.StringType)
 		return nil
 	}
 
 	var respPermissions []string
-	for _, p := range *resp.Role.Permissions {
+	for _, p := range resp.Role.Permissions {
 		if name, ok := p.GetNameOk(); ok {
-			respPermissions = append(respPermissions, name)
+			respPermissions = append(respPermissions, *name)
 		}
 	}
 
@@ -436,13 +432,13 @@ func toCreatePayload(ctx context.Context, model *Model) (*authorization.AddRoleP
 			return nil, fmt.Errorf("converting permission list entry to string: %w", err)
 		}
 
-		permissions = append(permissions, authorization.PermissionRequest{Name: &permission})
+		permissions = append(permissions, authorization.PermissionRequest{Name: permission})
 	}
 
 	return &authorization.AddRolePayload{
-		Name:        model.Name.ValueStringPointer(),
-		Description: model.Description.ValueStringPointer(),
-		Permissions: &permissions,
+		Name:        model.Name.ValueString(),
+		Description: model.Description.ValueString(),
+		Permissions: permissions,
 	}, nil
 }
 
@@ -463,13 +459,13 @@ func toUpdatePayload(ctx context.Context, model *Model) (*authorization.UpdateRo
 			return nil, fmt.Errorf("converting permission list entry to string: %w", err)
 		}
 
-		permissions = append(permissions, authorization.PermissionRequest{Name: &permission})
+		permissions = append(permissions, authorization.PermissionRequest{Name: permission})
 	}
 
 	return &authorization.UpdateRolePayload{
-		Name:        model.Name.ValueStringPointer(),
-		Description: model.Description.ValueStringPointer(),
-		Permissions: &permissions,
+		Name:        model.Name.ValueString(),
+		Description: model.Description.ValueString(),
+		Permissions: permissions,
 	}, nil
 }
 

--- a/stackit/internal/services/authorization/customrole/resource_test.go
+++ b/stackit/internal/services/authorization/customrole/resource_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
 )
 
 var (
@@ -40,19 +40,19 @@ func TestMapFields(t *testing.T) {
 			{
 				description: fmt.Sprintf("full_input_%s", resourceType),
 				input: &authorization.GetRoleResponse{
-					ResourceId:   &testResourceId,
-					ResourceType: &resourceType,
-					Role: new(authorization.Role{
+					ResourceId:   testResourceId,
+					ResourceType: resourceType,
+					Role: authorization.Role{
 						Id:          &testRoleId,
-						Name:        new("role-name"),
-						Description: new("Some description"),
-						Permissions: new([]authorization.Permission{
+						Name:        "role-name",
+						Description: "Some description",
+						Permissions: []authorization.Permission{
 							{
-								Name:        new("iam.subject.get"),
-								Description: new("Can read subjects."),
+								Name:        "iam.subject.get",
+								Description: "Can read subjects.",
 							},
-						}),
-					}),
+						},
+					},
 				},
 				expected: &Model{
 					Id:          types.StringValue(fmt.Sprintf("%s,%s", testResourceId, testRoleId)),
@@ -69,21 +69,25 @@ func TestMapFields(t *testing.T) {
 			{
 				description: fmt.Sprintf("partial_input_%s", resourceType),
 				input: &authorization.GetRoleResponse{
-					ResourceId:   &testResourceId,
-					ResourceType: &resourceType,
-					Role: new(authorization.Role{
-						Id: &testRoleId,
-						Permissions: new([]authorization.Permission{
+					ResourceId:   testResourceId,
+					ResourceType: resourceType,
+					Role: authorization.Role{
+						Id:          &testRoleId,
+						Name:        "role-name",
+						Description: "Some description",
+						Permissions: []authorization.Permission{
 							{
-								Name: new("iam.subject.get"),
+								Name: "iam.subject.get",
 							},
-						}),
-					}),
+						},
+					},
 				},
 				expected: &Model{
-					Id:         types.StringValue(fmt.Sprintf("%s,%s", testResourceId, testRoleId)),
-					RoleId:     types.StringValue(testRoleId),
-					ResourceId: types.StringValue(testResourceId),
+					Id:          types.StringValue(fmt.Sprintf("%s,%s", testResourceId, testRoleId)),
+					RoleId:      types.StringValue(testRoleId),
+					ResourceId:  types.StringValue(testResourceId),
+					Name:        types.StringValue("role-name"),
+					Description: types.StringValue("Some description"),
 					Permissions: types.ListValueMust(types.StringType, []attr.Value{
 						types.StringValue("iam.subject.get"),
 					}),
@@ -93,8 +97,8 @@ func TestMapFields(t *testing.T) {
 			{
 				description: fmt.Sprintf("missing_role_%s", resourceType),
 				input: &authorization.GetRoleResponse{
-					ResourceId:   &testResourceId,
-					ResourceType: &resourceType,
+					ResourceId:   testResourceId,
+					ResourceType: resourceType,
 				},
 				expected: nil,
 				isValid:  false,
@@ -102,11 +106,11 @@ func TestMapFields(t *testing.T) {
 			{
 				description: fmt.Sprintf("missing_permissions_%s", resourceType),
 				input: &authorization.GetRoleResponse{
-					ResourceId:   &testResourceId,
-					ResourceType: &resourceType,
-					Role: new(authorization.Role{
+					ResourceId:   testResourceId,
+					ResourceType: resourceType,
+					Role: authorization.Role{
 						Id: &testRoleId,
-					}),
+					},
 				},
 				expected: nil,
 				isValid:  false,
@@ -114,11 +118,11 @@ func TestMapFields(t *testing.T) {
 			{
 				description: fmt.Sprintf("missing_role_id_%s", resourceType),
 				input: &authorization.GetRoleResponse{
-					ResourceId:   &testResourceId,
-					ResourceType: &resourceType,
-					Role: new(authorization.Role{
-						Permissions: new([]authorization.Permission{}),
-					}),
+					ResourceId:   testResourceId,
+					ResourceType: resourceType,
+					Role: authorization.Role{
+						Permissions: []authorization.Permission{},
+					},
 				},
 				expected: nil,
 				isValid:  false,
@@ -126,8 +130,8 @@ func TestMapFields(t *testing.T) {
 			{
 				description: fmt.Sprintf("missing_role_%s", resourceType),
 				input: &authorization.GetRoleResponse{
-					ResourceId:   &testResourceId,
-					ResourceType: &resourceType,
+					ResourceId:   testResourceId,
+					ResourceType: resourceType,
 				},
 				expected: nil,
 				isValid:  false,
@@ -135,11 +139,11 @@ func TestMapFields(t *testing.T) {
 			{
 				description: fmt.Sprintf("missing_permissions_%s", resourceType),
 				input: &authorization.GetRoleResponse{
-					ResourceId:   &testResourceId,
-					ResourceType: &resourceType,
-					Role: new(authorization.Role{
+					ResourceId:   testResourceId,
+					ResourceType: resourceType,
+					Role: authorization.Role{
 						Id: &testRoleId,
-					}),
+					},
 				},
 				expected: nil,
 				isValid:  false,
@@ -201,20 +205,20 @@ func TestToCreatePayload(t *testing.T) {
 				}),
 			},
 			expected: authorization.AddRolePayload{
-				Name:        new("role-name"),
-				Description: new("Some description"),
-				Permissions: new([]authorization.PermissionRequest{
+				Name:        "role-name",
+				Description: "Some description",
+				Permissions: []authorization.PermissionRequest{
 					{
-						Name: new("iam.subject.get"),
+						Name: "iam.subject.get",
 					},
-				}),
+				},
 			},
 		},
 		{
 			description: "empty values still valid",
 			input:       &Model{},
 			expected: authorization.AddRolePayload{
-				Permissions: new([]authorization.PermissionRequest{}),
+				Permissions: []authorization.PermissionRequest{},
 			},
 			expectError: false,
 		},

--- a/stackit/internal/services/authorization/roleassignments/resource.go
+++ b/stackit/internal/services/authorization/roleassignments/resource.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -192,7 +192,7 @@ func (r *roleAssignmentResource) Create(ctx context.Context, req resource.Create
 	unlock := authorizationUtils.LockAssignment(lockKey)
 	defer unlock()
 
-	listMemberResp, err := r.authorizationClient.ListMembers(ctx, r.apiName, model.ResourceId.ValueString()).Subject(model.Subject.ValueString()).Execute()
+	listMemberResp, err := r.authorizationClient.DefaultAPI.ListMembers(ctx, r.apiName, model.ResourceId.ValueString()).Subject(model.Subject.ValueString()).Execute()
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error listing current resource members", fmt.Sprintf("Calling API: %v", err))
 		return
@@ -204,13 +204,13 @@ func (r *roleAssignmentResource) Create(ctx context.Context, req resource.Create
 	}
 
 	// Create new project role assignment
-	payload, err := toCreatePayload(&model, &r.apiName)
+	payload, err := toCreatePayload(&model, r.apiName)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating credential", fmt.Sprintf("Creating API payload: %v", err))
 		return
 	}
 
-	createResp, err := r.authorizationClient.AddMembers(ctx, model.ResourceId.ValueString()).AddMembersPayload(*payload).Execute()
+	createResp, err := r.authorizationClient.DefaultAPI.AddMembers(ctx, model.ResourceId.ValueString()).AddMembersPayload(*payload).Execute()
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, fmt.Sprintf("Error creating %s role assignment", r.apiName), fmt.Sprintf("Calling API: %v", err))
 		return
@@ -257,7 +257,7 @@ func (r *roleAssignmentResource) Read(ctx context.Context, req resource.ReadRequ
 	ctx = tflog.SetField(ctx, "resource_type", r.apiName)
 	ctx = tflog.SetField(ctx, "resource_id", model.ResourceId.ValueString())
 
-	listResp, err := r.authorizationClient.ListMembers(ctx, r.apiName, model.ResourceId.ValueString()).Subject(model.Subject.ValueString()).Execute()
+	listResp, err := r.authorizationClient.DefaultAPI.ListMembers(ctx, r.apiName, model.ResourceId.ValueString()).Subject(model.Subject.ValueString()).Execute()
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading authorizations", fmt.Sprintf("Calling API: %v", err))
 		return
@@ -306,17 +306,17 @@ func (r *roleAssignmentResource) Delete(ctx context.Context, req resource.Delete
 	ctx = tflog.SetField(ctx, "resource_id", model.ResourceId.ValueString())
 
 	payload := authorization.RemoveMembersPayload{
-		ResourceType: &r.apiName,
-		Members: &[]authorization.Member{
+		ResourceType: r.apiName,
+		Members: []authorization.Member{
 			{
-				Role:    model.Role.ValueStringPointer(),
-				Subject: model.Subject.ValueStringPointer(),
+				Role:    model.Role.ValueString(),
+				Subject: model.Subject.ValueString(),
 			},
 		},
 	}
 
 	// Delete existing project role assignment
-	_, err := r.authorizationClient.RemoveMembers(ctx, model.ResourceId.ValueString()).RemoveMembersPayload(payload).Execute()
+	_, err := r.authorizationClient.DefaultAPI.RemoveMembers(ctx, model.ResourceId.ValueString()).RemoveMembersPayload(payload).Execute()
 	if err != nil {
 		var oapiErr *oapierror.GenericOpenAPIError
 		if errors.As(err, &oapiErr) && oapiErr.StatusCode == http.StatusNotFound {
@@ -353,7 +353,7 @@ func (r *roleAssignmentResource) ImportState(ctx context.Context, req resource.I
 }
 
 // toCreatePayload builds the payload to add a member to a resource
-func toCreatePayload(model *Model, apiName *string) (*authorization.AddMembersPayload, error) {
+func toCreatePayload(model *Model, apiName string) (*authorization.AddMembersPayload, error) {
 	if model == nil {
 		return nil, fmt.Errorf("nil model")
 	}
@@ -368,10 +368,10 @@ func toCreatePayload(model *Model, apiName *string) (*authorization.AddMembersPa
 
 	return &authorization.AddMembersPayload{
 		ResourceType: apiName,
-		Members: &[]authorization.Member{
+		Members: []authorization.Member{
 			{
-				Role:    model.Role.ValueStringPointer(),
-				Subject: model.Subject.ValueStringPointer(),
+				Role:    model.Role.ValueString(),
+				Subject: model.Subject.ValueString(),
 			},
 		},
 	}, nil
@@ -385,20 +385,17 @@ func mapListMembersResponse(resp *authorization.ListMembersResponse, model *Mode
 	if resp.Members == nil {
 		return fmt.Errorf("response members are nil")
 	}
-	if resp.ResourceId == nil {
-		return fmt.Errorf("response resource_id is nil")
-	}
 	if model == nil {
 		return fmt.Errorf("model input is nil")
 	}
 
-	model.ResourceId = types.StringPointerValue(resp.ResourceId)
+	model.ResourceId = types.StringValue(resp.ResourceId)
 	model.Id = utils.BuildInternalTerraformId(model.ResourceId.ValueString(), model.Role.ValueString(), model.Subject.ValueString())
 
-	for _, m := range *resp.Members {
-		if *m.Role == model.Role.ValueString() && *m.Subject == model.Subject.ValueString() {
-			model.Role = types.StringPointerValue(m.Role)
-			model.Subject = types.StringPointerValue(m.Subject)
+	for _, m := range resp.Members {
+		if m.Role == model.Role.ValueString() && m.Subject == model.Subject.ValueString() {
+			model.Role = types.StringValue(m.Role)
+			model.Subject = types.StringValue(m.Subject)
 			return nil
 		}
 	}

--- a/stackit/internal/services/authorization/roleassignments/resource_test.go
+++ b/stackit/internal/services/authorization/roleassignments/resource_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
 
 	tfUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
 )
@@ -17,7 +17,7 @@ func TestToCreatePayload(t *testing.T) {
 	tests := []struct {
 		name        string
 		input       *Model
-		apiName     *string
+		apiName     string
 		expectError bool
 		expected    *authorization.AddMembersPayload
 	}{
@@ -27,14 +27,14 @@ func TestToCreatePayload(t *testing.T) {
 				Role:    types.StringValue("editor"),
 				Subject: types.StringValue("foo.bar@stackit.cloud"),
 			},
-			apiName:     &apiName,
+			apiName:     apiName,
 			expectError: false,
 			expected: &authorization.AddMembersPayload{
-				ResourceType: &apiName,
-				Members: &[]authorization.Member{
+				ResourceType: apiName,
+				Members: []authorization.Member{
 					{
-						Role:    new("editor"),
-						Subject: new("foo.bar@stackit.cloud"),
+						Role:    "editor",
+						Subject: "foo.bar@stackit.cloud",
 					},
 				},
 			},
@@ -42,7 +42,7 @@ func TestToCreatePayload(t *testing.T) {
 		{
 			name:        "nil model",
 			input:       nil,
-			apiName:     &apiName,
+			apiName:     apiName,
 			expectError: true,
 		},
 		{
@@ -51,7 +51,7 @@ func TestToCreatePayload(t *testing.T) {
 				Role:    types.StringUnknown(),
 				Subject: types.StringValue("foo.bar@stackit.cloud"),
 			},
-			apiName:     &apiName,
+			apiName:     apiName,
 			expectError: true,
 		},
 		{
@@ -60,7 +60,7 @@ func TestToCreatePayload(t *testing.T) {
 				Role:    types.StringValue(""),
 				Subject: types.StringValue("foo.bar@stackit.cloud"),
 			},
-			apiName:     &apiName,
+			apiName:     apiName,
 			expectError: true,
 		},
 		{
@@ -69,7 +69,7 @@ func TestToCreatePayload(t *testing.T) {
 				Role:    types.StringValue("editor"),
 				Subject: types.StringUnknown(),
 			},
-			apiName:     &apiName,
+			apiName:     apiName,
 			expectError: true,
 		},
 		{
@@ -78,7 +78,7 @@ func TestToCreatePayload(t *testing.T) {
 				Role:    types.StringValue("editor"),
 				Subject: types.StringValue(""),
 			},
-			apiName:     &apiName,
+			apiName:     apiName,
 			expectError: true,
 		},
 	}
@@ -118,11 +118,11 @@ func TestMapListMembersResponse(t *testing.T) {
 		{
 			name: "successfully maps values",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
-				Members: &[]authorization.Member{
+				ResourceId: resourceID,
+				Members: []authorization.Member{
 					{
-						Role:    &role,
-						Subject: &subject,
+						Role:    role,
+						Subject: subject,
 					},
 				},
 			},
@@ -150,25 +150,8 @@ func TestMapListMembersResponse(t *testing.T) {
 		{
 			name: "nil members input",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
+				ResourceId: resourceID,
 				Members:    nil,
-			},
-			inputModel: &Model{
-				Role:    types.StringValue(role),
-				Subject: types.StringValue(subject),
-			},
-			expectError: true,
-		},
-		{
-			name: "nil resource_id input",
-			resp: &authorization.ListMembersResponse{
-				ResourceId: nil,
-				Members: &[]authorization.Member{
-					{
-						Role:    &role,
-						Subject: &subject,
-					},
-				},
 			},
 			inputModel: &Model{
 				Role:    types.StringValue(role),
@@ -179,11 +162,11 @@ func TestMapListMembersResponse(t *testing.T) {
 		{
 			name: "nil model input",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
-				Members: &[]authorization.Member{
+				ResourceId: resourceID,
+				Members: []authorization.Member{
 					{
-						Role:    &role,
-						Subject: &subject,
+						Role:    role,
+						Subject: subject,
 					},
 				},
 			},
@@ -193,11 +176,11 @@ func TestMapListMembersResponse(t *testing.T) {
 		{
 			name: "no matching role/subject pair",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
-				Members: &[]authorization.Member{
+				ResourceId: resourceID,
+				Members: []authorization.Member{
 					{
-						Role:    new("reader"),
-						Subject: new("foo.bar@stackit.cloud"),
+						Role:    "reader",
+						Subject: "foo.bar@stackit.cloud",
 					},
 				},
 			},
@@ -244,8 +227,8 @@ func TestCheckDuplicate(t *testing.T) {
 		{
 			name: "no members => no duplicate",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
-				Members:    &[]authorization.Member{},
+				ResourceId: resourceID,
+				Members:    []authorization.Member{},
 			},
 			inputModel: Model{
 				ResourceId: types.StringValue(resourceID),
@@ -257,15 +240,15 @@ func TestCheckDuplicate(t *testing.T) {
 		{
 			name: "members but no matching role/subject => no duplicate",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
-				Members: &[]authorization.Member{
+				ResourceId: resourceID,
+				Members: []authorization.Member{
 					{
-						Role:    new("reader"),
-						Subject: new("foo.bar@stackit.cloud"),
+						Role:    "reader",
+						Subject: "foo.bar@stackit.cloud",
 					},
 					{
-						Role:    new("editor"),
-						Subject: new("someoneelse@stackit.cloud"),
+						Role:    "editor",
+						Subject: "someoneelse@stackit.cloud",
 					},
 				},
 			},
@@ -279,11 +262,11 @@ func TestCheckDuplicate(t *testing.T) {
 		{
 			name: "matching role/subject exists => duplicate error",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
-				Members: &[]authorization.Member{
+				ResourceId: resourceID,
+				Members: []authorization.Member{
 					{
-						Role:    &role,
-						Subject: &subject,
+						Role:    role,
+						Subject: subject,
 					},
 				},
 			},
@@ -309,26 +292,8 @@ func TestCheckDuplicate(t *testing.T) {
 		{
 			name: "nil members input => propagated error",
 			resp: &authorization.ListMembersResponse{
-				ResourceId: &resourceID,
+				ResourceId: resourceID,
 				Members:    nil,
-			},
-			inputModel: Model{
-				ResourceId: types.StringValue(resourceID),
-				Role:       types.StringValue(role),
-				Subject:    types.StringValue(subject),
-			},
-			expectError: true,
-		},
-		{
-			name: "nil resource_id input => propagated error",
-			resp: &authorization.ListMembersResponse{
-				ResourceId: nil,
-				Members: &[]authorization.Member{
-					{
-						Role:    &role,
-						Subject: &subject,
-					},
-				},
 			},
 			inputModel: Model{
 				ResourceId: types.StringValue(resourceID),

--- a/stackit/internal/services/authorization/utils/util.go
+++ b/stackit/internal/services/authorization/utils/util.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"

--- a/stackit/internal/services/authorization/utils/util_test.go
+++ b/stackit/internal/services/authorization/utils/util_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	sdkClients "github.com/stackitcloud/stackit-sdk-go/core/clients"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	"github.com/stackitcloud/stackit-sdk-go/services/authorization"
+	authorization "github.com/stackitcloud/stackit-sdk-go/services/authorization/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
@@ -105,31 +106,35 @@ func TestTypeConverter(t *testing.T) {
 		{
 			name: "success - all fields populated",
 			input: authorization.MembersResponse{
-				Members: &[]authorization.Member{
+				Members: []authorization.Member{
 					{
-						Role:    new("editor"),
-						Subject: new("foo.bar@stackit.cloud"),
+						Role:    "editor",
+						Subject: "foo.bar@stackit.cloud",
 					},
 				},
-				ResourceId:   new("project-123"),
-				ResourceType: new("project"),
+				ResourceId:   "project-123",
+				ResourceType: "project",
 			},
 			expected: &authorization.ListMembersResponse{
-				Members: &[]authorization.Member{
+				Members: []authorization.Member{
 					{
-						Role:    new("editor"),
-						Subject: new("foo.bar@stackit.cloud"),
+						Role:                 "editor",
+						Subject:              "foo.bar@stackit.cloud",
+						AdditionalProperties: map[string]interface{}{},
 					},
 				},
-				ResourceId:   new("project-123"),
-				ResourceType: new("project"),
+				ResourceId:           "project-123",
+				ResourceType:         "project",
+				AdditionalProperties: map[string]interface{}{},
 			},
 			expectError: false,
 		},
 		{
-			name:        "success - completely empty input",
-			input:       authorization.MembersResponse{},
-			expected:    &authorization.ListMembersResponse{},
+			name:  "success - completely empty input",
+			input: authorization.MembersResponse{},
+			expected: &authorization.ListMembersResponse{
+				AdditionalProperties: map[string]interface{}{},
+			},
 			expectError: false,
 		},
 	}
@@ -140,6 +145,11 @@ func TestTypeConverter(t *testing.T) {
 
 			if (err != nil) != tc.expectError {
 				t.Fatalf("unexpected error: got error=%v, expectError=%v", err, tc.expectError)
+			}
+
+			diff := cmp.Diff(tc.expected, actual)
+			if diff != "" {
+				t.Fatalf("Data does not match: %s", diff)
 			}
 
 			if !tc.expectError && !reflect.DeepEqual(actual, tc.expected) {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
