### PR TITLE
fix(sna, docs): add hint that existing network things are SNA not VPC

### DIFF
--- a/docs/data-sources/network_area.md
+++ b/docs/data-sources/network_area.md
@@ -4,11 +4,14 @@ page_title: "stackit_network_area Data Source - stackit"
 subcategory: ""
 description: |-
   Network area datasource schema. Must have a region specified in the provider configuration.
+  This datasource is for SNA, not VPC, networks.
 ---
 
 # stackit_network_area (Data Source)
 
 Network area datasource schema. Must have a `region` specified in the provider configuration.
+
+This datasource is for SNA, not VPC, networks.
 
 ## Example Usage
 

--- a/docs/data-sources/network_area_region.md
+++ b/docs/data-sources/network_area_region.md
@@ -4,11 +4,14 @@ page_title: "stackit_network_area_region Data Source - stackit"
 subcategory: ""
 description: |-
   Network area region data source schema.
+  This datasource is for SNA, not VPC, based networks.
 ---
 
 # stackit_network_area_region (Data Source)
 
 Network area region data source schema.
+
+This datasource is for SNA, not VPC, based networks.
 
 ## Example Usage
 

--- a/docs/data-sources/network_area_route.md
+++ b/docs/data-sources/network_area_route.md
@@ -4,11 +4,14 @@ page_title: "stackit_network_area_route Data Source - stackit"
 subcategory: ""
 description: |-
   Network area route data resource schema. Must have a region specified in the provider configuration.
+  This datasource is for SNA, not VPC, networks.
 ---
 
 # stackit_network_area_route (Data Source)
 
 Network area route data resource schema. Must have a `region` specified in the provider configuration.
+
+This datasource is for SNA, not VPC, networks.
 
 ## Example Usage
 

--- a/docs/data-sources/routing_table.md
+++ b/docs/data-sources/routing_table.md
@@ -4,12 +4,15 @@ page_title: "stackit_routing_table Data Source - stackit"
 subcategory: ""
 description: |-
   Routing table datasource schema. Must have a region specified in the provider configuration.
+  This datasource is for SNA, not VPC, based networks.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table (Data Source)
 
 Routing table datasource schema. Must have a `region` specified in the provider configuration.
+
+This datasource is for SNA, not VPC, based networks.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/data-sources/routing_table_route.md
+++ b/docs/data-sources/routing_table_route.md
@@ -4,12 +4,15 @@ page_title: "stackit_routing_table_route Data Source - stackit"
 subcategory: ""
 description: |-
   Routing table route datasource schema. Must have a region specified in the provider configuration.
+  This datasource is for SNA, not VPC, networks.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table_route (Data Source)
 
 Routing table route datasource schema. Must have a `region` specified in the provider configuration.
+
+This datasource is for SNA, not VPC, networks.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/data-sources/routing_table_routes.md
+++ b/docs/data-sources/routing_table_routes.md
@@ -4,12 +4,15 @@ page_title: "stackit_routing_table_routes Data Source - stackit"
 subcategory: ""
 description: |-
   Routing table routes datasource schema. Must have a region specified in the provider configuration.
+  This datasource is for SNA, not VPC, based networks.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table_routes (Data Source)
 
 Routing table routes datasource schema. Must have a `region` specified in the provider configuration.
+
+This datasource is for SNA, not VPC, based networks.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/data-sources/routing_tables.md
+++ b/docs/data-sources/routing_tables.md
@@ -4,12 +4,15 @@ page_title: "stackit_routing_tables Data Source - stackit"
 subcategory: ""
 description: |-
   Routing table datasource schema. Must have a region specified in the provider configuration.
+  This datasource is for SNA, not VPC, based networks.
   ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_tables (Data Source)
 
 Routing table datasource schema. Must have a `region` specified in the provider configuration.
+
+This datasource is for SNA, not VPC, based networks.
 
 ~> This datasource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/resources/network_area.md
+++ b/docs/resources/network_area.md
@@ -4,11 +4,15 @@ page_title: "stackit_network_area Resource - stackit"
 subcategory: ""
 description: |-
   Network area resource schema.
+
+This resource is for SNA, not VPC, networks.
 ---
 
 # stackit_network_area (Resource)
 
 Network area resource schema.
