### PR TITLE
refac(observability): Adjust scheme for scrapeconfig to new enum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/modelserving v0.10.0
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.8.3
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0
-	github.com/stackitcloud/stackit-sdk-go/services/observability v0.22.0
+	github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.28.0
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.8.0
 	github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -704,8 +704,8 @@ github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.8.3 h1:QW//diMedJ
 github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.8.3/go.mod h1:0hHEPiOEMAA23EzEl42Rm3FlyKIzkW+LWLvDkuFTZ+Q=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0 h1:T+ll3lS0Kn18d8hTOrVAMKcQrXiab+Cuj0cTnAYHmj0=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0/go.mod h1:QsPtoqAYvumyPU6ToX/5j1PbudN+VSTuvh6mp154ecM=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.22.0 h1:q6cWAfVwnWdiXgDWYxf2T/iy49eBQ+XEWpjjzfz1fAw=
-github.com/stackitcloud/stackit-sdk-go/services/observability v0.22.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0 h1:kgD32fG3rkdGz0C+kZ1S7BEur7btTSeaX3vxHE346FY=
+github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.28.0 h1:Bu8/UzMCAN8VyaEnz5O15zK+8xSV0kf8ndYXvwkNwOk=
 github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.28.0/go.mod h1:L+NlfC1hilLOqlLLukCj/UDnxlnNrc/oMikcw3Ansyw=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.8.0 h1:oWTviJKdlUxaaARJghTjOqBbarIK+7+nH3Kc3Wxn4rQ=

--- a/stackit/internal/services/observability/scrapeconfig/resource.go
+++ b/stackit/internal/services/observability/scrapeconfig/resource.go
@@ -729,7 +729,7 @@ func toCreatePayload(ctx context.Context, model *Model, saml2Model *saml2Model, 
 		ScrapeTimeout:  model.ScrapeTimeout.ValueString(),
 		// potentially lossy conversion, depending on the allowed range for sample_limit
 		SampleLimit: new(float32(model.SampleLimit.ValueInt32())),
-		Scheme:      model.Scheme.ValueString(),
+		Scheme:      observabilitySdk.CreateScrapeConfigPayloadScheme(model.Scheme.ValueString()),
 	}
 	setDefaultsCreateScrapeConfig(&sc, model, saml2Model)
 
@@ -818,7 +818,7 @@ func toUpdatePayload(ctx context.Context, model *Model, saml2Model *saml2Model, 
 		ScrapeTimeout:  model.ScrapeTimeout.ValueString(),
 		// potentially lossy conversion, depending on the allowed range for sample_limit
 		SampleLimit: new(float32(model.SampleLimit.ValueInt32())),
-		Scheme:      model.Scheme.ValueString(),
+		Scheme:      observabilitySdk.UpdateScrapeConfigPayloadScheme(model.Scheme.ValueString()),
 	}
 	setDefaultsUpdateScrapeConfig(&sc, model)
 

--- a/stackit/internal/services/observability/scrapeconfig/resource_test.go
+++ b/stackit/internal/services/observability/scrapeconfig/resource_test.go
@@ -47,7 +47,7 @@ func TestMapFields(t *testing.T) {
 					Username: "u",
 				},
 				Params:         &map[string][]string{"saml2": {"disabled"}, "x": {"y", "z"}},
-				Scheme:         new("http"),
+				Scheme:         observabilitySdk.SCHEME_HTTP.Ptr(),
 				ScrapeInterval: "1",
 				ScrapeTimeout:  "2",
 				SampleLimit:    new(int32(17)),


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->


## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
