### PR TITLE
fix(validate): extend allowed full version regex to allow patch/pre-release version

### DIFF
--- a/stackit/internal/validate/validate.go
+++ b/stackit/internal/validate/validate.go
@@ -23,7 +23,10 @@ import (
 
 const (
 	MajorMinorVersionRegex = `^\d+\.\d+?$`
-	FullVersionRegex       = `^\d+\.\d+.\d+?$`
+	FullVersionRegex       = `^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)` +
+		`(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)` +
+		`(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?` +
+		`(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`
 )
 
 type Validator struct {

--- a/stackit/internal/validate/validate_test.go
+++ b/stackit/internal/validate/validate_test.go
@@ -552,6 +552,26 @@ func TestVersionNumber(t *testing.T) {
 			true,
 		},
 		{
+			"ok-patch-version-prerelease",
+			"1.20.1-alpha",
+			true,
+		},
+		{
+			"ok-patch-version-prerelease-with-dot-separator",
+			"1.20.1-alpha.1",
+			true,
+		},
+		{
+			"ok-patch-version-prerelease-without-dot-separator",
+			"1.20.1-alpha1.2",
+			true,
+		},
+		{
+			"version-ends-with-dot",
+			"1.20.1-alpha.1.",
+			false,
+		},
+		{
 			"Empty",
 			"",
 			false,


### PR DESCRIPTION

## Description

SKE sometimes has a need to release patch versions that don't follow strict semver but also allow prerlease so x.y.z-pre.release
source: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
This changes extends the full version regex and adds tests for it

this fixes #1544 

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