+
+This resource is for SNA, not VPC, networks.
 
 ## Example Usage
 

--- a/docs/resources/network_area_region.md
+++ b/docs/resources/network_area_region.md
@@ -4,11 +4,14 @@ page_title: "stackit_network_area_region Resource - stackit"
 subcategory: ""
 description: |-
   Network area region resource schema.
+  This resource is for SNA, not VPC, based networks.
 ---
 
 # stackit_network_area_region (Resource)
 
 Network area region resource schema.
+
+This resource is for SNA, not VPC, based networks.
 
 ## Example Usage
 

--- a/docs/resources/network_area_route.md
+++ b/docs/resources/network_area_route.md
@@ -4,11 +4,15 @@ page_title: "stackit_network_area_route Resource - stackit"
 subcategory: ""
 description: |-
   Network area route resource schema. Must have a `region` specified in the provider configuration.
+
+This resource is for SNA, not VPC, based networks.
 ---
 
 # stackit_network_area_route (Resource)
 
 Network area route resource schema. Must have a `region` specified in the provider configuration.
+
+This resource is for SNA, not VPC, based networks.
 
 ## Example Usage
 

--- a/docs/resources/routing_table.md
+++ b/docs/resources/routing_table.md
@@ -4,12 +4,15 @@ page_title: "stackit_routing_table Resource - stackit"
 subcategory: ""
 description: |-
   Routing table resource schema. Must have a region specified in the provider configuration.
+  This resource is for SNA, not VPC, based networks.
   ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table (Resource)
 
 Routing table resource schema. Must have a `region` specified in the provider configuration.
+
+This resource is for SNA, not VPC, based networks.
 
 ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/docs/resources/routing_table_route.md
+++ b/docs/resources/routing_table_route.md
@@ -4,12 +4,15 @@ page_title: "stackit_routing_table_route Resource - stackit"
 subcategory: ""
 description: |-
   Routing table route resource schema. Must have a region specified in the provider configuration.
+  This resource is for SNA, not VPC, based networks.
   ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 ---
 
 # stackit_routing_table_route (Resource)
 
 Routing table route resource schema. Must have a `region` specified in the provider configuration.
+
+This resource is for SNA, not VPC, based networks.
 
 ~> This resource is part of the routing-tables experiment and is likely going to undergo significant changes or be removed in the future. Use it at your own discretion.
 

