### PR TITLE
chore(ske): Remove maintenance window from example

### DIFF
--- a/docs/resources/ske_cluster.md
+++ b/docs/resources/ske_cluster.md
@@ -33,12 +33,6 @@ resource "stackit_ske_cluster" "example" {
       volume_size        = "48"
     }
   ]
-  maintenance = {
-    enable_kubernetes_version_updates    = true
-    enable_machine_image_version_updates = true
-    start                                = "01:00:00Z"
-    end                                  = "02:00:00Z"
-  }
   network = {
     control_plane = {
       access_scope = "PUBLIC"

--- a/examples/resources/stackit_ske_cluster/resource.tf
+++ b/examples/resources/stackit_ske_cluster/resource.tf
@@ -15,12 +15,6 @@ resource "stackit_ske_cluster" "example" {
       volume_size        = "48"
     }
   ]
-  maintenance = {
-    enable_kubernetes_version_updates    = true
-    enable_machine_image_version_updates = true
-    start                                = "01:00:00Z"
-    end                                  = "02:00:00Z"
-  }
   network = {
     control_plane = {
       access_scope = "PUBLIC"


### PR DESCRIPTION
This window is optional and it seems to be that a lot of people are just using this without thinking about it

## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->


## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
