### PR TITLE
fix(vpn): remove state from model

### DIFF
--- a/docs/data-sources/vpn_gateway.md
+++ b/docs/data-sources/vpn_gateway.md
@@ -37,7 +37,6 @@ data "stackit_vpn_gateway" "example" {
 - `plan_id` (String) The service plan identifier (e.g. `p500`). For guidance on finding available plans, see [List available service plans](https://docs.stackit.cloud/products/network/connectivity-hybrid-multi-cloud/vpn/getting-started/gateway-create/#list-available-service-plans).
 - `region` (String) STACKIT region name the resource is located in. If not defined, the provider region is used.
 - `routing_type` (String) Routing architecture. Possible values are: `POLICY_BASED`, `ROUTE_BASED`, `BGP_ROUTE_BASED`.
-- `state` (String) The current lifecycle state of the gateway. Possible values are: `PENDING`, `READY`, `ERROR`, `DELETING`.
 
 <a id="nestedatt--availability_zones"></a>
 ### Nested Schema for `availability_zones`

--- a/docs/resources/vpn_gateway.md
+++ b/docs/resources/vpn_gateway.md
@@ -53,7 +53,6 @@ import {
 
 - `gateway_id` (String) The server-generated UUID of the VPN gateway.
 - `id` (String) Terraform's internal resource identifier. Structured as "`project_id`,`region`,`gateway_id`".
-- `state` (String) The current lifecycle state of the gateway. Possible values are: `PENDING`, `READY`, `ERROR`, `DELETING`.
 
 <a id="nestedatt--availability_zones"></a>
 ### Nested Schema for `availability_zones`

--- a/stackit/internal/services/vpn/gateway/datasource.go
+++ b/stackit/internal/services/vpn/gateway/datasource.go
@@ -128,10 +128,6 @@ func (d *vpnGatewayDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 				Computed:    true,
 				ElementType: types.StringType,
 			},
-			"state": schema.StringAttribute{
-				Description: schemaDescriptions["state"],
-				Computed:    true,
-			},
 		},
 	}
 }

--- a/stackit/internal/services/vpn/gateway/resource.go
+++ b/stackit/internal/services/vpn/gateway/resource.go
@@ -41,7 +41,6 @@ var (
 	_ resource.ResourceWithModifyPlan     = &gatewayResource{}
 	_ resource.ResourceWithValidateConfig = &gatewayResource{}
 
-	gatewayStates      = sdkUtils.EnumSliceToStringSlice(vpn.AllowedGatewayStatusEnumValues)
 	routingTypeOptions = sdkUtils.EnumSliceToStringSlice(vpn.AllowedRoutingTypeEnumValues)
 )
 
@@ -66,7 +65,6 @@ type Model struct {
 	AvailabilityZones *AvailabilityZonesModel `tfsdk:"availability_zones"`
 	Bgp               *BGPGatewayConfigModel  `tfsdk:"bgp"`
 	Labels            types.Map               `tfsdk:"labels"`
-	State             types.String            `tfsdk:"state"`
 }
 
 var schemaDescriptions = map[string]string{
@@ -84,7 +82,6 @@ var schemaDescriptions = map[string]string{
 	"bgp_local_asn":                  "Local ASN for BGP (private ASN range, 64512-4294967294).",
 	"bgp_override_advertised_routes": "List of IPv4 CIDRs to advertise via BGP. If omitted, SNA network ranges are advertised.",
 	"labels":                         "Map of custom labels (key-value string pairs).",
-	"state":                          fmt.Sprintf("The current lifecycle state of the gateway. %s", tfutils.FormatPossibleValues(gatewayStates...)),
 }
 
 type gatewayResource struct {
@@ -223,10 +220,6 @@ func (r *gatewayResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Optional:    true,
 				ElementType: types.StringType,
 				Validators:  validate.LabelValidators(),
-			},
-			"state": schema.StringAttribute{
-				Description: schemaDescriptions["state"],
-				Computed:    true,
 			},
 		},
 	}
@@ -629,10 +622,6 @@ func mapFields(ctx context.Context, gateway *vpn.GatewayResponse, model *Model, 
 		return fmt.Errorf("mapping labels: %w", err)
 	}
 	model.Labels = labels
-
-	if gateway.State != nil {
-		model.State = types.StringValue(string(*gateway.State))
-	}
 
 	return nil
 }

--- a/stackit/internal/services/vpn/gateway/resource_test.go
+++ b/stackit/internal/services/vpn/gateway/resource_test.go
@@ -43,7 +43,6 @@ func TestMapFields(t *testing.T) {
 						Tunnel1: "eu01-1",
 						Tunnel2: "eu01-2",
 					},
-					State: new(vpn.GatewayStatus("READY")),
 				},
 			},
 			expected: Model{
@@ -60,7 +59,6 @@ func TestMapFields(t *testing.T) {
 				},
 				Bgp:    nil,
 				Labels: types.MapNull(types.StringType),
-				State:  types.StringValue("READY"),
 			},
 			isValid: true,
 		},
@@ -87,7 +85,6 @@ func TestMapFields(t *testing.T) {
 						"env":  "prod",
 						"team": "network",
 					},
