### PR TITLE
fix(postgresflex): fix backup schedule value used in acc tests

### DIFF
--- a/stackit/internal/services/postgresflex/postgresflex_acc_test.go
+++ b/stackit/internal/services/postgresflex/postgresflex_acc_test.go
@@ -203,7 +203,7 @@ func TestAccPostgresFlexFlexResource(t *testing.T) {
 
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "acl.#", "1"),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "acl.0", instanceResource["acl"]),
-					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "backup_schedule", "0 16 * * *"),
+					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "backup_schedule", "00 16 * * *"),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "flavor.id", instanceResource["flavor_id"]),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "flavor.description", instanceResource["flavor_description"]),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "flavor.cpu", instanceResource["flavor_cpu"]),

--- a/stackit/internal/services/postgresflex/postgresflex_acc_test.go
+++ b/stackit/internal/services/postgresflex/postgresflex_acc_test.go
@@ -203,7 +203,7 @@ func TestAccPostgresFlexFlexResource(t *testing.T) {
 
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "acl.#", "1"),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "acl.0", instanceResource["acl"]),
-					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "backup_schedule", "00 16 * * *"),
+					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "backup_schedule", instanceResource["backup_schedule"]),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "flavor.id", instanceResource["flavor_id"]),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "flavor.description", instanceResource["flavor_description"]),
 					resource.TestCheckResourceAttr("data.stackit_postgresflex_instance.instance", "flavor.cpu", instanceResource["flavor_cpu"]),


### PR DESCRIPTION
## Description

relates to STACKITTPR-620

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
