### PR TITLE
fix(secretsmanager): remove RequiresReplace for secretsmanager description

### DIFF
--- a/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
+++ b/stackit/internal/services/secretsmanager/secretsmanager_acc_test.go
@@ -62,6 +62,7 @@ func configVarsMaxUpdated() config.Variables {
 	tempConfig["write_enabled"] = config.BoolVariable(false)
 	tempConfig["use_kms_key"] = config.BoolVariable(false)
 	tempConfig["acl2"] = config.StringVariable("10.100.2.0/24")
+	tempConfig["user_description"] = config.StringVariable("tf-acc-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 	return tempConfig
 }
 

--- a/stackit/internal/services/secretsmanager/user/resource.go
+++ b/stackit/internal/services/secretsmanager/user/resource.go
@@ -142,9 +142,6 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"description": schema.StringAttribute{
 				Description: descriptions["description"],
 				Required:    true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 			},
 			"write_enabled": schema.BoolAttribute{
 				Description: descriptions["write_enabled"],
@@ -415,7 +412,8 @@ func toUpdatePayload(model *Model) (*secretsmanager.UpdateUserPayload, error) {
 		return nil, fmt.Errorf("nil model")
 	}
 	return &secretsmanager.UpdateUserPayload{
-		Write: conversion.BoolValueToPointer(model.WriteEnabled),
+		Description: conversion.StringValueToPointer(model.Description),
+		Write:       conversion.BoolValueToPointer(model.WriteEnabled),
 	}, nil
 }
 

--- a/stackit/internal/services/secretsmanager/user/resource_test.go
+++ b/stackit/internal/services/secretsmanager/user/resource_test.go
@@ -234,17 +234,20 @@ func TestToUpdatePayload(t *testing.T) {
 			"default_values",
 			&Model{},
 			&secretsmanager.UpdateUserPayload{
-				Write: nil,
+				Description: nil,
+				Write:       nil,
 			},
 			true,
 		},
 		{
 			"simple_values",
 			&Model{
+				Description:  types.StringValue(""),
 				WriteEnabled: types.BoolValue(false),
 			},
 			&secretsmanager.UpdateUserPayload{
-				Write: new(false),
+				Description: new(""),
+				Write:       new(false),
 			},
 			true,
 		},


### PR DESCRIPTION
## Description

Change in the secretsmanager description triggers unnecessary replacement of resource.

relates to STACKITTPR-649 and #882 

## Testing Instructions

Acceptance tests are currently blocked, therefore you must test it manually:

```terraform
resource "stackit_secretsmanager_instance" "example" {
  project_id = local.project_id
  name       = "example-name"
}

resource "stackit_secretsmanager_user" "example" {
  project_id    = local.project_id
  instance_id   = stackit_secretsmanager_instance.example.instance_id
  description   = ""
  write_enabled = false
}
```

run `terraform apply` and approve -> the instance and the user should be created. Then change the user resource:

```terraform
resource "stackit_secretsmanager_user" "example" {
  project_id    = local.project_id
  instance_id   = stackit_secretsmanager_instance.example.instance_id
  description   = "example"
  write_enabled = false
}
```

run `terraform apply` -> tf should suggest an inplace update for the user.

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
