### PR TITLE
chore(mongodbflex): bump version of sdk module from 1.8.3 to 1.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/logs v0.9.0
 	github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.29.0
 	github.com/stackitcloud/stackit-sdk-go/services/modelserving v0.10.0
-	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.8.3
+	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.10.0
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0
 	github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0
 	github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.28.0

--- a/go.sum
+++ b/go.sum
@@ -700,8 +700,8 @@ github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.29.0 h1:dLXdQRTVSkb8t
 github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.29.0/go.mod h1:joa89Y1dyn0j22FstRcIKfW2ada3FDxNfttxSvq27uY=
 github.com/stackitcloud/stackit-sdk-go/services/modelserving v0.10.0 h1:k2mkHQkfzLH53dL1tHZo8pbpu062aQIgQmAw5OSZpss=
 github.com/stackitcloud/stackit-sdk-go/services/modelserving v0.10.0/go.mod h1:u7T85YqoqncJevbPU1ODKthbmxxEh1zw+bVaAO8v0Sg=
-github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.8.3 h1:QW//diMedJX1o4HQV+NSWT3we7Xlly+ReWcaQqwwG90=
-github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.8.3/go.mod h1:0hHEPiOEMAA23EzEl42Rm3FlyKIzkW+LWLvDkuFTZ+Q=
+github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.10.0 h1:lp9qX4sworFipMIKPORxuNZlVHDrpqZLppQN5YKGsP4=
+github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.10.0/go.mod h1:0hHEPiOEMAA23EzEl42Rm3FlyKIzkW+LWLvDkuFTZ+Q=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0 h1:T+ll3lS0Kn18d8hTOrVAMKcQrXiab+Cuj0cTnAYHmj0=
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0/go.mod h1:QsPtoqAYvumyPU6ToX/5j1PbudN+VSTuvh6mp154ecM=
 github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0 h1:kgD32fG3rkdGz0C+kZ1S7BEur7btTSeaX3vxHE346FY=

--- a/stackit/internal/services/mongodbflex/instance/resource_test.go
+++ b/stackit/internal/services/mongodbflex/instance/resource_test.go
@@ -122,7 +122,7 @@ func TestMapFields(t *testing.T) {
 					Id:       new(instanceId),
 					Name:     new("name"),
 					Replicas: new(int32(56)),
-					Status:   new("READY"),
+					Status:   mongodbflex.INSTANCESTATUS_READY.Ptr(),
 					Storage: &mongodbflex.Storage{
 						Class: new("class"),
 						Size:  new(int64(78)),
@@ -197,7 +197,7 @@ func TestMapFields(t *testing.T) {
 					Id:             new(instanceId),
 					Name:           new("name"),
 					Replicas:       new(int32(56)),
-					Status:         new("READY"),
+					Status:         mongodbflex.INSTANCESTATUS_READY.Ptr(),
 					Storage:        nil,
 					Options: &map[string]string{
 						"type":                           "type",
@@ -282,7 +282,7 @@ func TestMapFields(t *testing.T) {
 					Id:             new(instanceId),
 					Name:           new("name"),
 					Replicas:       new(int32(56)),
-					Status:         new("READY"),
+					Status:         mongodbflex.INSTANCESTATUS_READY.Ptr(),
 					Storage:        nil,
 					Options: &map[string]string{
 						"type":                           "type",


### PR DESCRIPTION
## Description

Unit tests are failing with SDK mongodbflex v1.9.0 or above.

```
➜  terraform-provider-stackit git:(fix/STACKITTPR-677-mongodbflex-instance-unit-tests-failing) ✗ go test ./stackit/internal/services/mongodbflex/instance/
# github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/mongodbflex/instance [github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/mongodbflex/instance.test]
stackit/internal/services/mongodbflex/instance/resource_test.go:125:16: cannot use new("READY") (value of type *string) as *v2api.InstanceStatus value in struct literal
stackit/internal/services/mongodbflex/instance/resource_test.go:200:22: cannot use new("READY") (value of type *string) as *v2api.InstanceStatus value in struct literal
stackit/internal/services/mongodbflex/instance/resource_test.go:285:22: cannot use new("READY") (value of type *string) as *v2api.InstanceStatus value in struct literal
FAIL    github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/mongodbflex/instance [build failed]
FAIL
```

relates to STACKITTPR-677

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