--- a/stackit/internal/services/iaas/networkarea/datasource.go
+++ b/stackit/internal/services/iaas/networkarea/datasource.go
@@ -64,7 +64,8 @@ func (d *networkAreaDataSource) Configure(ctx context.Context, req datasource.Co
 // Schema defines the schema for the data source.
 func (d *networkAreaDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	deprecationMsg := "Deprecated because of the IaaS API v1 -> v2 migration. Will be removed in May 2026."
-	description := "Network area datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Network area datasource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This datasource is for SNA, not VPC, networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkarea/resource.go
+++ b/stackit/internal/services/iaas/networkarea/resource.go
@@ -193,7 +193,8 @@ func (r *networkAreaResource) ValidateConfig(ctx context.Context, req resource.V
 // Schema defines the schema for the resource.
 func (r *networkAreaResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	deprecationMsg := "Deprecated because of the IaaS API v1 -> v2 migration. Will be removed in May 2026. Use the new `stackit_network_area_region` resource instead."
-	description := "Network area resource schema."
+	description := "Network area resource schema.\n\n" +
+		"This resource is for SNA, not VPC, networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkarearegion/datasource.go
+++ b/stackit/internal/services/iaas/networkarearegion/datasource.go
@@ -60,7 +60,8 @@ func (d *networkAreaRegionDataSource) Configure(ctx context.Context, req datasou
 
 // Schema defines the schema for the resource.
 func (d *networkAreaRegionDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Network area region data source schema."
+	description := "Network area region data source schema.\n\n" +
+		"This datasource is for SNA, not VPC, based networks."
 
 	resp.Schema = schema.Schema{
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkarearegion/resource.go
+++ b/stackit/internal/services/iaas/networkarearegion/resource.go
@@ -137,7 +137,8 @@ func (r *networkAreaRegionResource) Configure(ctx context.Context, req resource.
 
 // Schema defines the schema for the resource.
 func (r *networkAreaRegionResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Network area region resource schema."
+	description := "Network area region resource schema.\n\n" +
+		"This resource is for SNA, not VPC, based networks."
 
 	resp.Schema = schema.Schema{
 		Description: description,

--- a/stackit/internal/services/iaas/networkarearoute/datasource.go
+++ b/stackit/internal/services/iaas/networkarearoute/datasource.go
@@ -58,7 +58,8 @@ func (d *networkAreaRouteDataSource) Configure(ctx context.Context, req datasour
 
 // Schema defines the schema for the data source.
 func (d *networkAreaRouteDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Network area route data resource schema. Must have a `region` specified in the provider configuration."
+	description := "Network area route data resource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This datasource is for SNA, not VPC, networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/networkarearoute/resource.go
+++ b/stackit/internal/services/iaas/networkarearoute/resource.go
@@ -134,7 +134,8 @@ func (r *networkAreaRouteResource) Configure(ctx context.Context, req resource.C
 
 // Schema defines the schema for the resource.
 func (r *networkAreaRouteResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Network area route resource schema. Must have a `region` specified in the provider configuration."
+	description := "Network area route resource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This resource is for SNA, not VPC, based networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: description,

--- a/stackit/internal/services/iaas/routingtable/route/datasource.go
+++ b/stackit/internal/services/iaas/routingtable/route/datasource.go
@@ -61,7 +61,8 @@ func (d *routingTableRouteDataSource) Configure(ctx context.Context, req datasou
 
 // Schema defines the schema for the data source.
 func (d *routingTableRouteDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table route datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table route datasource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This datasource is for SNA, not VPC, networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),

--- a/stackit/internal/services/iaas/routingtable/route/resource.go
+++ b/stackit/internal/services/iaas/routingtable/route/resource.go
@@ -107,7 +107,8 @@ func (r *routeResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanR
 
 // Schema defines the schema for the resource.
 func (r *routeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Routing table route resource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table route resource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This resource is for SNA, not VPC, based networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Resource),

--- a/stackit/internal/services/iaas/routingtable/routes/datasource.go
+++ b/stackit/internal/services/iaas/routingtable/routes/datasource.go
@@ -73,7 +73,8 @@ func (d *routingTableRoutesDataSource) Configure(ctx context.Context, req dataso
 
 // Schema defines the schema for the data source.
 func (d *routingTableRoutesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table routes datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table routes datasource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This datasource is for SNA, not VPC, based networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),

--- a/stackit/internal/services/iaas/routingtable/table/datasource.go
+++ b/stackit/internal/services/iaas/routingtable/table/datasource.go
@@ -66,7 +66,8 @@ func (d *routingTableDataSource) Configure(ctx context.Context, req datasource.C
 
 // Schema defines the schema for the data source.
 func (d *routingTableDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table datasource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This datasource is for SNA, not VPC, based networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),

--- a/stackit/internal/services/iaas/routingtable/table/resource.go
+++ b/stackit/internal/services/iaas/routingtable/table/resource.go
@@ -122,7 +122,8 @@ func (r *routingTableResource) ModifyPlan(ctx context.Context, req resource.Modi
 }
 
 func (r *routingTableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	description := "Routing table resource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table resource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This resource is for SNA, not VPC, based networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Resource),

--- a/stackit/internal/services/iaas/routingtable/tables/datasource.go
+++ b/stackit/internal/services/iaas/routingtable/tables/datasource.go
@@ -75,7 +75,8 @@ func (d *routingTablesDataSource) Configure(ctx context.Context, req datasource.
 
 // Schema defines the schema for the data source.
 func (d *routingTablesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	description := "Routing table datasource schema. Must have a `region` specified in the provider configuration."
+	description := "Routing table datasource schema. Must have a `region` specified in the provider configuration.\n\n" +
+		"This datasource is for SNA, not VPC, based networks."
 	resp.Schema = schema.Schema{
 		Description:         description,
 		MarkdownDescription: features.AddExperimentDescription(description, features.RoutingTablesExperiment, core.Datasource),


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
