### PR TITLE
fix(mongodbflex): add regex to username validation

### DIFF
--- a/stackit/internal/services/mongodbflex/mongodbflex_test.go
+++ b/stackit/internal/services/mongodbflex/mongodbflex_test.go
@@ -167,3 +167,32 @@ resource "stackit_mongodbflex_user" "user" {
 		},
 	})
 }
+
+func TestMongoDBUserInvalidUsernameValidationError(t *testing.T) {
+	projectId := uuid.NewString()
+	instanceId := uuid.NewString()
+	tfConfig := fmt.Sprintf(`
+provider "stackit" {
+	mongodbflex_custom_endpoint = "http://localhost:12345"
+	service_account_token = "mock-server-needs-no-auth"
+}
+
+resource "stackit_mongodbflex_user" "user" {
+	project_id = "%s"
+	instance_id = "%s"
+	username = "-invalid-username"
+	roles = ["read"]
+	database = "db-name"
+}
+`, projectId, instanceId)
+
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutil.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      tfConfig,
+				ExpectError: regexp.MustCompile("Attribute username must start with a letter.*"),
+			},
+		},
+	})
+}

--- a/stackit/internal/services/mongodbflex/mongodbflex_test.go
+++ b/stackit/internal/services/mongodbflex/mongodbflex_test.go
@@ -172,11 +172,6 @@ func TestMongoDBUserInvalidUsernameValidationError(t *testing.T) {
 	projectId := uuid.NewString()
 	instanceId := uuid.NewString()
 	tfConfig := fmt.Sprintf(`
-provider "stackit" {
-	mongodbflex_custom_endpoint = "http://localhost:12345"
-	service_account_token = "mock-server-needs-no-auth"
-}
-
 resource "stackit_mongodbflex_user" "user" {
 	project_id = "%s"
 	instance_id = "%s"

--- a/stackit/internal/services/mongodbflex/user/resource.go
+++ b/stackit/internal/services/mongodbflex/user/resource.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
@@ -182,6 +184,12 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 					stringplanmodifier.UseStateForUnknown(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile("^[A-Za-z][A-Za-z0-9-]{1,61}[A-Za-z0-9]$"),
+						"must start with a letter, must have between 3 and 63 letters, numbers or hyphens, and no hyphen at the end",
+					),
 				},
 			},
 			"roles": schema.SetAttribute{


### PR DESCRIPTION
## Description

See https://github.com/stackitcloud/terraform-provider-stackit/issues/683 for details.

relates to STACKITTPR-679.

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
