### PR TITLE
STACKITLB-1981 | fix: NLB backend nic security group reference and docs

### DIFF
--- a/docs/data-sources/loadbalancer.md
+++ b/docs/data-sources/loadbalancer.md
@@ -37,11 +37,12 @@ data "stackit_loadbalancer" "example" {
 - `external_address` (String) External Load Balancer IP address where this Load Balancer is exposed.
 - `id` (String) Terraform's internal resource ID. It is structured as "`project_id`","region","`name`".
 - `listeners` (Attributes List) List of all listeners which will accept traffic. Limited to 20. (see [below for nested schema](#nestedatt--listeners))
+- `load_balancer_security_group_id` (String) The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.
 - `networks` (Attributes List) List of networks that listeners and targets reside in. (see [below for nested schema](#nestedatt--networks))
 - `options` (Attributes) Defines any optional functionality you want to have enabled on your load balancer. (see [below for nested schema](#nestedatt--options))
 - `plan_id` (String) The service plan ID. If not defined, the default service plan is `p10`. Possible values are: `p10`, `p50`, `p250`, `p750`.
 - `private_address` (String) Transient private Load Balancer IP address. It can change any time.
-- `security_group_id` (String) The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT Network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.
+- `security_group_id` (String) The ID of the automatically created security group that allows the targets to receive traffic from the LoadBalancer. Useful when disableTargetSecurityGroupAssignment=true to manually assign this security groups to targets.
 - `target_pools` (Attributes List) List of all target pools which will be used in the Load Balancer. Limited to 20. (see [below for nested schema](#nestedatt--target_pools))
 - `version` (String) Load balancer resource version.
 

--- a/docs/resources/loadbalancer.md
+++ b/docs/resources/loadbalancer.md
@@ -17,9 +17,21 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 ## Example Usage
 
 ```terraform
+variable "project_id" {
+  description = "The STACKIT Project ID"
+  type        = string
+  default     = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+
+variable "image_id" {
+  description = "A valid Debian 12 Image ID available in all projects"
+  type        = string
+  default     = "939249d1-6f48-4ab7-929b-95170728311a"
+}
+
 # Create a network
 resource "stackit_network" "example_network" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "example-network"
   ipv4_nameservers = ["8.8.8.8"]
   ipv4_prefix      = "192.168.0.0/25"
@@ -31,13 +43,13 @@ resource "stackit_network" "example_network" {
 
 # Create a network interface
 resource "stackit_network_interface" "nic" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   network_id = stackit_network.example_network.network_id
 }
 
 # Create a public IP for the load balancer
 resource "stackit_public_ip" "public-ip" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   lifecycle {
     ignore_changes = [network_interface_id]
   }
@@ -51,7 +63,7 @@ resource "stackit_key_pair" "keypair" {
 
 # Create a server instance
 resource "stackit_server" "boot-from-image" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   name       = "example-server"
   boot_volume = {
     size        = 64
@@ -68,7 +80,7 @@ resource "stackit_server" "boot-from-image" {
 
 # Create a load balancer
 resource "stackit_loadbalancer" "example" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   name       = "example-load-balancer"
   plan_id    = "p10"
   target_pools = [
@@ -116,29 +128,30 @@ resource "stackit_loadbalancer" "example" {
 # This example demonstrates an advanced setup where the Load Balancer is in one
 # network and the target server is in another. This requires manual
 # security group configuration using the `disable_security_group_assignment`
-# and `security_group_id` attributes.
+# and `load_balancer_security_group_id` attributes.
 
 # We create two separate networks: one for the load balancer and one for the target.
 resource "stackit_network" "lb_network" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "lb-network-example"
   ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
+  routed           = true
 }
 
 resource "stackit_network" "target_network" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "target-network-example"
-  ipv4_prefix      = "192.168.10.0/25"
+  ipv4_prefix      = "192.168.15.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 
 resource "stackit_public_ip" "example" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
 }
 
 resource "stackit_loadbalancer" "example" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "example-advanced-lb"
   external_address = stackit_public_ip.example.ip
 
@@ -168,15 +181,15 @@ resource "stackit_loadbalancer" "example" {
 
 # Create a new security group to be assigned to the target server.
 resource "stackit_security_group" "target_sg" {
-  project_id  = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id  = var.project_id
   name        = "target-sg-for-lb-access"
   description = "Allows ingress traffic from the example load balancer."
 }
 
 # Create a rule to allow traffic FROM the load balancer.
-# This rule uses the computed `security_group_id` of the load balancer.
+# This rule uses the computed `load_balancer_security_group_id` of the load balancer.
 resource "stackit_security_group_rule" "allow_lb_ingress" {
-  project_id        = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id        = var.project_id
   security_group_id = stackit_security_group.target_sg.security_group_id
   direction         = "ingress"
   protocol = {
@@ -184,7 +197,7 @@ resource "stackit_security_group_rule" "allow_lb_ingress" {
   }
 
   # This is the crucial link: it allows traffic from the LB's security group.
-  remote_security_group_id = stackit_loadbalancer.example.security_group_id
+  remote_security_group_id = stackit_loadbalancer.example.load_balancer_security_group_id
 
   port_range = {
     min = 80
@@ -193,14 +206,14 @@ resource "stackit_security_group_rule" "allow_lb_ingress" {
 }
 
 resource "stackit_server" "example" {
-  project_id        = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id        = var.project_id
   name              = "example-remote-target"
   machine_type      = "g2i.2"
   availability_zone = "eu01-1"
 
   boot_volume = {
     source_type = "image"
-    source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    source_id   = var.image_id
     size        = 10
   }
 
@@ -210,7 +223,7 @@ resource "stackit_server" "example" {
 }
 
 resource "stackit_network_interface" "nic" {
-  project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id         = var.project_id
   network_id         = stackit_network.target_network.network_id
   security_group_ids = [stackit_security_group.target_sg.security_group_id]
 }
@@ -245,8 +258,9 @@ import {
 ### Read-Only
 
 - `id` (String) Terraform's internal resource ID. It is structured as "`project_id`","region","`name`".
+- `load_balancer_security_group_id` (String) The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.
 - `private_address` (String) Transient private Load Balancer IP address. It can change any time.
-- `security_group_id` (String) The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.
+- `security_group_id` (String) The ID of the automatically created security group that allows the targets to receive traffic from the LoadBalancer. Useful when disableTargetSecurityGroupAssignment=true to manually assign this security groups to targets.
 - `version` (String) Load balancer resource version. This is needed to have concurrency safe updates.
 
 <a id="nestedatt--listeners"></a>

--- a/examples/resources/stackit_loadbalancer/resource.tf
+++ b/examples/resources/stackit_loadbalancer/resource.tf
@@ -1,6 +1,18 @@
+variable "project_id" {
+  description = "The STACKIT Project ID"
+  type        = string
+  default     = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+
+variable "image_id" {
+  description = "A valid Debian 12 Image ID available in all projects"
+  type        = string
+  default     = "939249d1-6f48-4ab7-929b-95170728311a"
+}
+
 # Create a network
 resource "stackit_network" "example_network" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "example-network"
   ipv4_nameservers = ["8.8.8.8"]
   ipv4_prefix      = "192.168.0.0/25"
@@ -12,13 +24,13 @@ resource "stackit_network" "example_network" {
 
 # Create a network interface
 resource "stackit_network_interface" "nic" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   network_id = stackit_network.example_network.network_id
 }
 
 # Create a public IP for the load balancer
 resource "stackit_public_ip" "public-ip" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   lifecycle {
     ignore_changes = [network_interface_id]
   }
@@ -32,7 +44,7 @@ resource "stackit_key_pair" "keypair" {
 
 # Create a server instance
 resource "stackit_server" "boot-from-image" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   name       = "example-server"
   boot_volume = {
     size        = 64
@@ -49,7 +61,7 @@ resource "stackit_server" "boot-from-image" {
 
 # Create a load balancer
 resource "stackit_loadbalancer" "example" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
   name       = "example-load-balancer"
   plan_id    = "p10"
   target_pools = [
@@ -97,29 +109,30 @@ resource "stackit_loadbalancer" "example" {
 # This example demonstrates an advanced setup where the Load Balancer is in one
 # network and the target server is in another. This requires manual
 # security group configuration using the `disable_security_group_assignment`
-# and `security_group_id` attributes.
+# and `load_balancer_security_group_id` attributes.
 
 # We create two separate networks: one for the load balancer and one for the target.
 resource "stackit_network" "lb_network" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "lb-network-example"
   ipv4_prefix      = "192.168.10.0/25"
   ipv4_nameservers = ["8.8.8.8"]
+  routed           = true
 }
 
 resource "stackit_network" "target_network" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "target-network-example"
-  ipv4_prefix      = "192.168.10.0/25"
+  ipv4_prefix      = "192.168.15.0/25"
   ipv4_nameservers = ["8.8.8.8"]
 }
 
 resource "stackit_public_ip" "example" {
-  project_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id = var.project_id
 }
 
 resource "stackit_loadbalancer" "example" {
-  project_id       = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id       = var.project_id
   name             = "example-advanced-lb"
   external_address = stackit_public_ip.example.ip
 
@@ -149,15 +162,15 @@ resource "stackit_loadbalancer" "example" {
 
 # Create a new security group to be assigned to the target server.
 resource "stackit_security_group" "target_sg" {
-  project_id  = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id  = var.project_id
   name        = "target-sg-for-lb-access"
   description = "Allows ingress traffic from the example load balancer."
 }
 
 # Create a rule to allow traffic FROM the load balancer.
-# This rule uses the computed `security_group_id` of the load balancer.
+# This rule uses the computed `load_balancer_security_group_id` of the load balancer.
 resource "stackit_security_group_rule" "allow_lb_ingress" {
-  project_id        = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id        = var.project_id
   security_group_id = stackit_security_group.target_sg.security_group_id
   direction         = "ingress"
   protocol = {
@@ -165,7 +178,7 @@ resource "stackit_security_group_rule" "allow_lb_ingress" {
   }
 
   # This is the crucial link: it allows traffic from the LB's security group.
-  remote_security_group_id = stackit_loadbalancer.example.security_group_id
+  remote_security_group_id = stackit_loadbalancer.example.load_balancer_security_group_id
 
   port_range = {
     min = 80
@@ -174,14 +187,14 @@ resource "stackit_security_group_rule" "allow_lb_ingress" {
 }
 
 resource "stackit_server" "example" {
-  project_id        = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id        = var.project_id
   name              = "example-remote-target"
   machine_type      = "g2i.2"
   availability_zone = "eu01-1"
 
   boot_volume = {
     source_type = "image"
-    source_id   = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    source_id   = var.image_id
     size        = 10
   }
 
@@ -191,7 +204,7 @@ resource "stackit_server" "example" {
 }
 
 resource "stackit_network_interface" "nic" {
-  project_id         = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+  project_id         = var.project_id
   network_id         = stackit_network.target_network.network_id
   security_group_ids = [stackit_security_group.target_sg.security_group_id]
 }

--- a/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/datasource.go
@@ -71,7 +71,8 @@ func (r *loadBalancerDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 		"project_id":                            "STACKIT project ID to which the Load Balancer is associated.",
 		"external_address":                      "External Load Balancer IP address where this Load Balancer is exposed.",
 		"disable_security_group_assignment":     "If set to true, this will disable the automatic assignment of a security group to the load balancer's targets. This option is primarily used to allow targets that are not within the load balancer's own network or SNA (STACKIT Network area). When this is enabled, you are fully responsible for ensuring network connectivity to the targets, including managing all routing and security group rules manually. This setting cannot be changed after the load balancer is created.",
-		"security_group_id":                     "The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT Network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.",
+		"security_group_id":                     "The ID of the automatically created security group that allows the targets to receive traffic from the LoadBalancer. Useful when disableTargetSecurityGroupAssignment=true to manually assign this security groups to targets.",
+		"load_balancer_security_group_id":       "The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.",
 		"listeners":                             "List of all listeners which will accept traffic. Limited to 20.",
 		"port":                                  "Port number where we listen for traffic.",
 		"protocol":                              "Protocol is the highest network protocol we understand to load balance.",
@@ -372,6 +373,10 @@ func (r *loadBalancerDataSource) Schema(_ context.Context, _ datasource.SchemaRe
 			},
 			"security_group_id": schema.StringAttribute{
 				Description: descriptions["security_group_id"],
+				Computed:    true,
+			},
+			"load_balancer_security_group_id": schema.StringAttribute{
+				Description: descriptions["load_balancer_security_group_id"],
 				Computed:    true,
 			},
 			"version": schema.StringAttribute{

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -64,6 +64,7 @@ type Model struct {
 	TargetPools                    types.List   `tfsdk:"target_pools"`
 	Region                         types.String `tfsdk:"region"`
 	SecurityGroupId                types.String `tfsdk:"security_group_id"`
+	LoadBalancerSecurityGroupId    types.String `tfsdk:"load_balancer_security_group_id"`
 	Version                        types.String `tfsdk:"version"`
 }
 
@@ -366,7 +367,8 @@ func (r *loadBalancerResource) Schema(_ context.Context, _ resource.SchemaReques
 		"targets.display_name":                  "Target display name",
 		"ip":                                    "Target IP",
 		"region":                                "The resource region. If not defined, the provider region is used.",
-		"security_group_id":                     "The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.",
+		"security_group_id":                     "The ID of the automatically created security group that allows the targets to receive traffic from the LoadBalancer. Useful when disableTargetSecurityGroupAssignment=true to manually assign this security groups to targets.",
+		"load_balancer_security_group_id":       "The ID of the egress security group assigned to the Load Balancer's internal machines. This ID is essential for allowing traffic from the Load Balancer to targets in different networks or STACKIT network areas (SNA). To enable this, create a security group rule for your target VMs and set the `remote_security_group_id` of that rule to this value. This is typically used when `disable_security_group_assignment` is set to `true`.",
 		"tcp_options":                           "Options that are specific to the TCP protocol.",
 		"tcp_options_idle_timeout":              "Time after which an idle connection is closed. The default value is set to 300 seconds, and the maximum value is 3600 seconds. The format is a duration and the unit must be seconds. Example: 30s",
 		"udp_options":                           "Options that are specific to the UDP protocol.",
@@ -727,6 +729,13 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 			},
 			"security_group_id": schema.StringAttribute{
 				Description: descriptions["security_group_id"],
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"load_balancer_security_group_id": schema.StringAttribute{
+				Description: descriptions["load_balancer_security_group_id"],
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
@@ -1383,6 +1392,11 @@ func mapFields(ctx context.Context, lb *loadbalancer.LoadBalancer, m *Model, reg
 		m.SecurityGroupId = types.StringPointerValue(lb.TargetSecurityGroup.Id)
 	} else {
 		m.SecurityGroupId = types.StringNull()
+	}
+	if lb.LoadBalancerSecurityGroup != nil {
+		m.LoadBalancerSecurityGroupId = types.StringPointerValue(lb.LoadBalancerSecurityGroup.Id)
+	} else {
+		m.LoadBalancerSecurityGroupId = types.StringNull()
 	}
 	err := mapListeners(lb, m)
 	if err != nil {

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource_test.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource_test.go
@@ -419,10 +419,11 @@ func TestMapFields(t *testing.T) {
 						}),
 					}),
 				}),
-				PrivateAddress:  types.StringNull(),
-				SecurityGroupId: types.StringNull(),
-				TargetPools:     types.ListNull(types.ObjectType{AttrTypes: targetPoolTypes}),
-				Region:          types.StringValue(testRegion),
+				PrivateAddress:              types.StringNull(),
+				SecurityGroupId:             types.StringNull(),
+				LoadBalancerSecurityGroupId: types.StringNull(),
+				TargetPools:                 types.ListNull(types.ObjectType{AttrTypes: targetPoolTypes}),
+				Region:                      types.StringValue(testRegion),
 			},
 			true,
 		},
@@ -477,6 +478,10 @@ func TestMapFields(t *testing.T) {
 					Id:   new("sg-id-12345"),
 					Name: new("sg-name-abcde"),
 				}),
+				LoadBalancerSecurityGroup: new(loadbalancer.SecurityGroup{
+					Id:   new("lb-sg-id-12345"),
+					Name: new("lb-sg-name-abcde"),
+				}),
 				TargetPools: []loadbalancer.TargetPool{
 					{
 						ActiveHealthCheck: new(loadbalancer.ActiveHealthCheck{
@@ -503,10 +508,11 @@ func TestMapFields(t *testing.T) {
 			nil,
 			testRegion,
 			&Model{
-				Id:              types.StringValue(id),
-				ProjectId:       types.StringValue("pid"),
-				ExternalAddress: types.StringValue("external_address"),
-				SecurityGroupId: types.StringValue("sg-id-12345"),
+				Id:                          types.StringValue(id),
+				ProjectId:                   types.StringValue("pid"),
+				ExternalAddress:             types.StringValue("external_address"),
+				SecurityGroupId:             types.StringValue("sg-id-12345"),
+				LoadBalancerSecurityGroupId: types.StringValue("lb-sg-id-12345"),
 				Listeners: types.ListValueMust(types.ObjectType{AttrTypes: listenerTypes}, []attr.Value{
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),

--- a/stackit/internal/services/loadbalancer/loadbalancer_acc_test.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer_acc_test.go
@@ -169,6 +169,7 @@ func TestAccLoadBalancerResourceMin(t *testing.T) {
 					resource.TestCheckNoResourceAttr("stackit_loadbalancer.loadbalancer", "options.observability.metrics.credentials_ref"),
 					resource.TestCheckNoResourceAttr("stackit_loadbalancer.loadbalancer", "options.observability.metrics.push_url"),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "security_group_id"),
+					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id"),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "version"),
 
 					// Loadbalancer observability credentials resource
@@ -222,9 +223,14 @@ func TestAccLoadBalancerResourceMin(t *testing.T) {
 					resource.TestCheckNoResourceAttr("data.stackit_loadbalancer.loadbalancer", "options.observability.metrics.credentials_ref"),
 					resource.TestCheckNoResourceAttr("data.stackit_loadbalancer.loadbalancer", "options.observability.metrics.push_url"),
 					resource.TestCheckResourceAttrSet("data.stackit_loadbalancer.loadbalancer", "security_group_id"),
+					resource.TestCheckResourceAttrSet("data.stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id"),
 					resource.TestCheckResourceAttrPair(
 						"stackit_loadbalancer.loadbalancer", "security_group_id",
 						"data.stackit_loadbalancer.loadbalancer", "security_group_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id",
+						"data.stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id",
 					),
 					resource.TestCheckResourceAttrPair(
 						"stackit_loadbalancer.loadbalancer", "version",
@@ -291,6 +297,7 @@ func TestAccLoadBalancerResourceMin(t *testing.T) {
 					resource.TestCheckNoResourceAttr("stackit_loadbalancer.loadbalancer", "options.observability.metrics.credentials_ref"),
 					resource.TestCheckNoResourceAttr("stackit_loadbalancer.loadbalancer", "options.observability.metrics.push_url"),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "security_group_id"),
+					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id"),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "version"),
 
 					// Loadbalancer observability credentials resource
@@ -325,6 +332,7 @@ func TestAccLoadBalancerResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "external_address"),
 					resource.TestCheckResourceAttr("stackit_loadbalancer.loadbalancer", "disable_security_group_assignment", testutil.ConvertConfigVariable(testConfigVarsMax["disable_security_group_assignment"])),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "security_group_id"),
+					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id"),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "version"),
 
 					resource.TestCheckResourceAttr("stackit_loadbalancer.loadbalancer", "listeners.0.display_name", testutil.ConvertConfigVariable(testConfigVarsMax["sni_listener_display_name"])),
@@ -409,6 +417,7 @@ func TestAccLoadBalancerResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.stackit_loadbalancer.loadbalancer", "external_address"),
 					resource.TestCheckResourceAttr("data.stackit_loadbalancer.loadbalancer", "disable_security_group_assignment", testutil.ConvertConfigVariable(testConfigVarsMax["disable_security_group_assignment"])),
 					resource.TestCheckResourceAttrSet("data.stackit_loadbalancer.loadbalancer", "security_group_id"),
+					resource.TestCheckResourceAttrSet("data.stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id"),
 					resource.TestCheckResourceAttrSet("data.stackit_loadbalancer.loadbalancer", "version"),
 
 					resource.TestCheckResourceAttr("data.stackit_loadbalancer.loadbalancer", "target_pools.0.name", testutil.ConvertConfigVariable(testConfigVarsMax["sni_target_pool_name"])),
@@ -444,6 +453,10 @@ func TestAccLoadBalancerResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						"stackit_loadbalancer.loadbalancer", "security_group_id",
 						"data.stackit_loadbalancer.loadbalancer", "security_group_id",
+					),
+					resource.TestCheckResourceAttrPair(
+						"stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id",
+						"data.stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id",
 					),
 					resource.TestCheckResourceAttrPair(
 						"stackit_loadbalancer.loadbalancer", "version",
@@ -499,6 +512,7 @@ func TestAccLoadBalancerResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "external_address"),
 					resource.TestCheckResourceAttr("stackit_loadbalancer.loadbalancer", "disable_security_group_assignment", testutil.ConvertConfigVariable(configVarsMaxUpdated()["disable_security_group_assignment"])),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "security_group_id"),
+					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "load_balancer_security_group_id"),
 					resource.TestCheckResourceAttrSet("stackit_loadbalancer.loadbalancer", "version"),
 
 					resource.TestCheckResourceAttr("stackit_loadbalancer.loadbalancer", "listeners.0.display_name", testutil.ConvertConfigVariable(configVarsMaxUpdated()["sni_listener_display_name"])),


### PR DESCRIPTION
## Description

The STACKIT network load balancer has an advanced example for set up of a NLB with a security group for the targets.
This did not work because the wrong security group was used in it. Additionally the correct one did not exist in the provider yet. Hence, it will be added with this PR and the example is corrected.

Internal issue tracking: STACKITLB-1981

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)