-					State: new(vpn.GatewayStatus("READY")),
 				},
 			},
 			expected: Model{
@@ -113,7 +110,6 @@ func TestMapFields(t *testing.T) {
 					"env":  types.StringValue("prod"),
 					"team": types.StringValue("network"),
 				}),
-				State: types.StringValue("READY"),
 			},
 			isValid: true,
 		},
@@ -141,7 +137,6 @@ func TestMapFields(t *testing.T) {
 						OverrideAdvertisedRoutes: []string{},
 					},
 					Labels: nil,
-					State:  new(vpn.GatewayStatus("READY")),
 				},
 			},
 			expected: Model{
@@ -161,7 +156,6 @@ func TestMapFields(t *testing.T) {
 					OverrideAdvertisedRoutes: types.ListValueMust(types.StringType, []attr.Value{}),
 				},
 				Labels: types.MapValueMust(types.StringType, map[string]attr.Value{}),
-				State:  types.StringValue("READY"),
 			},
 			isValid: true,
 		},

--- a/stackit/internal/services/vpn/vpn_acc_test.go
+++ b/stackit/internal/services/vpn/vpn_acc_test.go
@@ -97,7 +97,6 @@ func TestAccVpnGatewayResourceMin(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "availability_zones.tunnel1", testutil.ConvertConfigVariable(gatewayMinVars["az_tunnel1"])),
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "availability_zones.tunnel2", testutil.ConvertConfigVariable(gatewayMinVars["az_tunnel2"])),
 					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "gateway_id"),
-					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "state"),
 				),
 			},
 			// Data source
@@ -123,7 +122,6 @@ func TestAccVpnGatewayResourceMin(t *testing.T) {
 					resource.TestCheckResourceAttr("data.stackit_vpn_gateway.gateway", "availability_zones.tunnel2", testutil.ConvertConfigVariable(gatewayMinVars["az_tunnel2"])),
 
 					resource.TestCheckResourceAttrSet("data.stackit_vpn_gateway.gateway", "gateway_id"),
-					resource.TestCheckResourceAttrSet("data.stackit_vpn_gateway.gateway", "state"),
 
 					resource.TestCheckResourceAttrPair("data.stackit_vpn_gateway.gateway", "region", "stackit_vpn_gateway.gateway", "region"),
 					resource.TestCheckResourceAttrPair("data.stackit_vpn_gateway.gateway", "gateway_id", "stackit_vpn_gateway.gateway", "gateway_id"),
@@ -142,7 +140,6 @@ func TestAccVpnGatewayResourceMin(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "availability_zones.tunnel1", testutil.ConvertConfigVariable(gatewayMinVarsUpdated["az_tunnel1"])),
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "availability_zones.tunnel2", testutil.ConvertConfigVariable(gatewayMinVarsUpdated["az_tunnel2"])),
 					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "gateway_id"),
-					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "state"),
 				),
 			},
 			// Import
@@ -194,7 +191,6 @@ func TestAccVpnGatewayResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "bgp.override_advertised_routes.1", testutil.ConvertConfigVariable(gatewayMaxVars["advertised_route_2"])),
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "labels."+testutil.ConvertConfigVariable(gatewayMaxVars["label_key"]), testutil.ConvertConfigVariable(gatewayMaxVars["label_value"])),
 					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "gateway_id"),
-					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "state"),
 				),
 			},
 			// Data source
@@ -225,7 +221,6 @@ func TestAccVpnGatewayResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("data.stackit_vpn_gateway.gateway", "labels."+testutil.ConvertConfigVariable(gatewayMaxVars["label_key"]), testutil.ConvertConfigVariable(gatewayMaxVars["label_value"])),
 
 					resource.TestCheckResourceAttrSet("data.stackit_vpn_gateway.gateway", "gateway_id"),
-					resource.TestCheckResourceAttrSet("data.stackit_vpn_gateway.gateway", "state"),
 
 					resource.TestCheckResourceAttrPair("data.stackit_vpn_gateway.gateway", "region", "stackit_vpn_gateway.gateway", "region"),
 					resource.TestCheckResourceAttrPair("data.stackit_vpn_gateway.gateway", "gateway_id", "stackit_vpn_gateway.gateway", "gateway_id"),
@@ -250,7 +245,6 @@ func TestAccVpnGatewayResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "bgp.override_advertised_routes.2", testutil.ConvertConfigVariable(gatewayMaxVarsUpdated["advertised_route_3"])),
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "labels."+testutil.ConvertConfigVariable(gatewayMaxVarsUpdated["label_key"]), testutil.ConvertConfigVariable(gatewayMaxVarsUpdated["label_value"])),
 					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "gateway_id"),
-					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "state"),
 				),
 			},
 			// Update step 2 - test removal of optional fields
@@ -269,7 +263,6 @@ func TestAccVpnGatewayResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "bgp.override_advertised_routes.#", "0"),
 					resource.TestCheckResourceAttr("stackit_vpn_gateway.gateway", "labels.#", "0"),
 					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "gateway_id"),
-					resource.TestCheckResourceAttrSet("stackit_vpn_gateway.gateway", "state"),
 				),
 			},
 			// Import


### PR DESCRIPTION
## Description

fix of gateway onboarding
relates to #1453 and STACKITTPR-633

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
