### PR TITLE
feat(ci): re-enable linting rule to prevent usage of deprecated code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/stackitcloud/stackit-sdk-go/core v0.26.0
-	github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2
+	github.com/stackitcloud/stackit-sdk-go/services/alb v0.15.0
 	github.com/stackitcloud/stackit-sdk-go/services/cdn v1.16.0
 	github.com/stackitcloud/stackit-sdk-go/services/certificates v1.7.0
 	github.com/stackitcloud/stackit-sdk-go/services/dns v0.20.2
@@ -23,7 +23,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.12.0
 	github.com/stackitcloud/stackit-sdk-go/services/intake v0.9.0
 	github.com/stackitcloud/stackit-sdk-go/services/kms v1.10.0
-	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.13.0
+	github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0
 	github.com/stackitcloud/stackit-sdk-go/services/logme v0.29.0
 	github.com/stackitcloud/stackit-sdk-go/services/logs v0.9.0
 	github.com/stackitcloud/stackit-sdk-go/services/mariadb v0.29.0
@@ -31,7 +31,7 @@ require (
 	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v1.10.0
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0
 	github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0
-	github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.28.0
+	github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.0.0
 	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.8.0
 	github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v0.30.0
 	github.com/stackitcloud/stackit-sdk-go/services/redis v0.28.2

--- a/go.sum
+++ b/go.sum
@@ -670,8 +670,8 @@ github.com/ssgreg/nlreturn/v2 v2.2.1 h1:X4XDI7jstt3ySqGU86YGAURbxw3oTDPK9sPEi6YE
 github.com/ssgreg/nlreturn/v2 v2.2.1/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0 h1:jQEb9gkehfp6VCP6TcYk7BI10cz4l0KM2L6hqYBH2QA=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0/go.mod h1:WU1hhxnjXw2EV7CYa1nlEvNpMiRY6CvmIOaHuL3pOaA=
-github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2 h1:hGzfOJjlCRoFpri5eYIiwhE27qu02pKZLprKvbsTC/w=
-github.com/stackitcloud/stackit-sdk-go/services/alb v0.14.2/go.mod h1:eK6oRB5Tmpt6KbXQ4UYBGg2LgW5bPtVoncL9E8JSRww=
+github.com/stackitcloud/stackit-sdk-go/services/alb v0.15.0 h1:GDiNrm0A1KIHARcx6xI2I4PvNEWJuNysP3w1M/9WYps=
+github.com/stackitcloud/stackit-sdk-go/services/alb v0.15.0/go.mod h1:eK6oRB5Tmpt6KbXQ4UYBGg2LgW5bPtVoncL9E8JSRww=
 github.com/stackitcloud/stackit-sdk-go/services/authorization v0.15.2 h1:b7WJ/vwxlVmNNX91kI3obqGcuoPAyaCbDL5aCMQ/sNg=
 github.com/stackitcloud/stackit-sdk-go/services/authorization v0.15.2/go.mod h1:T/JF25XGJ3GqER/1L2N//DgY8x5tY7gA3N+/0nvmOWY=
 github.com/stackitcloud/stackit-sdk-go/services/cdn v1.16.0 h1:Wqxx0PDTL2F5gqI5jjznuJY0TdqECltjA0aa/rHY63U=
@@ -692,8 +692,8 @@ github.com/stackitcloud/stackit-sdk-go/services/intake v0.9.0 h1:vtKZgDNsrZTr8jn
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.9.0/go.mod h1:UXhPs7JXjQvTp14d4ZffSLnFMQyB7y1cj100XWwQudI=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.10.0 h1:/xPQvEaSbysmIKL/wtTYiweEe74P9iCzzyIA7ZHY8FU=
 github.com/stackitcloud/stackit-sdk-go/services/kms v1.10.0/go.mod h1:pVaCmb1ZHAPGVRlSlBlVOjThp9Tb2sX9+nRX0M+d1KU=
-github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.13.0 h1:UuLNwFHjJCpL11y4F7B9oBKtZkxpu01VkNPILNkpex4=
-github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.13.0/go.mod h1:+Ld3dn648I+YKcBV3fEkYpDSr3fel421+LurJGywSBs=
+github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0 h1:1dvL7tX91ziklayQmOupniE3jM4D5Nbtc0auNcx2p18=
+github.com/stackitcloud/stackit-sdk-go/services/loadbalancer v1.14.0/go.mod h1:+Ld3dn648I+YKcBV3fEkYpDSr3fel421+LurJGywSBs=
 github.com/stackitcloud/stackit-sdk-go/services/logme v0.29.0 h1:zsZaPr15UkjLuNhOiF+K7dikhenZAd+sQuEvTlGnkvg=
 github.com/stackitcloud/stackit-sdk-go/services/logme v0.29.0/go.mod h1:JDOOYaGgcBts2x52nKPRMFgSZe7qqOFmfz1xIXCQgRY=
 github.com/stackitcloud/stackit-sdk-go/services/logs v0.9.0 h1:m/FSPciEqsci1e7Ph2Nn+XyV+1bNPCLDfm1rm42xjAk=
@@ -708,8 +708,8 @@ github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0 h1:T+ll3lS0
 github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0/go.mod h1:QsPtoqAYvumyPU6ToX/5j1PbudN+VSTuvh6mp154ecM=
 github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0 h1:kgD32fG3rkdGz0C+kZ1S7BEur7btTSeaX3vxHE346FY=
 github.com/stackitcloud/stackit-sdk-go/services/observability v0.23.0/go.mod h1:0fEZQHm729mBdvg4sNrAhM6KmHROHJSeS2FwCMRk46k=
-github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.28.0 h1:Bu8/UzMCAN8VyaEnz5O15zK+8xSV0kf8ndYXvwkNwOk=
-github.com/stackitcloud/stackit-sdk-go/services/opensearch v0.28.0/go.mod h1:L+NlfC1hilLOqlLLukCj/UDnxlnNrc/oMikcw3Ansyw=
+github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.0.0 h1:xJ/rhcMTV2pZ+s9PX/Q7+f4amNqn+kBl0t62cJ6xfko=
+github.com/stackitcloud/stackit-sdk-go/services/opensearch v1.0.0/go.mod h1:L+NlfC1hilLOqlLLukCj/UDnxlnNrc/oMikcw3Ansyw=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.8.0 h1:oWTviJKdlUxaaARJghTjOqBbarIK+7+nH3Kc3Wxn4rQ=
 github.com/stackitcloud/stackit-sdk-go/services/postgresflex v1.8.0/go.mod h1:yzlakB+f8ur4yAHR6lyCABO+HcEtZG3G2Faj6m5/uW8=
 github.com/stackitcloud/stackit-sdk-go/services/rabbitmq v0.30.0 h1:zAFgiybClUjSaSKkGRfxKRiPmuJI7j5bnb+41/Zhtm8=

--- a/golang-ci.yaml
+++ b/golang-ci.yaml
@@ -83,7 +83,6 @@ linters:
         - "-ST1021" # The documentation of an exported type should start with type's name.
         - "-ST1022" # The documentation of an exported variable or constant should start with variable's name.
         # customizations
-        - "-SA1019" # disable deprecation errors while we switch over to the SDK structure with multi API version support
         - "-QF1001" # disable 'could apply De Morgan's law': readability of boolean expressions is subjective and should be decided on a case-by-case basis
         - "-QF1012" # disable 'use fmt.Fprintf instead' Fprintf returns bytes written and an error, which we'd have to handle/ignore to appease some other linter
   exclusions:

--- a/stackit/internal/conversion/conversion.go
+++ b/stackit/internal/conversion/conversion.go
@@ -161,38 +161,27 @@ func StringListToPointer(list basetypes.ListValue) (*[]string, error) {
 // StringListToSlice converts basetypes.ListValue to a list of strings.
 // It returns nil if the value is null or unknown.
 func StringListToSlice(list basetypes.ListValue) ([]string, error) {
+	return StringListToEnumSlice[string](list)
+}
+
+// StringListToEnumSlice converts basetypes.ListValue to a list of enums.
+// It returns nil if the value is null or unknown.
+func StringListToEnumSlice[T ~string](list basetypes.ListValue) ([]T, error) {
 	if list.IsNull() || list.IsUnknown() {
 		return nil, nil
 	}
 
 	// Instantiate an empty slice to ensure the slice is not nil
-	listStr := []string{}
+	listStr := []T{}
 	for i, el := range list.Elements() {
 		elStr, ok := el.(types.String)
 		if !ok {
 			return nil, fmt.Errorf("element %d is not a string", i)
 		}
-		listStr = append(listStr, elStr.ValueString())
+		listStr = append(listStr, T(elStr.ValueString()))
 	}
 
 	return listStr, nil
-}
-
-// StringListToSlice converts basetypes.ListValue to a list of enums.
-// It returns nil if the value is null or unknown.
-func StringListToEnumSlice[T ~string](list basetypes.ListValue) ([]T, error) {
-	s, err := StringListToSlice(list)
-	if err != nil {
-		return nil, err
-	}
-
-	if s == nil {
-		return nil, nil
-	}
-
-	return utils.Map(s, func(s string) T {
-		return T(s)
-	}), nil
 }
 
 // StringSetToPointer converts basetypes.SetValue to a pointer to a list of strings.

--- a/stackit/internal/conversion/conversion.go
+++ b/stackit/internal/conversion/conversion.go
@@ -86,8 +86,7 @@ func StringValueToPointer(s basetypes.StringValue) *string {
 	if s.IsNull() || s.IsUnknown() {
 		return nil
 	}
-	value := s.ValueString()
-	return &value
+	return new(s.ValueString())
 }
 
 // StringValueToPointer converts basetypes.StringValue to a pointer to enum.
@@ -96,8 +95,7 @@ func StringValueToEnumPointer[T ~string](s basetypes.StringValue) *T {
 	if s.IsNull() || s.IsUnknown() {
 		return nil
 	}
-	value := s.ValueString()
-	return new(T(value))
+	return new(T(s.ValueString()))
 }
 
 // Int32ValueToPointer converts basetypes.Int32Value to a pointer to int32.

--- a/stackit/internal/conversion/conversion.go
+++ b/stackit/internal/conversion/conversion.go
@@ -90,6 +90,16 @@ func StringValueToPointer(s basetypes.StringValue) *string {
 	return &value
 }
 
+// StringValueToPointer converts basetypes.StringValue to a pointer to enum.
+// It returns nil if the value is null or unknown.
+func StringValueToEnumPointer[T ~string](s basetypes.StringValue) *T {
+	if s.IsNull() || s.IsUnknown() {
+		return nil
+	}
+	value := s.ValueString()
+	return new(T(value))
+}
+
 // Int32ValueToPointer converts basetypes.Int32Value to a pointer to int32.
 // It returns nil if the value is null or unknown.
 func Int32ValueToPointer(s basetypes.Int32Value) *int32 {
@@ -168,6 +178,23 @@ func StringListToSlice(list basetypes.ListValue) ([]string, error) {
 	}
 
 	return listStr, nil
+}
+
+// StringListToSlice converts basetypes.ListValue to a list of enums.
+// It returns nil if the value is null or unknown.
+func StringListToEnumSlice[T ~string](list basetypes.ListValue) ([]T, error) {
+	s, err := StringListToSlice(list)
+	if err != nil {
+		return nil, err
+	}
+
+	if s == nil {
+		return nil, nil
+	}
+
+	return utils.Map(s, func(s string) T {
+		return T(s)
+	}), nil
 }
 
 // StringSetToPointer converts basetypes.SetValue to a pointer to a list of strings.

--- a/stackit/internal/conversion/conversion_test.go
+++ b/stackit/internal/conversion/conversion_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	opensearch "github.com/stackitcloud/stackit-sdk-go/services/opensearch/v1api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
 
@@ -631,6 +632,158 @@ func TestTerraformStringSetToList(t *testing.T) {
 
 			if d := cmp.Diff(got, tt.want); d != "" {
 				t.Fatalf("no match, diff: %s", d)
+			}
+		})
+	}
+}
+
+func TestStringValueToPointer(t *testing.T) {
+	type args struct {
+		s basetypes.StringValue
+	}
+	tests := []struct {
+		name string
+		args args
+		want *string
+	}{
+		{
+			name: "default",
+			args: args{
+				s: basetypes.NewStringValue("abc"),
+			},
+			want: new("abc"),
+		},
+		{
+			name: "unknown",
+			args: args{
+				s: basetypes.NewStringUnknown(),
+			},
+			want: nil,
+		},
+		{
+			name: "null",
+			args: args{
+				s: basetypes.NewStringNull(),
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringValueToPointer(tt.args.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StringValueToPointer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringValueToEnumPointer(t *testing.T) {
+	type args struct {
+		s basetypes.StringValue
+	}
+	type testCase[T interface{ ~string }] struct {
+		name string
+		args args
+		want *T
+	}
+	tests := []testCase[opensearch.InstanceParametersJavaGarbageCollector]{
+		{
+			name: "default",
+			args: args{
+				s: basetypes.NewStringValue("UseG1GC"),
+			},
+			want: new(opensearch.INSTANCEPARAMETERSJAVAGARBAGECOLLECTOR_USE_G1_GC),
+		},
+		{
+			name: "unknown",
+			args: args{
+				s: basetypes.NewStringUnknown(),
+			},
+			want: nil,
+		},
+		{
+			name: "null",
+			args: args{
+				s: basetypes.NewStringNull(),
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringValueToEnumPointer[opensearch.InstanceParametersJavaGarbageCollector](tt.args.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StringValueToEnumPointer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringListToEnumSlice(t *testing.T) {
+	type args struct {
+		list basetypes.ListValue
+	}
+	type testCase[T interface{ ~string }] struct {
+		name    string
+		args    args
+		want    []T
+		wantErr bool
+	}
+	tests := []testCase[opensearch.InstanceParametersTlsProtocolsInner]{
+		{
+			name: "default",
+			args: args{
+				list: basetypes.NewListValueMust(types.StringType, []attr.Value{
+					types.StringValue("TLSv1.2"),
+					types.StringValue("TLSv1.3"),
+				}),
+			},
+			want: []opensearch.InstanceParametersTlsProtocolsInner{
+				opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_2,
+				opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_3,
+			},
+			wantErr: false,
+		},
+		{
+			name: "unknown",
+			args: args{
+				list: basetypes.NewListUnknown(types.StringType),
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "null",
+			args: args{
+				list: basetypes.NewListNull(types.StringType),
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "empty list",
+			args: args{
+				list: basetypes.NewListValueMust(types.StringType, []attr.Value{}),
+			},
+			want:    []opensearch.InstanceParametersTlsProtocolsInner{},
+			wantErr: false,
+		},
+		{
+			name: "invalid type",
+			args: args{
+				list: basetypes.NewListValueMust(types.Int64Type, []attr.Value{types.Int64Value(123)}),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := StringListToEnumSlice[opensearch.InstanceParametersTlsProtocolsInner](tt.args.list)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StringListToEnumSlice() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("StringListToEnumSlice() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/stackit/internal/conversion/conversion_test.go
+++ b/stackit/internal/conversion/conversion_test.go
@@ -728,18 +728,18 @@ func TestStringListToEnumSlice(t *testing.T) {
 		want    []T
 		wantErr bool
 	}
-	tests := []testCase[opensearch.InstanceParametersTlsProtocolsInner]{
+	tests := []testCase[opensearch.InstanceParametersPluginsInner]{
 		{
 			name: "default",
 			args: args{
 				list: basetypes.NewListValueMust(types.StringType, []attr.Value{
-					types.StringValue("TLSv1.2"),
-					types.StringValue("TLSv1.3"),
+					types.StringValue("repository-s3"),
+					types.StringValue("repository-azure"),
 				}),
 			},
-			want: []opensearch.InstanceParametersTlsProtocolsInner{
-				opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_2,
-				opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_3,
+			want: []opensearch.InstanceParametersPluginsInner{
+				opensearch.INSTANCEPARAMETERSPLUGINSINNER_REPOSITORY_S3,
+				opensearch.INSTANCEPARAMETERSPLUGINSINNER_REPOSITORY_AZURE,
 			},
 			wantErr: false,
 		},
@@ -764,7 +764,7 @@ func TestStringListToEnumSlice(t *testing.T) {
 			args: args{
 				list: basetypes.NewListValueMust(types.StringType, []attr.Value{}),
 			},
-			want:    []opensearch.InstanceParametersTlsProtocolsInner{},
+			want:    []opensearch.InstanceParametersPluginsInner{},
 			wantErr: false,
 		},
 		{
@@ -777,7 +777,7 @@ func TestStringListToEnumSlice(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := StringListToEnumSlice[opensearch.InstanceParametersTlsProtocolsInner](tt.args.list)
+			got, err := StringListToEnumSlice[opensearch.InstanceParametersPluginsInner](tt.args.list)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StringListToEnumSlice() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/stackit/internal/services/alb/applicationloadbalancer/datasource.go
+++ b/stackit/internal/services/alb/applicationloadbalancer/datasource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	legacyAlb "github.com/stackitcloud/stackit-sdk-go/services/alb"
 	albSdk "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -60,9 +59,9 @@ func (r *albDataSource) Configure(ctx context.Context, req datasource.ConfigureR
 
 // Schema defines the schema for the resource.
 func (r *albDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	protocolOptions := sdkUtils.EnumSliceToStringSlice(legacyAlb.AllowedListenerProtocolEnumValues)
-	roleOptions := sdkUtils.EnumSliceToStringSlice(legacyAlb.AllowedNetworkRoleEnumValues)
-	errorOptions := sdkUtils.EnumSliceToStringSlice(legacyAlb.AllowedLoadBalancerErrorTypesEnumValues)
+	protocolOptions := sdkUtils.EnumSliceToStringSlice(albSdk.AllowedListenerProtocolEnumValues)
+	roleOptions := sdkUtils.EnumSliceToStringSlice(albSdk.AllowedNetworkRoleEnumValues)
+	errorOptions := sdkUtils.EnumSliceToStringSlice(albSdk.AllowedLoadBalancerErrorTypeEnumValues)
 
 	descriptions := map[string]string{
 		"main":       "Application Load Balancer resource schema.",

--- a/stackit/internal/services/alb/applicationloadbalancer/resource.go
+++ b/stackit/internal/services/alb/applicationloadbalancer/resource.go
@@ -32,7 +32,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
 	sdkUtils "github.com/stackitcloud/stackit-sdk-go/core/utils"
-	legacyAlb "github.com/stackitcloud/stackit-sdk-go/services/alb"
 	albSdk "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 	"github.com/stackitcloud/stackit-sdk-go/services/alb/v2api/wait"
 
@@ -390,9 +389,9 @@ func (r *applicationLoadBalancerResource) Configure(ctx context.Context, req res
 
 // Schema defines the schema for the resource.
 func (r *applicationLoadBalancerResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	protocolOptions := sdkUtils.EnumSliceToStringSlice(legacyAlb.AllowedListenerProtocolEnumValues)
-	roleOptions := sdkUtils.EnumSliceToStringSlice(legacyAlb.AllowedNetworkRoleEnumValues)
-	errorOptions := sdkUtils.EnumSliceToStringSlice(legacyAlb.AllowedLoadBalancerErrorTypesEnumValues)
+	protocolOptions := sdkUtils.EnumSliceToStringSlice(albSdk.AllowedListenerProtocolEnumValues)
+	roleOptions := sdkUtils.EnumSliceToStringSlice(albSdk.AllowedNetworkRoleEnumValues)
+	errorOptions := sdkUtils.EnumSliceToStringSlice(albSdk.AllowedLoadBalancerErrorTypeEnumValues)
 
 	descriptions := map[string]string{
 		"main":       "Application Load Balancer resource schema.",
@@ -1464,7 +1463,7 @@ func toListenersPayload(ctx context.Context, model *Model) ([]albSdk.Listener, e
 			Https:         httpsPayload,
 			Name:          conversion.StringValueToPointer(listenerModel.Name),
 			Port:          conversion.Int32ValueToPointer(listenerModel.Port),
-			Protocol:      conversion.StringValueToPointer(listenerModel.Protocol),
+			Protocol:      conversion.StringValueToEnumPointer[albSdk.ListenerProtocol](listenerModel.Protocol),
 			WafConfigName: conversion.StringValueToPointer(listenerModel.WafConfigName),
 		})
 	}
@@ -1718,7 +1717,7 @@ func toNetworksPayload(ctx context.Context, model *Model) ([]albSdk.Network, err
 		networkModel := networksModel[i]
 		payload = append(payload, albSdk.Network{
 			NetworkId: conversion.StringValueToPointer(networkModel.NetworkId),
-			Role:      conversion.StringValueToPointer(networkModel.Role),
+			Role:      conversion.StringValueToEnumPointer[albSdk.NetworkRole](networkModel.Role),
 		})
 	}
 

--- a/stackit/internal/services/alb/applicationloadbalancer/resource_test.go
+++ b/stackit/internal/services/alb/applicationloadbalancer/resource_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/stackitcloud/stackit-sdk-go/core/utils"
-	legacyAlb "github.com/stackitcloud/stackit-sdk-go/services/alb"
 	albSdk "github.com/stackitcloud/stackit-sdk-go/services/alb/v2api"
 )
 
@@ -38,14 +36,14 @@ func fixtureModel(explicitBool *bool, mods ...func(m *Model)) *Model {
 					errorsType,
 					map[string]attr.Value{
 						"description": types.StringValue("quota test error"),
-						"type":        types.StringValue(string(legacyAlb.LOADBALANCERERRORTYPE_QUOTA_SECGROUP_EXCEEDED)),
+						"type":        types.StringValue(string(albSdk.LOADBALANCERERRORTYPE_TYPE_QUOTA_SECGROUP_EXCEEDED)),
 					},
 				),
 				types.ObjectValueMust(
 					errorsType,
 					map[string]attr.Value{
 						"description": types.StringValue("fip test error"),
-						"type":        types.StringValue(string(legacyAlb.LOADBALANCERERRORTYPE_FIP_NOT_CONFIGURED)),
+						"type":        types.StringValue(string(albSdk.LOADBALANCERERRORTYPE_TYPE_FIP_NOT_CONFIGURED)),
 					},
 				),
 			},
@@ -342,18 +340,18 @@ func fixtureApplicationLoadBalancer(explicitBool *bool, mods ...func(m *albSdk.L
 		Errors: []albSdk.LoadBalancerError{
 			{
 				Description: new("quota test error"),
-				Type:        new(string(legacyAlb.LOADBALANCERERRORTYPE_QUOTA_SECGROUP_EXCEEDED)),
+				Type:        new(albSdk.LOADBALANCERERRORTYPE_TYPE_QUOTA_SECGROUP_EXCEEDED),
 			},
 			{
 				Description: new("fip test error"),
-				Type:        new(string(legacyAlb.LOADBALANCERERRORTYPE_FIP_NOT_CONFIGURED)),
+				Type:        new(albSdk.LOADBALANCERERRORTYPE_TYPE_FIP_NOT_CONFIGURED),
 			},
 		},
 		Name:           new(lbName),
 		PlanId:         new("p10"),
 		PrivateAddress: new("10.1.11.0"),
 		Region:         new(region),
-		Status:         new("STATUS_READY"),
+		Status:         new(albSdk.LOADBALANCERSTATUS_STATUS_READY),
 		Version:        new(lbVersion),
 		Labels: &map[string]string{
 			"key":  "value",
@@ -362,18 +360,18 @@ func fixtureApplicationLoadBalancer(explicitBool *bool, mods ...func(m *albSdk.L
 		Networks: []albSdk.Network{
 			{
 				NetworkId: new("c7c92cc1-a6bd-4e15-a129-b6e2b9899bbc"),
-				Role:      utils.Ptr("ROLE_LISTENERS"),
+				Role:      new(albSdk.NETWORKROLE_ROLE_LISTENERS),
 			},
 			{
 				NetworkId: new("ed3f1822-ca1c-4969-bea6-74c6b3e9aa40"),
-				Role:      utils.Ptr("ROLE_TARGETS"),
+				Role:      new(albSdk.NETWORKROLE_ROLE_TARGETS),
 			},
 		},
 		Listeners: []albSdk.Listener{
 			{
 				Name:     new("http-80"),
 				Port:     new(int32(80)),
-				Protocol: utils.Ptr("PROTOCOL_HTTP"),
+				Protocol: new(albSdk.LISTENERPROTOCOL_PROTOCOL_HTTP),
 				Http: &albSdk.ProtocolOptionsHTTP{
 					Hosts: []albSdk.HostConfig{
 						{
@@ -887,7 +885,7 @@ func TestMapFields(t *testing.T) {
 					{
 						Name:     new("http-80"),
 						Port:     new(int32(80)),
-						Protocol: utils.Ptr("PROTOCOL_HTTP"),
+						Protocol: new(albSdk.LISTENERPROTOCOL_PROTOCOL_HTTP),
 						Http: &albSdk.ProtocolOptionsHTTP{
 							Hosts: []albSdk.HostConfig{
 								{
@@ -1013,7 +1011,7 @@ func TestMapFields(t *testing.T) {
 					{
 						Name:     new("http-80"),
 						Port:     new(int32(80)),
-						Protocol: utils.Ptr("PROTOCOL_HTTP"),
+						Protocol: new(albSdk.LISTENERPROTOCOL_PROTOCOL_HTTP),
 						Http: &albSdk.ProtocolOptionsHTTP{
 							Hosts: []albSdk.HostConfig{
 								{
@@ -1132,7 +1130,7 @@ func TestMapFields(t *testing.T) {
 					{
 						Name:     new("http-80"),
 						Port:     new(int32(80)),
-						Protocol: utils.Ptr("PROTOCOL_HTTP"),
+						Protocol: new(albSdk.LISTENERPROTOCOL_PROTOCOL_HTTP),
 						Http: &albSdk.ProtocolOptionsHTTP{
 							Hosts: []albSdk.HostConfig{
 								{
@@ -1234,7 +1232,7 @@ func TestMapFields(t *testing.T) {
 					{
 						Name:     new("http-80"),
 						Port:     new(int32(80)),
-						Protocol: utils.Ptr("PROTOCOL_HTTP"),
+						Protocol: new(albSdk.LISTENERPROTOCOL_PROTOCOL_HTTP),
 						Http: &albSdk.ProtocolOptionsHTTP{
 							Hosts: []albSdk.HostConfig{
 								{
@@ -1314,7 +1312,7 @@ func TestMapFields(t *testing.T) {
 					{
 						Name:     new("http-80"),
 						Port:     new(int32(80)),
-						Protocol: utils.Ptr("PROTOCOL_HTTP"),
+						Protocol: new(albSdk.LISTENERPROTOCOL_PROTOCOL_HTTP),
 						Http: &albSdk.ProtocolOptionsHTTP{
 							Hosts: nil,
 						},
@@ -1380,7 +1378,7 @@ func TestMapFields(t *testing.T) {
 					{
 						Name:     new("http-80"),
 						Port:     new(int32(80)),
-						Protocol: utils.Ptr("PROTOCOL_HTTP"),
+						Protocol: new(albSdk.LISTENERPROTOCOL_PROTOCOL_HTTP),
 						Http:     nil,
 						Https: &albSdk.ProtocolOptionsHTTPS{
 							CertificateConfig: new(albSdk.CertificateConfig{

--- a/stackit/internal/services/iaas/project/datasource.go
+++ b/stackit/internal/services/iaas/project/datasource.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas" //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -53,7 +53,7 @@ func (d *projectDataSource) Configure(ctx context.Context, req datasource.Config
 		return
 	}
 
-	apiClient := iaasUtils.ConfigureClientLegacy(ctx, &providerData, &resp.Diagnostics)
+	apiClient := iaasUtils.ConfigureClientLegacy(ctx, &providerData, &resp.Diagnostics) //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -138,7 +138,7 @@ func (d *projectDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	ctx = tflog.SetField(ctx, "project_id", projectId)
 
-	projectResp, err := d.client.GetProjectDetailsExecute(ctx, projectId)
+	projectResp, err := d.client.GetProjectDetailsExecute(ctx, projectId) //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 	if err != nil {
 		utils.LogError(
 			ctx,

--- a/stackit/internal/services/iaas/project/datasource_test.go
+++ b/stackit/internal/services/iaas/project/datasource_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
-	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas" //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 )
 
 const (
@@ -74,7 +74,7 @@ func TestMapDataSourceFields(t *testing.T) {
 			},
 			input: &iaas.Project{
 				AreaId: new(iaas.AreaId{
-					StaticAreaID: iaas.STATICAREAID_PUBLIC.Ptr(),
+					StaticAreaID: iaas.STATICAREAID_PUBLIC.Ptr(), //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 				}),
 				Id: utils.Ptr(projectId),
 			},

--- a/stackit/internal/services/iaas/utils/util.go
+++ b/stackit/internal/services/iaas/utils/util.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	iaasLegacy "github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	iaasLegacy "github.com/stackitcloud/stackit-sdk-go/services/iaas" //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -34,7 +34,8 @@ func ConfigureClient(ctx context.Context, providerData *core.ProviderData, diags
 	return apiClient
 }
 
-func ConfigureClientLegacy(ctx context.Context, providerData *core.ProviderData, diags *diag.Diagnostics) *iaasLegacy.APIClient {
+// Deprecated: Use ConfigureClient instead
+func ConfigureClientLegacy(ctx context.Context, providerData *core.ProviderData, diags *diag.Diagnostics) *iaasLegacy.APIClient { //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 	apiClientConfigOptions := []config.ConfigurationOption{
 		config.WithCustomAuth(providerData.RoundTripper),
 		utils.UserAgentConfigOption(providerData.Version),

--- a/stackit/internal/services/iaas/utils/util_test.go
+++ b/stackit/internal/services/iaas/utils/util_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	sdkClients "github.com/stackitcloud/stackit-sdk-go/core/clients"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	iaasLegacy "github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	iaasLegacy "github.com/stackitcloud/stackit-sdk-go/services/iaas" //nolint:staticcheck // TODO: will be done within STACKITTPR-713
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource.go
@@ -1082,7 +1082,7 @@ func toListenersPayload(ctx context.Context, model *Model) ([]loadbalancer.Liste
 		payload = append(payload, loadbalancer.Listener{
 			DisplayName:          conversion.StringValueToPointer(listenerModel.DisplayName),
 			Port:                 conversion.Int32ValueToPointer(listenerModel.Port),
-			Protocol:             conversion.StringValueToPointer(listenerModel.Protocol),
+			Protocol:             conversion.StringValueToEnumPointer[loadbalancer.ListenerProtocol](listenerModel.Protocol),
 			ServerNameIndicators: serverNameIndicatorsPayload,
 			TargetPool:           conversion.StringValueToPointer(listenerModel.TargetPool),
 			Tcp:                  tcp,
@@ -1173,7 +1173,7 @@ func toNetworksPayload(ctx context.Context, model *Model) ([]loadbalancer.Networ
 		networkModel := networksModel[i]
 		payload = append(payload, loadbalancer.Network{
 			NetworkId: conversion.StringValueToPointer(networkModel.NetworkId),
-			Role:      conversion.StringValueToPointer(networkModel.Role),
+			Role:      conversion.StringValueToEnumPointer[loadbalancer.NetworkRole](networkModel.Role),
 		})
 	}
 
@@ -1415,7 +1415,7 @@ func mapListeners(loadBalancerResp *loadbalancer.LoadBalancer, m *Model) error {
 		listenerMap := map[string]attr.Value{
 			"display_name": types.StringPointerValue(listenerResp.DisplayName),
 			"port":         types.Int32PointerValue(listenerResp.Port),
-			"protocol":     types.StringPointerValue(listenerResp.Protocol),
+			"protocol":     types.StringPointerValue((*string)(listenerResp.Protocol)),
 			"target_pool":  types.StringPointerValue(listenerResp.TargetPool),
 		}
 
@@ -1530,7 +1530,7 @@ func mapNetworks(loadBalancerResp *loadbalancer.LoadBalancer, m *Model) error {
 	for i, networkResp := range loadBalancerResp.Networks {
 		networkMap := map[string]attr.Value{
 			"network_id": types.StringPointerValue(networkResp.NetworkId),
-			"role":       types.StringPointerValue(networkResp.Role),
+			"role":       types.StringPointerValue((*string)(networkResp.Role)),
 		}
 
 		networkTF, diags := types.ObjectValue(networkTypes, networkMap)

--- a/stackit/internal/services/loadbalancer/loadbalancer/resource_test.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer/resource_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	legacyLoadbalancer "github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 	loadbalancer "github.com/stackitcloud/stackit-sdk-go/services/loadbalancer/v2api"
 )
 
@@ -51,7 +50,7 @@ func TestToCreatePayload(t *testing.T) {
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),
 						"port":         types.Int32Value(80),
-						"protocol":     types.StringValue(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						"protocol":     types.StringValue(string(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP)),
 						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
 							types.ObjectValueMust(
 								serverNameIndicatorTypes,
@@ -74,11 +73,11 @@ func TestToCreatePayload(t *testing.T) {
 				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id_2"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 				}),
 				Options: types.ObjectValueMust(
@@ -129,7 +128,7 @@ func TestToCreatePayload(t *testing.T) {
 					{
 						DisplayName: new("display_name"),
 						Port:        new(int32(80)),
-						Protocol:    new(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						Protocol:    new(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP),
 						ServerNameIndicators: []loadbalancer.ServerNameIndicator{
 							{
 								Name: new("domain.com"),
@@ -148,11 +147,11 @@ func TestToCreatePayload(t *testing.T) {
 				Networks: []loadbalancer.Network{
 					{
 						NetworkId: new("network_id"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 					{
 						NetworkId: new("network_id_2"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 				},
 				Options: &loadbalancer.LoadBalancerOptions{
@@ -205,7 +204,7 @@ func TestToCreatePayload(t *testing.T) {
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),
 						"port":         types.Int32Value(80),
-						"protocol":     types.StringValue(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						"protocol":     types.StringValue(string(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP)),
 						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
 							types.ObjectValueMust(
 								serverNameIndicatorTypes,
@@ -224,11 +223,11 @@ func TestToCreatePayload(t *testing.T) {
 				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id_2"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 				}),
 				Options: types.ObjectValueMust(
@@ -280,7 +279,7 @@ func TestToCreatePayload(t *testing.T) {
 					{
 						DisplayName: new("display_name"),
 						Port:        new(int32(80)),
-						Protocol:    new(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						Protocol:    new(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP),
 						ServerNameIndicators: []loadbalancer.ServerNameIndicator{
 							{
 								Name: new("domain.com"),
@@ -293,11 +292,11 @@ func TestToCreatePayload(t *testing.T) {
 				Networks: []loadbalancer.Network{
 					{
 						NetworkId: new("network_id"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 					{
 						NetworkId: new("network_id_2"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 				},
 				Options: &loadbalancer.LoadBalancerOptions{
@@ -435,7 +434,7 @@ func TestMapFields(t *testing.T) {
 					{
 						DisplayName: new("display_name"),
 						Port:        new(int32(80)),
-						Protocol:    new(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						Protocol:    new(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP),
 						ServerNameIndicators: []loadbalancer.ServerNameIndicator{
 							{
 								Name: new("domain.com"),
@@ -454,11 +453,11 @@ func TestMapFields(t *testing.T) {
 				Networks: []loadbalancer.Network{
 					{
 						NetworkId: new("network_id"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 					{
 						NetworkId: new("network_id_2"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 				},
 				Options: new(loadbalancer.LoadBalancerOptions{
@@ -512,7 +511,7 @@ func TestMapFields(t *testing.T) {
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),
 						"port":         types.Int32Value(80),
-						"protocol":     types.StringValue(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						"protocol":     types.StringValue(string(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP)),
 						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
 							types.ObjectValueMust(
 								serverNameIndicatorTypes,
@@ -535,11 +534,11 @@ func TestMapFields(t *testing.T) {
 				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id_2"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 				}),
 				Options: types.ObjectValueMust(
@@ -593,7 +592,7 @@ func TestMapFields(t *testing.T) {
 					{
 						DisplayName: new("display_name"),
 						Port:        new(int32(80)),
-						Protocol:    new(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						Protocol:    new(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP),
 						ServerNameIndicators: []loadbalancer.ServerNameIndicator{
 							{
 								Name: new("domain.com"),
@@ -606,11 +605,11 @@ func TestMapFields(t *testing.T) {
 				Networks: []loadbalancer.Network{
 					{
 						NetworkId: new("network_id"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 					{
 						NetworkId: new("network_id_2"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 				},
 				Options: new(loadbalancer.LoadBalancerOptions{
@@ -662,7 +661,7 @@ func TestMapFields(t *testing.T) {
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),
 						"port":         types.Int32Value(80),
-						"protocol":     types.StringValue(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						"protocol":     types.StringValue(string(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP)),
 						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
 							types.ObjectValueMust(
 								serverNameIndicatorTypes,
@@ -681,11 +680,11 @@ func TestMapFields(t *testing.T) {
 				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id_2"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 				}),
 				Options: types.ObjectValueMust(
@@ -925,7 +924,7 @@ func Test_toUpdatePayload(t *testing.T) {
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),
 						"port":         types.Int32Value(80),
-						"protocol":     types.StringValue(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						"protocol":     types.StringValue(string(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP)),
 						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
 							types.ObjectValueMust(
 								serverNameIndicatorTypes,
@@ -948,11 +947,11 @@ func Test_toUpdatePayload(t *testing.T) {
 				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id_2"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 				}),
 				Options: types.ObjectValueMust(
@@ -1003,7 +1002,7 @@ func Test_toUpdatePayload(t *testing.T) {
 					{
 						DisplayName: new("display_name"),
 						Port:        new(int32(80)),
-						Protocol:    new(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						Protocol:    new(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP),
 						ServerNameIndicators: []loadbalancer.ServerNameIndicator{
 							{
 								Name: new("domain.com"),
@@ -1022,11 +1021,11 @@ func Test_toUpdatePayload(t *testing.T) {
 				Networks: []loadbalancer.Network{
 					{
 						NetworkId: new("network_id"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 					{
 						NetworkId: new("network_id_2"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 				},
 				Options: &loadbalancer.LoadBalancerOptions{
@@ -1079,7 +1078,7 @@ func Test_toUpdatePayload(t *testing.T) {
 					types.ObjectValueMust(listenerTypes, map[string]attr.Value{
 						"display_name": types.StringValue("display_name"),
 						"port":         types.Int32Value(80),
-						"protocol":     types.StringValue(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						"protocol":     types.StringValue(string(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP)),
 						"server_name_indicators": types.ListValueMust(types.ObjectType{AttrTypes: serverNameIndicatorTypes}, []attr.Value{
 							types.ObjectValueMust(
 								serverNameIndicatorTypes,
@@ -1098,11 +1097,11 @@ func Test_toUpdatePayload(t *testing.T) {
 				Networks: types.ListValueMust(types.ObjectType{AttrTypes: networkTypes}, []attr.Value{
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 					types.ObjectValueMust(networkTypes, map[string]attr.Value{
 						"network_id": types.StringValue("network_id_2"),
-						"role":       types.StringValue(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						"role":       types.StringValue(string(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS)),
 					}),
 				}),
 				Options: types.ObjectValueMust(
@@ -1154,7 +1153,7 @@ func Test_toUpdatePayload(t *testing.T) {
 					{
 						DisplayName: new("display_name"),
 						Port:        new(int32(80)),
-						Protocol:    new(string(legacyLoadbalancer.LISTENERPROTOCOL_TCP)),
+						Protocol:    new(loadbalancer.LISTENERPROTOCOL_PROTOCOL_TCP),
 						ServerNameIndicators: []loadbalancer.ServerNameIndicator{
 							{
 								Name: new("domain.com"),
@@ -1167,11 +1166,11 @@ func Test_toUpdatePayload(t *testing.T) {
 				Networks: []loadbalancer.Network{
 					{
 						NetworkId: new("network_id"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 					{
 						NetworkId: new("network_id_2"),
-						Role:      new(string(legacyLoadbalancer.NETWORKROLE_LISTENERS_AND_TARGETS)),
+						Role:      new(loadbalancer.NETWORKROLE_ROLE_LISTENERS_AND_TARGETS),
 					},
 				},
 				Options: &loadbalancer.LoadBalancerOptions{

--- a/stackit/internal/services/opensearch/instance/resource.go
+++ b/stackit/internal/services/opensearch/instance/resource.go
@@ -762,7 +762,7 @@ func toInstanceParams(parameters *parametersModel) (*opensearch.InstanceParamete
 	payloadParams.SgwAcl = conversion.StringValueToPointer(parameters.SgwAcl)
 	payloadParams.EnableMonitoring = conversion.BoolValueToPointer(parameters.EnableMonitoring)
 	payloadParams.Graphite = conversion.StringValueToPointer(parameters.Graphite)
-	payloadParams.JavaGarbageCollector = conversion.StringValueToPointer(parameters.JavaGarbageCollector)
+	payloadParams.JavaGarbageCollector = conversion.StringValueToEnumPointer[opensearch.InstanceParametersJavaGarbageCollector](parameters.JavaGarbageCollector)
 	payloadParams.JavaHeapspace = conversion.Int32ValueToPointer(parameters.JavaHeapspace)
 	payloadParams.JavaMaxmetaspace = conversion.Int32ValueToPointer(parameters.JavaMaxmetaspace)
 	payloadParams.MaxDiskThreshold = conversion.Int32ValueToPointer(parameters.MaxDiskThreshold)
@@ -771,7 +771,7 @@ func toInstanceParams(parameters *parametersModel) (*opensearch.InstanceParamete
 	payloadParams.MonitoringInstanceId = conversion.StringValueToPointer(parameters.MonitoringInstanceId)
 
 	var err error
-	payloadParams.Plugins, err = conversion.StringListToSlice(parameters.Plugins)
+	payloadParams.Plugins, err = conversion.StringListToEnumSlice[opensearch.InstanceParametersPluginsInner](parameters.Plugins)
 	if err != nil {
 		return nil, fmt.Errorf("convert plugins: %w", err)
 	}
@@ -786,7 +786,7 @@ func toInstanceParams(parameters *parametersModel) (*opensearch.InstanceParamete
 		return nil, fmt.Errorf("convert tls_ciphers: %w", err)
 	}
 
-	payloadParams.TlsProtocols, err = conversion.StringListToSlice(parameters.TlsProtocols)
+	payloadParams.TlsProtocols, err = conversion.StringListToEnumSlice[opensearch.InstanceParametersTlsProtocolsInner](parameters.TlsProtocols)
 	if err != nil {
 		return nil, fmt.Errorf("convert tls_protocols: %w", err)
 	}

--- a/stackit/internal/services/opensearch/instance/resource_test.go
+++ b/stackit/internal/services/opensearch/instance/resource_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	legacyOpensearch "github.com/stackitcloud/stackit-sdk-go/services/opensearch"
 	opensearch "github.com/stackitcloud/stackit-sdk-go/services/opensearch/v1api"
 )
 
@@ -16,7 +15,7 @@ var fixtureModelParameters = types.ObjectValueMust(parametersTypes, map[string]a
 	"sgw_acl":                types.StringValue("acl"),
 	"enable_monitoring":      types.BoolValue(true),
 	"graphite":               types.StringValue("graphite"),
-	"java_garbage_collector": types.StringValue(string(legacyOpensearch.INSTANCEPARAMETERSJAVA_GARBAGE_COLLECTOR_USE_G1_GC)),
+	"java_garbage_collector": types.StringValue(string(opensearch.INSTANCEPARAMETERSJAVAGARBAGECOLLECTOR_USE_G1_GC)),
 	"java_heapspace":         types.Int32Value(10),
 	"java_maxmetaspace":      types.Int32Value(10),
 	"max_disk_threshold":     types.Int32Value(10),
@@ -24,8 +23,8 @@ var fixtureModelParameters = types.ObjectValueMust(parametersTypes, map[string]a
 	"metrics_prefix":         types.StringValue("prefix"),
 	"monitoring_instance_id": types.StringValue("mid"),
 	"plugins": types.ListValueMust(types.StringType, []attr.Value{
-		types.StringValue("plugin"),
-		types.StringValue("plugin2"),
+		types.StringValue("repository-s3"),
+		types.StringValue("repository-azure"),
 	}),
 	"syslog": types.ListValueMust(types.StringType, []attr.Value{
 		types.StringValue("syslog"),
@@ -62,17 +61,23 @@ var fixtureInstanceParameters = opensearch.InstanceParameters{
 	SgwAcl:               new("acl"),
 	EnableMonitoring:     new(true),
 	Graphite:             new("graphite"),
-	JavaGarbageCollector: new(string(legacyOpensearch.INSTANCEPARAMETERSJAVA_GARBAGE_COLLECTOR_USE_G1_GC)),
+	JavaGarbageCollector: new(opensearch.INSTANCEPARAMETERSJAVAGARBAGECOLLECTOR_USE_G1_GC),
 	JavaHeapspace:        new(int32(10)),
 	JavaMaxmetaspace:     new(int32(10)),
 	MaxDiskThreshold:     new(int32(10)),
 	MetricsFrequency:     new(int32(10)),
 	MetricsPrefix:        new("prefix"),
 	MonitoringInstanceId: new("mid"),
-	Plugins:              []string{"plugin", "plugin2"},
-	Syslog:               []string{"syslog", "syslog2"},
-	TlsCiphers:           []string{"cipher", "cipher2"},
-	TlsProtocols:         []string{"TLSv1.2", "TLSv1.3"},
+	Plugins: []opensearch.InstanceParametersPluginsInner{
+		opensearch.INSTANCEPARAMETERSPLUGINSINNER_REPOSITORY_S3,
+		opensearch.INSTANCEPARAMETERSPLUGINSINNER_REPOSITORY_AZURE,
+	},
+	Syslog:     []string{"syslog", "syslog2"},
+	TlsCiphers: []string{"cipher", "cipher2"},
+	TlsProtocols: []opensearch.InstanceParametersTlsProtocolsInner{
+		opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_2,
+		opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_3,
+	},
 }
 
 func TestMapFields(t *testing.T) {
@@ -116,14 +121,14 @@ func TestMapFields(t *testing.T) {
 					"sgw_acl":                "acl",
 					"enable_monitoring":      true,
 					"graphite":               "graphite",
-					"java_garbage_collector": string(legacyOpensearch.INSTANCEPARAMETERSJAVA_GARBAGE_COLLECTOR_USE_G1_GC),
+					"java_garbage_collector": string(opensearch.INSTANCEPARAMETERSJAVAGARBAGECOLLECTOR_USE_G1_GC),
 					"java_heapspace":         int32(10),
 					"java_maxmetaspace":      int32(10),
 					"max_disk_threshold":     int32(10),
 					"metrics_frequency":      int32(10),
 					"metrics_prefix":         "prefix",
 					"monitoring_instance_id": "mid",
-					"plugins":                []string{"plugin", "plugin2"},
+					"plugins":                []string{"repository-s3", "repository-azure"},
 					"syslog":                 []string{"syslog", "syslog2"},
 					"tls-ciphers":            []string{"cipher", "cipher2"},
 					"tls-protocols":          []string{"TLSv1.2", "TLSv1.3"},
@@ -350,7 +355,7 @@ func TestToUpdatePayload(t *testing.T) {
 					"sgw_acl":                types.StringValue("acl"),
 					"enable_monitoring":      types.BoolValue(true),
 					"graphite":               types.StringValue("graphite"),
-					"java_garbage_collector": types.StringValue(string(legacyOpensearch.INSTANCEPARAMETERSJAVA_GARBAGE_COLLECTOR_USE_G1_GC)),
+					"java_garbage_collector": types.StringValue(string(opensearch.INSTANCEPARAMETERSJAVAGARBAGECOLLECTOR_USE_G1_GC)),
 					"java_heapspace":         types.Int32Value(10),
 					"java_maxmetaspace":      types.Int32Value(10),
 					"max_disk_threshold":     types.Int32Value(10),
@@ -377,17 +382,20 @@ func TestToUpdatePayload(t *testing.T) {
 					SgwAcl:               new("acl"),
 					EnableMonitoring:     new(true),
 					Graphite:             new("graphite"),
-					JavaGarbageCollector: new(string(legacyOpensearch.INSTANCEPARAMETERSJAVA_GARBAGE_COLLECTOR_USE_G1_GC)),
+					JavaGarbageCollector: new(opensearch.INSTANCEPARAMETERSJAVAGARBAGECOLLECTOR_USE_G1_GC),
 					JavaHeapspace:        new(int32(10)),
 					JavaMaxmetaspace:     new(int32(10)),
 					MaxDiskThreshold:     new(int32(10)),
 					MetricsFrequency:     new(int32(10)),
 					MetricsPrefix:        new("prefix"),
 					MonitoringInstanceId: new("mid"),
-					Plugins:              []string{},
+					Plugins:              []opensearch.InstanceParametersPluginsInner{},
 					Syslog:               []string{"syslog", "syslog2"},
 					TlsCiphers:           []string{"cipher", "cipher2"},
-					TlsProtocols:         []string{"TLSv1.2", "TLSv1.3"},
+					TlsProtocols: []opensearch.InstanceParametersTlsProtocolsInner{
+						opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_2,
+						opensearch.INSTANCEPARAMETERSTLSPROTOCOLSINNER_TLSV1_3,
+					},
 				},
 				PlanId: new("plan"),
 			},

--- a/stackit/internal/services/opensearch/opensearch_acc_test.go
+++ b/stackit/internal/services/opensearch/opensearch_acc_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/stackitcloud/stackit-sdk-go/core/utils"
-	legacyOpensearch "github.com/stackitcloud/stackit-sdk-go/services/opensearch"
 	opensearch "github.com/stackitcloud/stackit-sdk-go/services/opensearch/v1api"
 	"github.com/stackitcloud/stackit-sdk-go/services/opensearch/v1api/wait"
 
@@ -549,12 +548,12 @@ func testAccCheckOpenSearchDestroy(s *terraform.State) error {
 }
 
 func checkInstanceDeleteSuccess(i *opensearch.Instance) bool {
-	if i.LastOperation.Type != string(legacyOpensearch.INSTANCELASTOPERATIONTYPE_DELETE) {
+	if i.LastOperation.Type != opensearch.INSTANCELASTOPERATIONTYPE_DELETE {
 		return false
 	}
 
-	if i.LastOperation.Type == string(legacyOpensearch.INSTANCELASTOPERATIONTYPE_DELETE) {
-		if i.LastOperation.State != string(legacyOpensearch.INSTANCELASTOPERATIONSTATE_SUCCEEDED) {
+	if i.LastOperation.Type == opensearch.INSTANCELASTOPERATIONTYPE_DELETE {
+		if i.LastOperation.State != opensearch.INSTANCELASTOPERATIONSTATE_SUCCEEDED {
 			return false
 		} else if strings.Contains(i.LastOperation.Description, "DeleteFailed") || strings.Contains(i.LastOperation.Description, "failed") {
 			return false

--- a/stackit/internal/services/resourcemanager/utils/util.go
+++ b/stackit/internal/services/resourcemanager/utils/util.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	resourcemanagerLegacy "github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
 	resourcemanager "github.com/stackitcloud/stackit-sdk-go/services/resourcemanager/v0api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -22,24 +21,6 @@ func ConfigureClient(ctx context.Context, providerData *core.ProviderData, diags
 		apiClientConfigOptions = append(apiClientConfigOptions, config.WithEndpoint(providerData.ResourceManagerCustomEndpoint))
 	}
 	apiClient, err := resourcemanager.NewAPIClient(apiClientConfigOptions...)
-	if err != nil {
-		core.LogAndAddError(ctx, diags, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the resource configuration", err))
-		return nil
-	}
-
-	return apiClient
-}
-
-// Deprecated: Will be removed as soon as the IaaS SDK module with multi-API-version support is integrated
-func ConfigureClientLegacy(ctx context.Context, providerData *core.ProviderData, diags *diag.Diagnostics) *resourcemanagerLegacy.APIClient {
-	apiClientConfigOptions := []config.ConfigurationOption{
-		config.WithCustomAuth(providerData.RoundTripper),
-		utils.UserAgentConfigOption(providerData.Version),
-	}
-	if providerData.ResourceManagerCustomEndpoint != "" {
-		apiClientConfigOptions = append(apiClientConfigOptions, config.WithEndpoint(providerData.ResourceManagerCustomEndpoint))
-	}
-	apiClient, err := resourcemanagerLegacy.NewAPIClient(apiClientConfigOptions...)
 	if err != nil {
 		core.LogAndAddError(ctx, diags, "Error configuring API client", fmt.Sprintf("Configuring client: %v. This is an error related to the provider configuration, not to the resource configuration", err))
 		return nil

--- a/stackit/internal/services/resourcemanager/utils/util_test.go
+++ b/stackit/internal/services/resourcemanager/utils/util_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	sdkClients "github.com/stackitcloud/stackit-sdk-go/core/clients"
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	resourcemanagerLegacy "github.com/stackitcloud/stackit-sdk-go/services/resourcemanager"
 	resourcemanager "github.com/stackitcloud/stackit-sdk-go/services/resourcemanager/v0api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
@@ -83,80 +82,6 @@ func TestConfigureClient(t *testing.T) {
 			diags := diag.Diagnostics{}
 
 			actual := ConfigureClient(ctx, tt.args.providerData, &diags)
-			if diags.HasError() != tt.wantErr {
-				t.Errorf("ConfigureClient() error = %v, want %v", diags.HasError(), tt.wantErr)
-			}
-
-			if !reflect.DeepEqual(actual, tt.expected) {
-				t.Errorf("ConfigureClient() = %v, want %v", actual, tt.expected)
-			}
-		})
-	}
-}
-
-// Deprecated: Will be removed as soon as the IaaS SDK module with multi-API-version support is integrated
-func TestConfigureClientLegacy(t *testing.T) {
-	/* mock authentication by setting service account token env variable */
-	os.Clearenv()
-	err := os.Setenv(sdkClients.ServiceAccountToken, "mock-val")
-	if err != nil {
-		t.Errorf("error setting env variable: %v", err)
-	}
-
-	type args struct {
-		providerData *core.ProviderData
-	}
-	tests := []struct {
-		name     string
-		args     args
-		wantErr  bool
-		expected *resourcemanagerLegacy.APIClient
-	}{
-		{
-			name: "default endpoint",
-			args: args{
-				providerData: &core.ProviderData{
-					Version: testVersion,
-				},
-			},
-			expected: func() *resourcemanagerLegacy.APIClient {
-				apiClient, err := resourcemanagerLegacy.NewAPIClient(
-					utils.UserAgentConfigOption(testVersion),
-				)
-				if err != nil {
-					t.Errorf("error configuring client: %v", err)
-				}
-				return apiClient
-			}(),
-			wantErr: false,
-		},
-		{
-			name: "custom endpoint",
-			args: args{
-				providerData: &core.ProviderData{
-					Version:                       testVersion,
-					ResourceManagerCustomEndpoint: testCustomEndpoint,
-				},
-			},
-			expected: func() *resourcemanagerLegacy.APIClient {
-				apiClient, err := resourcemanagerLegacy.NewAPIClient(
-					utils.UserAgentConfigOption(testVersion),
-					config.WithEndpoint(testCustomEndpoint),
-				)
-				if err != nil {
-					t.Errorf("error configuring client: %v", err)
-				}
-				return apiClient
-			}(),
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
-			diags := diag.Diagnostics{}
-
-			actual := ConfigureClientLegacy(ctx, tt.args.providerData, &diags)
 			if diags.HasError() != tt.wantErr {
 				t.Errorf("ConfigureClient() error = %v, want %v", diags.HasError(), tt.wantErr)
 			}

--- a/stackit/internal/services/sfs/sfs_test.go
+++ b/stackit/internal/services/sfs/sfs_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/stackitcloud/stackit-sdk-go/services/sfs"
+	sfs "github.com/stackitcloud/stackit-sdk-go/services/sfs/v1api"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/testutil"
 )
@@ -47,7 +47,7 @@ resource "stackit_sfs_resource_pool" "resourcepool" {
 						testutil.MockResponse{
 							Description: "create instance",
 							ToJsonBody: sfs.CreateResourcePoolResponse{
-								ResourcePool: &sfs.CreateResourcePoolResponseResourcePool{
+								ResourcePool: &sfs.ResourcePool{
 									Id: new(instanceId),
 								},
 							},
@@ -122,7 +122,7 @@ resource "stackit_sfs_share" "example" {
 						testutil.MockResponse{
 							Description: "create instance",
 							ToJsonBody: sfs.CreateShareResponse{
-								Share: &sfs.CreateShareResponseShare{
+								Share: &sfs.Share{
 									Id: new(instanceId),
 								},
 							},


### PR DESCRIPTION
## Description

can be re-enabled now since the migration to the new SDK layer is done

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
