### PR TITLE
fix(dremio): fix context for instance

### DIFF
--- a/stackit/internal/services/dremio/instance/datasource.go
+++ b/stackit/internal/services/dremio/instance/datasource.go
@@ -99,7 +99,7 @@ func (d *instanceDataSource) Configure(ctx context.Context, req datasource.Confi
 	tflog.Info(ctx, "Dremio instance client configured for data source")
 }
 
-func mapDatasourceFields(instanceResp *dremioSdk.DremioResponse, model *InstanceDataSourceModel, region string) error {
+func mapDatasourceFields(ctx context.Context, instanceResp *dremioSdk.DremioResponse, model *InstanceDataSourceModel, region string) error {
 	if instanceResp == nil {
 		return fmt.Errorf("response input is nil")
 	}
@@ -107,7 +107,7 @@ func mapDatasourceFields(instanceResp *dremioSdk.DremioResponse, model *Instance
 		return fmt.Errorf("model input is nil")
 	}
 
-	err := mapModelFields(instanceResp, &model.Model, region)
+	err := mapModelFields(ctx, instanceResp, &model.Model, region)
 	if err != nil {
 		return fmt.Errorf("failed to map Model fields")
 	}
@@ -344,7 +344,7 @@ func (d *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	ctx = core.LogResponse(ctx)
 
-	err = mapDatasourceFields(instanceResp, &model, region)
+	err = mapDatasourceFields(ctx, instanceResp, &model, region)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading Dremio instance", fmt.Sprintf("Processing API payload: %v", err))
 		return

--- a/stackit/internal/services/dremio/instance/resource.go
+++ b/stackit/internal/services/dremio/instance/resource.go
@@ -447,7 +447,7 @@ func (r *instanceResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	err = mapFields(instanceResp, &model, region)
+	err = mapFields(ctx, instanceResp, &model, region)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error creating Dremio instance", fmt.Sprintf("Processing API payload: %v", err))
 		return
@@ -500,7 +500,7 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	ctx = core.LogResponse(ctx)
 
-	err = mapFields(instanceResp, &model, region)
+	err = mapFields(ctx, instanceResp, &model, region)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading dremio instance", fmt.Sprintf("Processing API payload: %v", err))
 		return
@@ -571,7 +571,7 @@ func (r *instanceResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	err = mapFields(instanceResp, &model, region)
+	err = mapFields(ctx, instanceResp, &model, region)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating Dremio instance", fmt.Sprintf("Processing API payload: %v", err))
 		return
@@ -649,7 +649,7 @@ func (r *instanceResource) ImportState(ctx context.Context, req resource.ImportS
 	tflog.Info(ctx, "Dremio instance state imported")
 }
 
-func mapFields(instanceResp *dremioSdk.DremioResponse, model *InstanceModel, region string) error {
+func mapFields(ctx context.Context, instanceResp *dremioSdk.DremioResponse, model *InstanceModel, region string) error {
 	if instanceResp == nil {
 		return fmt.Errorf("response input is nil")
 	}
@@ -657,7 +657,7 @@ func mapFields(instanceResp *dremioSdk.DremioResponse, model *InstanceModel, reg
 		return fmt.Errorf("model input is nil")
 	}
 
-	err := mapModelFields(instanceResp, &model.Model, region)
+	err := mapModelFields(ctx, instanceResp, &model.Model, region)
 	if err != nil {
 		return fmt.Errorf("failed to map Model fields")
 	}
@@ -674,7 +674,7 @@ func mapFields(instanceResp *dremioSdk.DremioResponse, model *InstanceModel, reg
 }
 
 // Maps instance fields to the provider's internal model
-func mapModelFields(instanceResp *dremioSdk.DremioResponse, model *Model, region string) error {
+func mapModelFields(ctx context.Context, instanceResp *dremioSdk.DremioResponse, model *Model, region string) error {
 	if instanceResp == nil {
 		return fmt.Errorf("response input is nil")
 	}
@@ -698,7 +698,7 @@ func mapModelFields(instanceResp *dremioSdk.DremioResponse, model *Model, region
 		Catalog:     types.StringValue(instanceResp.Endpoints.Catalog),
 		Ui:          types.StringValue(instanceResp.Endpoints.Ui),
 	}
-	endpointsObj, diags := types.ObjectValueFrom(context.Background(), endpointsAttrTypes, endpoints)
+	endpointsObj, diags := types.ObjectValueFrom(ctx, endpointsAttrTypes, endpoints)
 	if diags.HasError() {
 		return fmt.Errorf("failed to parse endpoints")
 	}

--- a/stackit/internal/services/dremio/instance/resource_test.go
+++ b/stackit/internal/services/dremio/instance/resource_test.go
@@ -1,6 +1,7 @@
 package dremio
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -144,7 +145,7 @@ func TestMapFields(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			err := mapFields(tt.input, tt.state, "rid")
+			err := mapFields(context.Background(), tt.input, tt.state, "rid")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("mapFields error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/stackit/internal/services/iaas/volumeattach/resource.go
+++ b/stackit/internal/services/iaas/volumeattach/resource.go
@@ -214,7 +214,7 @@ func (r *volumeAttachResource) Create(ctx context.Context, req resource.CreateRe
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error attaching volume to server", fmt.Sprintf("Reading x-request-ID: %v", err))
 		return
 	}
-	_, err = wait.ProjectRequestWaitHandler(ctx, r.client.DefaultAPI, projectId, region, requestId).WaitWithContext(context.Background())
+	_, err = wait.ProjectRequestWaitHandler(ctx, r.client.DefaultAPI, projectId, region, requestId).WaitWithContext(ctx)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error attaching volume to server", fmt.Sprintf("volume attachment waiting: %v", err))
 		return
@@ -322,7 +322,7 @@ func (r *volumeAttachResource) Delete(ctx context.Context, req resource.DeleteRe
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error attaching volume to server", fmt.Sprintf("Reading x-request-ID: %v", err))
 		return
 	}
-	_, err = wait.ProjectRequestWaitHandler(ctx, r.client.DefaultAPI, projectId, region, requestId).WaitWithContext(context.Background())
+	_, err = wait.ProjectRequestWaitHandler(ctx, r.client.DefaultAPI, projectId, region, requestId).WaitWithContext(ctx)
 	if err != nil {
 		core.LogAndAddError(ctx, &resp.Diagnostics, "Error removing volume from server", fmt.Sprintf("volume removal waiting: %v", err))
 		return


### PR DESCRIPTION
## Description

No issue; remove context.Background() from production code

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
