### PR TITLE
docs(alb): fix wrong defined alb example

### DIFF
--- a/docs/resources/application_load_balancer.md
+++ b/docs/resources/application_load_balancer.md
@@ -26,7 +26,7 @@ variable "project_id" {
 variable "image_id" {
   description = "A valid Debian 12 Image ID available in all projects"
   type        = string
-  default     = "939249d1-6f48-4ab7-929b-95170728311a"
+  default     = "d333affd-9f00-446d-978f-524cb0384360"
 }
 
 variable "availability_zone" {
@@ -205,7 +205,9 @@ resource "stackit_application_load_balancer" "example" {
     }
   ]
   options = {
-    acl                  = ["123.123.123.123/24", "12.12.12.12/24"]
+    access_control = {
+      allowed_source_ranges = ["123.123.123.123/24", "12.12.12.12/24"]
+    }
     ephemeral_address    = true
     private_network_only = false
     observability = {

--- a/examples/resources/stackit_application_load_balancer/resource.tf
+++ b/examples/resources/stackit_application_load_balancer/resource.tf
@@ -7,7 +7,7 @@ variable "project_id" {
 variable "image_id" {
   description = "A valid Debian 12 Image ID available in all projects"
   type        = string
-  default     = "939249d1-6f48-4ab7-929b-95170728311a"
+  default     = "d333affd-9f00-446d-978f-524cb0384360"
 }
 
 variable "availability_zone" {
@@ -186,7 +186,9 @@ resource "stackit_application_load_balancer" "example" {
     }
   ]
   options = {
-    acl                  = ["123.123.123.123/24", "12.12.12.12/24"]
+    access_control = {
+      allowed_source_ranges = ["123.123.123.123/24", "12.12.12.12/24"]
+    }
     ephemeral_address    = true
     private_network_only = false
     observability = {


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITTPR-681

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
