### PR TITLE
fix(observability): validate alertgroup/rules/annotations values whit…

### DIFF
--- a/stackit/internal/services/observability/alertgroup/resource.go
+++ b/stackit/internal/services/observability/alertgroup/resource.go
@@ -261,6 +261,7 @@ func (a *alertGroupResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								mapvalidator.KeysAre(stringvalidator.LengthAtMost(200)),
 								mapvalidator.ValueStringsAre(stringvalidator.LengthAtMost(200)),
 								mapvalidator.SizeAtMost(5),
+								mapvalidator.ValueStringsAre(validate.NoLeadingOrTrailingWhitespace()),
 							},
 						},
 						"record": schema.StringAttribute{

--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 	_ "time/tzdata"
+	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
@@ -390,6 +391,32 @@ func IsLowercased() *Validator {
 					val,
 				))
 				return
+			}
+		},
+	}
+}
+
+// NoLeadingOrTrailingWhitespace returns a Validator that checks if the input string has leading or trailing whitespace.
+// Examples:
+// - "example": valid
+// - "": valid, empty value
+// - " example": invalid, leading whitespace
+// - "example ": invalid, trailing whitespace
+func NoLeadingOrTrailingWhitespace() *Validator {
+	description := "Value must not have leading or trailing whitespace, as defined by gos unicode.IsSpace(rune)."
+	return &Validator{
+		description: description,
+		validate: func(_ context.Context, request validator.StringRequest, response *validator.StringResponse) {
+			val := request.ConfigValue.ValueString()
+			if val == "" {
+				return
+			}
+			if unicode.IsSpace(rune(val[0])) || unicode.IsSpace(rune(val[len(val)-1])) {
+				response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+					request.Path,
+					description,
+					val,
+				))
 			}
 		},
 	}

--- a/stackit/internal/validate/validate_test.go
+++ b/stackit/internal/validate/validate_test.go
@@ -1008,3 +1008,60 @@ func TestIsLowercased(t *testing.T) {
 		})
 	}
 }
+
+func TestNoLeadingOrtTrailingWhitespace(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:  "empty",
+			input: "",
+		},
+		{
+			name:  "valid",
+			input: "valid",
+		},
+		{
+			name:  "single char, valid",
+			input: "a",
+		},
+		{
+			name:    "leading whitespace",
+			input:   " leading",
+			wantErr: true,
+		},
+		{
+			name:    "trailing whitespace",
+			input:   "trailing ",
+			wantErr: true,
+		},
+		{
+			name:    "leading and trailing whitespace",
+			input:   " leading and trailing ",
+			wantErr: true,
+		},
+		{
+			name:    "single space",
+			input:   " ",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := validator.StringResponse{}
+			NoLeadingOrTrailingWhitespace().ValidateString(context.Background(), validator.StringRequest{
+				ConfigValue: types.StringValue(tt.input),
+			}, &r)
+			if tt.wantErr && !r.Diagnostics.HasError() {
+				t.Fatalf("Expected validation to fail for input: %q", tt.input)
+			}
+			if !tt.wantErr && r.Diagnostics.HasError() {
+				t.Fatalf("Expected validation to succeed for input: %q, but got errors: %v", tt.input, r.Diagnostics.Errors())
+			}
+		})
+	}
+}


### PR DESCRIPTION
…espace

- API returns trimmed values -> inconsistent result after apply

STACKITTPR-674

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
