### PR TITLE
fix: deletion of resources in acc tests

### DIFF
--- a/stackit/internal/services/cdn/cdn_acc_test.go
+++ b/stackit/internal/services/cdn/cdn_acc_test.go
@@ -688,6 +688,7 @@ func testAccCheckCDNDistributionDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_cdn_distribution" {
 			continue
 		}
+		// terraform ID: "[project_id],[distribution_id]"
 		distributionId := strings.Split(rs.Primary.ID, core.Separator)[1]
 		distributionsToDestroy = append(distributionsToDestroy, distributionId)
 	}

--- a/stackit/internal/services/git/git_acc_test.go
+++ b/stackit/internal/services/git/git_acc_test.go
@@ -307,6 +307,7 @@ func testAccCheckGitInstanceDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_git" {
 			continue
 		}
+		// terraform ID: "[project_id],[instance_id]"
 		instanceId := strings.Split(rs.Primary.ID, core.Separator)[1]
 		instancesToDestroy = append(instancesToDestroy, instanceId)
 	}

--- a/stackit/internal/services/iaas/iaas_acc_test.go
+++ b/stackit/internal/services/iaas/iaas_acc_test.go
@@ -5846,6 +5846,7 @@ func testAccCheckNetworkAreaRegionDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_network_area_region" {
 			continue
 		}
+		// terraform ID: "[organization_id],[network_area_id]"
 		networkAreaId := strings.Split(rs.Primary.ID, core.Separator)[1]
 		networkAreasToDestroy = append(networkAreasToDestroy, networkAreaId)
 	}
@@ -5883,6 +5884,7 @@ func testAccCheckNetworkAreaDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_network_area" {
 			continue
 		}
+		// terraform ID: "[organization_id],[network_area_id]"
 		networkAreaId := strings.Split(rs.Primary.ID, core.Separator)[1]
 		networkAreasToDestroy = append(networkAreasToDestroy, networkAreaId)
 	}
@@ -5919,8 +5921,8 @@ func testAccCheckIaaSVolumeDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_volume" {
 			continue
 		}
-		// volume terraform ID: "[project_id],[volume_id]"
-		volumeId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// volume terraform ID: "[project_id],[region],[volume_id]"
+		volumeId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		volumesToDestroy = append(volumesToDestroy, volumeId)
 	}
 
@@ -5976,9 +5978,9 @@ func testAccCheckServerDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_network" {
 			continue
 		}
-		// network terraform ID: "[project_id],[network_id]"
+		// network terraform ID: "[project_id],[region],[network_id]"
 		projectId = strings.Split(rs.Primary.ID, core.Separator)[0]
-		networkId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		networkId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		networksToDestroy = append(networksToDestroy, networkId)
 	}
 

--- a/stackit/internal/services/loadbalancer/loadbalancer_acc_test.go
+++ b/stackit/internal/services/loadbalancer/loadbalancer_acc_test.go
@@ -587,8 +587,8 @@ func testAccCheckLoadBalancerDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_loadbalancer" {
 			continue
 		}
-		// loadbalancer terraform ID: = "[project_id],[name]"
-		loadbalancerName := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// loadbalancer terraform ID: = "[project_id],[region],[name]"
+		loadbalancerName := strings.Split(rs.Primary.ID, core.Separator)[2]
 		loadbalancersToDestroy = append(loadbalancersToDestroy, loadbalancerName)
 	}
 

--- a/stackit/internal/services/objectstorage/objectstorage_acc_test.go
+++ b/stackit/internal/services/objectstorage/objectstorage_acc_test.go
@@ -122,7 +122,7 @@ func TestAccObjectStorageResourceMin(t *testing.T) {
 								project_id  = stackit_objectstorage_credentials_group.credentials_group.project_id
 								credentials_group_id = stackit_objectstorage_credentials_group.credentials_group.credentials_group_id
 							}
-	
+
 							data "stackit_objectstorage_credential" "credential" {
 								project_id  = stackit_objectstorage_credential.credential.project_id
 								credentials_group_id = stackit_objectstorage_credential.credential.credentials_group_id
@@ -141,7 +141,7 @@ func TestAccObjectStorageResourceMin(t *testing.T) {
 								project_id  = stackit_objectstorage_bucket.bucket_object_lock.project_id
 								name = stackit_objectstorage_bucket.bucket_object_lock.name
 							}
-					
+
 							data "stackit_objectstorage_default_retention" "retention" {
   							bucket_name = stackit_objectstorage_bucket.bucket_object_lock.name
   							project_id  = var.project_id
@@ -330,8 +330,8 @@ func testAccCheckObjectStorageDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_objectstorage_bucket" {
 			continue
 		}
-		// bucket terraform ID: "[project_id],[name]"
-		bucketName := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// bucket terraform ID: "[project_id],[region],[name]"
+		bucketName := strings.Split(rs.Primary.ID, core.Separator)[2]
 		bucketsToDestroy = append(bucketsToDestroy, bucketName)
 	}
 
@@ -360,8 +360,8 @@ func testAccCheckObjectStorageDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_objectstorage_credentials_group" {
 			continue
 		}
-		// credentials group terraform ID: "[project_id],[credentials_group_id]"
-		credentialsGroupId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// credentials group terraform ID: "[project_id],[region],[credentials_group_id]"
+		credentialsGroupId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		credentialsGroupsToDestroy = append(credentialsGroupsToDestroy, credentialsGroupId)
 	}
 

--- a/stackit/internal/services/observability/observability_acc_test.go
+++ b/stackit/internal/services/observability/observability_acc_test.go
@@ -1075,7 +1075,7 @@ func testAccCheckObservabilityDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_observability_instance" {
 			continue
 		}
-		// instance terraform ID: = "[project_id],[instance_id],[name]"
+		// instance terraform ID: = "[project_id],[instance_id]"
 		instanceId := strings.Split(rs.Primary.ID, core.Separator)[1]
 		instancesToDestroy = append(instancesToDestroy, instanceId)
 	}

--- a/stackit/internal/services/rabbitmq/rabbitmq_acc_test.go
+++ b/stackit/internal/services/rabbitmq/rabbitmq_acc_test.go
@@ -264,8 +264,8 @@ func testAccCheckRabbitMQDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_rabbitmq_instance" {
 			continue
 		}
-		// instance terraform ID: "[project_id],[instance_id]"
-		instanceId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// instance terraform ID: "[project_id],[region],[instance_id]"
+		instanceId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		instancesToDestroy = append(instancesToDestroy, instanceId)
 	}
 

--- a/stackit/internal/services/redis/redis_acc_test.go
+++ b/stackit/internal/services/redis/redis_acc_test.go
@@ -292,8 +292,8 @@ func testAccCheckRedisDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_redis_instance" {
 			continue
 		}
-		// instance terraform ID: "[project_id],[instance_id]"
-		instanceId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// instance terraform ID: "[project_id],[region],[instance_id]"
+		instanceId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		instancesToDestroy = append(instancesToDestroy, instanceId)
 	}
 

--- a/stackit/internal/services/scf/scf_acc_test.go
+++ b/stackit/internal/services/scf/scf_acc_test.go
@@ -419,7 +419,8 @@ func testAccCheckScfOrganizationDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_scf_organization" {
 			continue
 		}
-		orgId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// terraform ID: "[project_id],[region],[org_id]"
+		orgId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		orgsToDestroy = append(orgsToDestroy, orgId)
 	}
 

--- a/stackit/internal/services/serviceaccount/serviceaccount_acc_test.go
+++ b/stackit/internal/services/serviceaccount/serviceaccount_acc_test.go
@@ -323,6 +323,7 @@ func testAccCheckServiceAccountDestroy(s *terraform.State) error {
 		if rs.Type != "stackit_service_account" {
 			continue
 		}
+		// terraform ID: "[project_id],[email]"
 		serviceAccountEmail := strings.Split(rs.Primary.ID, core.Separator)[1]
 		instancesToDestroy = append(instancesToDestroy, serviceAccountEmail)
 	}

--- a/stackit/internal/services/sfs/sfs_acc_test.go
+++ b/stackit/internal/services/sfs/sfs_acc_test.go
@@ -1042,7 +1042,7 @@ func testAccExportPolicyDestroy(s *terraform.State) error {
 			continue
 		}
 		// export policy transform id: "[projectId],[region],[policyId]"
-		policyId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		policyId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		policyToDestroy = append(policyToDestroy, policyId)
 	}
 
@@ -1077,8 +1077,8 @@ func testAccResourcePoolDestroyed(s *terraform.State) error {
 		if rs.Type != "stackit_sfs_resource_pool" {
 			continue
 		}
-		// export policy transform id: "[projectId],[resource_pool_id]"
-		resourcePoolId := strings.Split(rs.Primary.ID, core.Separator)[1]
+		// export policy transform id: "[project_id],[region],[resource_pool_id]"
+		resourcePoolId := strings.Split(rs.Primary.ID, core.Separator)[2]
 		resourcePoolsToDestroy = append(resourcePoolsToDestroy, resourcePoolId)
 	}
 


### PR DESCRIPTION
## Description

Some resource identifiers are not queried correctly within the clean-up function of the ACC tests.

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
