### PR TITLE
fix(postgresflex,sqlserverflex): some flavors can not be found

### DIFF
--- a/docs/resources/sqlserverflex_instance.md
+++ b/docs/resources/sqlserverflex_instance.md
@@ -44,7 +44,7 @@ resource "stackit_sqlserverflex_instance" "example" {
 - `backup_schedule` (String) The backup schedule. Should follow the cron scheduling system format (e.g. "0 0 * * *") Will be required in the future. Set a value to prevent breaking changes.
 - `encryption` (Attributes) Parameter to define which key to use for storage encryption. (see [below for nested schema](#nestedatt--encryption))
 - `flavor` (Attributes, Deprecated) (see [below for nested schema](#nestedatt--flavor))
-- `flavor_id` (String) The flavor ID of the sqlserver Flex instance. Can only be set when `flavor` and `replicas` are not set. You can list available storage classes using the [STACKIT CLI](https://github.com/stackitcloud/stackit-cli):
+- `flavor_id` (String) The flavor ID of the SQLServer Flex instance. Can only be set when `flavor` and `replicas` are not set. You can list available storage classes using the [STACKIT CLI](https://github.com/stackitcloud/stackit-cli):
 ```bash
 stackit curl https://mssql-flex-service.api.stackit.cloud/v3/projects/{project_id}/regions/{region}/flavors\?size=100
 ```

--- a/stackit/internal/services/postgresflex/instance/datasource.go
+++ b/stackit/internal/services/postgresflex/instance/datasource.go
@@ -264,18 +264,18 @@ func (r *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 
 	ctx = core.LogResponse(ctx)
 
+	flavor := &flavorModel{}
 	flavorResp, err := getFlavor(ctx, r.client.DefaultAPI, projectId, region, instanceResp.FlavorId)
 	if err != nil {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", fmt.Sprintf("Finding flavor %q: %v", instanceResp.FlavorId, err))
-		return
-	}
-
-	flavor := &flavorModel{
-		Id:          types.StringValue(flavorResp.Id),
-		Description: types.StringValue(flavorResp.Description),
-		CPU:         types.Int64Value(flavorResp.Cpu),
-		RAM:         types.Int64Value(flavorResp.Memory),
-		NodeType:    types.StringValue(flavorResp.NodeType),
+		core.LogAndAddWarning(ctx, &resp.Diagnostics, "Flavor not populated", fmt.Sprintf("Finding flavor %q: %v", instanceResp.FlavorId, err))
+	} else if flavorResp != nil {
+		flavor = &flavorModel{
+			Id:          types.StringValue(flavorResp.Id),
+			Description: types.StringValue(flavorResp.Description),
+			CPU:         types.Int64Value(flavorResp.Cpu),
+			RAM:         types.Int64Value(flavorResp.Memory),
+			NodeType:    types.StringValue(flavorResp.NodeType),
+		}
 	}
 
 	err = mapFields(ctx, instanceResp, &model, flavor, region)

--- a/stackit/internal/services/postgresflex/instance/resource.go
+++ b/stackit/internal/services/postgresflex/instance/resource.go
@@ -65,18 +65,19 @@ type Model struct {
 	ACL            types.List   `tfsdk:"acl"`
 	BackupSchedule types.String `tfsdk:"backup_schedule"`
 	ConnectionInfo types.Object `tfsdk:"connection_info"`
-	Flavor         types.Object `tfsdk:"flavor"`
-	FlavorId       types.String `tfsdk:"flavor_id"`
-	Replicas       types.Int32  `tfsdk:"replicas"`
-	Storage        types.Object `tfsdk:"storage"`
-	Encryption     types.Object `tfsdk:"encryption"`
-	Network        types.Object `tfsdk:"network"`
-	RetentionDays  types.Int32  `tfsdk:"retention_days"`
-	Version        types.String `tfsdk:"version"`
-	Region         types.String `tfsdk:"region"`
+	// Deprecated: Flavor is deprecated and will be removed after February 2027.
+	Flavor        types.Object `tfsdk:"flavor"`
+	FlavorId      types.String `tfsdk:"flavor_id"`
+	Replicas      types.Int32  `tfsdk:"replicas"`
+	Storage       types.Object `tfsdk:"storage"`
+	Encryption    types.Object `tfsdk:"encryption"`
+	Network       types.Object `tfsdk:"network"`
+	RetentionDays types.Int32  `tfsdk:"retention_days"`
+	Version       types.String `tfsdk:"version"`
+	Region        types.String `tfsdk:"region"`
 }
 
-// Struct corresponding to Model.Flavor
+// Deprecated: Will be removed after February 2027. Struct corresponding to Model.Flavor
 type flavorModel struct {
 	Id          types.String `tfsdk:"id"`
 	Description types.String `tfsdk:"description"`
@@ -85,7 +86,7 @@ type flavorModel struct {
 	NodeType    types.String `tfsdk:"node_type"`
 }
 
-// Types corresponding to flavorModel
+// Deprecated: Will be removed after February 2027. Types corresponding to flavorModel
 var flavorTypes = map[string]attr.Type{
 	"id":          basetypes.StringType{},
 	"description": basetypes.StringType{},
@@ -704,7 +705,6 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 	} else {
 		flavorResp, err := getFlavor(ctx, r.client.DefaultAPI, projectId, region, instanceResp.FlavorId)
 		if err != nil {
-			// Log a warning or handle missing flavor specifically, while failing on hard network/API errors
 			core.LogAndAddWarning(ctx, &resp.Diagnostics, "Flavor not populated", fmt.Sprintf("Finding flavor %q: %v", instanceResp.FlavorId, err))
 		} else if flavorResp != nil {
 			flavor = &flavorModel{
@@ -715,7 +715,6 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 				NodeType:    types.StringValue(flavorResp.NodeType),
 			}
 		}
-
 	}
 
 	// Map response body to schema
@@ -1138,6 +1137,7 @@ type postgresFlexClient interface {
 	ListFlavorsExecute(r postgresflex.ApiListFlavorsRequest) (*postgresflex.ListFlavorsResponse, error)
 }
 
+// Deprecated: getAllFlavors is deprecated and will be removed after February 2027. This function is only required for the v2 to v3 api migration.
 func getAllFlavors(ctx context.Context, client postgresFlexClient, projectId, region string) ([]postgresflex.ListFlavors, error) {
 	var result []postgresflex.ListFlavors
 	req := client.ListFlavors(ctx, projectId, region).Size(100)
@@ -1175,6 +1175,7 @@ func getAllFlavors(ctx context.Context, client postgresFlexClient, projectId, re
 	return result, nil
 }
 
+// Deprecated: loadFlavorId is deprecated and will be removed after February 2027. This function is only required for the v2 to v3 api migration.
 func loadFlavorId(ctx context.Context, client postgresFlexClient, model *Model, flavor *flavorModel) error {
 	if model == nil {
 		return fmt.Errorf("nil model")
@@ -1233,6 +1234,7 @@ func loadFlavorId(ctx context.Context, client postgresFlexClient, model *Model, 
 	return nil
 }
 
+// Deprecated: getFlavor is deprecated and will be removed after February 2027. This function is only required for the v2 to v3 api migration.
 func getFlavor(ctx context.Context, client postgresFlexClient, projectId, region, flavorId string) (*postgresflex.ListFlavors, error) {
 	flavorsResp, err := getAllFlavors(ctx, client, projectId, region)
 	if err != nil {

--- a/stackit/internal/services/postgresflex/instance/resource.go
+++ b/stackit/internal/services/postgresflex/instance/resource.go
@@ -704,16 +704,18 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 	} else {
 		flavorResp, err := getFlavor(ctx, r.client.DefaultAPI, projectId, region, instanceResp.FlavorId)
 		if err != nil {
-			core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", fmt.Sprintf("Finding flavor: %v", err))
-			return
+			// Log a warning or handle missing flavor specifically, while failing on hard network/API errors
+			core.LogAndAddWarning(ctx, &resp.Diagnostics, "Flavor not populated", fmt.Sprintf("Finding flavor %q: %v", instanceResp.FlavorId, err))
+		} else if flavorResp != nil {
+			flavor = &flavorModel{
+				Id:          types.StringValue(flavorResp.Id),
+				Description: types.StringValue(flavorResp.Description),
+				CPU:         types.Int64Value(flavorResp.Cpu),
+				RAM:         types.Int64Value(flavorResp.Memory),
+				NodeType:    types.StringValue(flavorResp.NodeType),
+			}
 		}
-		flavor = &flavorModel{
-			Id:          types.StringValue(flavorResp.Id),
-			Description: types.StringValue(flavorResp.Description),
-			CPU:         types.Int64Value(flavorResp.Cpu),
-			RAM:         types.Int64Value(flavorResp.Memory),
-			NodeType:    types.StringValue(flavorResp.NodeType),
-		}
+
 	}
 
 	// Map response body to schema
@@ -1136,6 +1138,43 @@ type postgresFlexClient interface {
 	ListFlavorsExecute(r postgresflex.ApiListFlavorsRequest) (*postgresflex.ListFlavorsResponse, error)
 }
 
+func getAllFlavors(ctx context.Context, client postgresFlexClient, projectId, region string) ([]postgresflex.ListFlavors, error) {
+	var result []postgresflex.ListFlavors
+	req := client.ListFlavors(ctx, projectId, region).Size(100)
+	resp, err := client.ListFlavorsExecute(req)
+	if err != nil {
+		return nil, fmt.Errorf("error listing flavors: %w", err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("nil response received when listing flavors")
+	}
+	if resp.Flavors != nil {
+		result = append(result, resp.Flavors...)
+	}
+
+	currentPage := resp.Pagination.Page
+	totalPages := resp.Pagination.TotalPages
+	for currentPage < totalPages {
+		nextPage := currentPage + 1
+		resp, err = client.ListFlavorsExecute(req.Page(nextPage))
+		if err != nil {
+			return nil, fmt.Errorf("error listing flavors: %w", err)
+		}
+		if resp == nil {
+			return nil, fmt.Errorf("nil response received when listing flavors on page %d", nextPage)
+		}
+		if resp.Flavors != nil {
+			result = append(result, resp.Flavors...)
+		}
+		if resp.Pagination.Page <= currentPage {
+			break // Prevent infinite loop if page number does not advance
+		}
+		currentPage = resp.Pagination.Page
+		totalPages = resp.Pagination.TotalPages
+	}
+	return result, nil
+}
+
 func loadFlavorId(ctx context.Context, client postgresFlexClient, model *Model, flavor *flavorModel) error {
 	if model == nil {
 		return fmt.Errorf("nil model")
@@ -1154,14 +1193,13 @@ func loadFlavorId(ctx context.Context, client postgresFlexClient, model *Model, 
 
 	projectId := model.ProjectId.ValueString()
 	region := model.Region.ValueString()
-	req := client.ListFlavors(ctx, projectId, region)
-	res, err := client.ListFlavorsExecute(req)
+	res, err := getAllFlavors(ctx, client, projectId, region)
 	if err != nil {
 		return fmt.Errorf("listing postgresflex flavors: %w", err)
 	}
 
 	avl := ""
-	if res.Flavors == nil {
+	if res == nil {
 		return fmt.Errorf("finding flavors for project %s", projectId)
 	}
 	if model.Replicas.IsNull() || model.Replicas.IsUnknown() {
@@ -1176,7 +1214,7 @@ func loadFlavorId(ctx context.Context, client postgresFlexClient, model *Model, 
 	default:
 		return fmt.Errorf("unknown replica count. only 1 and 3 are supported")
 	}
-	for _, f := range res.Flavors {
+	for _, f := range res {
 		if f.Id == "" || f.Cpu == 0 || f.Memory == 0 {
 			continue
 		}
@@ -1196,12 +1234,11 @@ func loadFlavorId(ctx context.Context, client postgresFlexClient, model *Model, 
 }
 
 func getFlavor(ctx context.Context, client postgresFlexClient, projectId, region, flavorId string) (*postgresflex.ListFlavors, error) {
-	req := client.ListFlavors(ctx, projectId, region)
-	flavorsResp, err := client.ListFlavorsExecute(req)
+	flavorsResp, err := getAllFlavors(ctx, client, projectId, region)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list flavors: %w", err)
 	}
-	for _, flavor := range flavorsResp.Flavors {
+	for _, flavor := range flavorsResp {
 		if flavor.Id == flavorId {
 			return &flavor, nil
 		}

--- a/stackit/internal/services/postgresflex/instance/resource_test.go
+++ b/stackit/internal/services/postgresflex/instance/resource_test.go
@@ -3,7 +3,6 @@ package postgresflex
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1292,7 +1291,7 @@ func TestGetAllFlavors(t *testing.T) {
 				t.Errorf("getAllFlavors() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !cmp.Equal(got, tt.want) {
 				t.Errorf("getAllFlavors() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/stackit/internal/services/postgresflex/instance/resource_test.go
+++ b/stackit/internal/services/postgresflex/instance/resource_test.go
@@ -3,6 +3,7 @@ package postgresflex
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,9 +14,11 @@ import (
 )
 
 type postgresFlexClientMocked struct {
-	returnError     bool
-	listFlavorsResp *postgresflex.ListFlavorsResponse
-	listFlavorsReq  postgresflex.ApiListFlavorsRequest
+	returnError      bool
+	listFlavorsResps []*postgresflex.ListFlavorsResponse
+	listFlavorsReq   postgresflex.ApiListFlavorsRequest
+	callsCount       int
+	failOnCall       int
 }
 
 func (c *postgresFlexClientMocked) ListFlavors(_ context.Context, _, _ string) postgresflex.ApiListFlavorsRequest {
@@ -23,11 +26,21 @@ func (c *postgresFlexClientMocked) ListFlavors(_ context.Context, _, _ string) p
 }
 
 func (c *postgresFlexClientMocked) ListFlavorsExecute(_ postgresflex.ApiListFlavorsRequest) (*postgresflex.ListFlavorsResponse, error) { // nolint:gocritic // function signature required by the Go SDK
-	if c.returnError {
+	c.callsCount++
+	if c.returnError || (c.failOnCall > 0 && c.callsCount == c.failOnCall) {
 		return nil, fmt.Errorf("get flavors failed")
 	}
 
-	return c.listFlavorsResp, nil
+	if len(c.listFlavorsResps) == 0 {
+		return nil, nil
+	}
+
+	idx := c.callsCount - 1
+	if idx >= len(c.listFlavorsResps) {
+		return c.listFlavorsResps[len(c.listFlavorsResps)-1], nil
+	}
+
+	return c.listFlavorsResps[idx], nil
 }
 
 func TestMapFields(t *testing.T) {
@@ -882,8 +895,8 @@ func TestLoadFlavorId(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			client := &postgresFlexClientMocked{
-				returnError:     tt.getFlavorsFails,
-				listFlavorsResp: tt.mockedResp,
+				returnError:      tt.getFlavorsFails,
+				listFlavorsResps: []*postgresflex.ListFlavorsResponse{tt.mockedResp},
 			}
 			model := &Model{
 				ProjectId: types.StringValue("pid"),
@@ -1078,8 +1091,8 @@ func TestGetFlavor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			client := &postgresFlexClientMocked{
-				returnError:     tt.getFlavorsFails,
-				listFlavorsResp: tt.mockedResp,
+				returnError:      tt.getFlavorsFails,
+				listFlavorsResps: []*postgresflex.ListFlavorsResponse{tt.mockedResp},
 			}
 			got, err := getFlavor(context.Background(), client, "pid", "region", tt.flavorId)
 			if !tt.isValid && err == nil {
@@ -1093,6 +1106,194 @@ func TestGetFlavor(t *testing.T) {
 				if diff != "" {
 					t.Fatalf("Data does not match: %s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestGetAllFlavors(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		client    postgresFlexClient
+		projectId string
+		region    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []postgresflex.ListFlavors
+		wantErr bool
+	}{
+		{
+			name: "single page success",
+			args: args{
+				ctx: context.Background(),
+				client: &postgresFlexClientMocked{
+					listFlavorsResps: []*postgresflex.ListFlavorsResponse{
+						{
+							Flavors: []postgresflex.ListFlavors{
+								{
+									Id:          "fid-1",
+									Cpu:         2,
+									Description: "description-1",
+									Memory:      8,
+									NodeType:    "Single",
+								},
+							},
+							Pagination: postgresflex.Pagination{
+								Page:       1,
+								TotalPages: 1,
+							},
+						},
+					},
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want: []postgresflex.ListFlavors{
+				{
+					Id:          "fid-1",
+					Cpu:         2,
+					Description: "description-1",
+					Memory:      8,
+					NodeType:    "Single",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple pages success",
+			args: args{
+				ctx: context.Background(),
+				client: &postgresFlexClientMocked{
+					listFlavorsResps: []*postgresflex.ListFlavorsResponse{
+						{
+							Flavors: []postgresflex.ListFlavors{
+								{
+									Id:          "fid-1",
+									Cpu:         2,
+									Description: "description-1",
+									Memory:      8,
+									NodeType:    "Single",
+								},
+							},
+							Pagination: postgresflex.Pagination{
+								Page:       1,
+								TotalPages: 2,
+							},
+						},
+						{
+							Flavors: []postgresflex.ListFlavors{
+								{
+									Id:          "fid-2",
+									Cpu:         4,
+									Description: "description-2",
+									Memory:      16,
+									NodeType:    "Replica",
+								},
+							},
+							Pagination: postgresflex.Pagination{
+								Page:       2,
+								TotalPages: 2,
+							},
+						},
+					},
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want: []postgresflex.ListFlavors{
+				{
+					Id:          "fid-1",
+					Cpu:         2,
+					Description: "description-1",
+					Memory:      8,
+					NodeType:    "Single",
+				},
+				{
+					Id:          "fid-2",
+					Cpu:         4,
+					Description: "description-2",
+					Memory:      16,
+					NodeType:    "Replica",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error on first page",
+			args: args{
+				ctx: context.Background(),
+				client: &postgresFlexClientMocked{
+					returnError: true,
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error on second page",
+			args: args{
+				ctx: context.Background(),
+				client: &postgresFlexClientMocked{
+					listFlavorsResps: []*postgresflex.ListFlavorsResponse{
+						{
+							Flavors: []postgresflex.ListFlavors{
+								{
+									Id:          "fid-1",
+									Cpu:         2,
+									Description: "description-1",
+									Memory:      8,
+									NodeType:    "Single",
+								},
+							},
+							Pagination: postgresflex.Pagination{
+								Page:       1,
+								TotalPages: 2,
+							},
+						},
+					},
+					failOnCall: 2,
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty response",
+			args: args{
+				ctx: context.Background(),
+				client: &postgresFlexClientMocked{
+					listFlavorsResps: []*postgresflex.ListFlavorsResponse{
+						{
+							Flavors: []postgresflex.ListFlavors{},
+							Pagination: postgresflex.Pagination{
+								Page:       1,
+								TotalPages: 1,
+							},
+						},
+					},
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getAllFlavors(tt.args.ctx, tt.args.client, tt.args.projectId, tt.args.region)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAllFlavors() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAllFlavors() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/stackit/internal/services/sqlserverflex/instance/datasource.go
+++ b/stackit/internal/services/sqlserverflex/instance/datasource.go
@@ -278,16 +278,17 @@ func (r *instanceDataSource) Read(ctx context.Context, req datasource.ReadReques
 		}
 	}
 
+	flavor := &flavorModel{}
 	flavorResp, err := getFlavor(ctx, r.client.DefaultAPI, projectId, region, instanceResp.FlavorId)
 	if err != nil {
-		core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", fmt.Sprintf("Finding flavor: %v", err))
-		return
-	}
-	flavor := &flavorModel{
-		Id:          types.StringValue(flavorResp.Id),
-		Description: types.StringValue(flavorResp.Description),
-		CPU:         types.Int64Value(flavorResp.Cpu),
-		RAM:         types.Int64Value(flavorResp.Memory),
+		core.LogAndAddWarning(ctx, &resp.Diagnostics, "Flavor not populated", fmt.Sprintf("Finding flavor %q: %v", instanceResp.FlavorId, err))
+	} else if flavorResp != nil {
+		flavor = &flavorModel{
+			Id:          types.StringValue(flavorResp.Id),
+			Description: types.StringValue(flavorResp.Description),
+			CPU:         types.Int64Value(flavorResp.Cpu),
+			RAM:         types.Int64Value(flavorResp.Memory),
+		}
 	}
 
 	err = mapFields(ctx, instanceResp, &model, flavor, region)

--- a/stackit/internal/services/sqlserverflex/instance/resource.go
+++ b/stackit/internal/services/sqlserverflex/instance/resource.go
@@ -824,14 +824,15 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 		// Read the flavor here from the API, because during an import the flavor should be set
 		flavorResp, err := getFlavor(ctx, r.client.DefaultAPI, projectId, region, instanceResp.FlavorId)
 		if err != nil {
-			core.LogAndAddError(ctx, &resp.Diagnostics, "Error reading instance", fmt.Sprintf("Finding flavor: %v", err))
-			return
-		}
-		flavor = &flavorModel{
-			Id:          types.StringValue(flavorResp.Id),
-			Description: types.StringValue(flavorResp.Description),
-			CPU:         types.Int64Value(flavorResp.Cpu),
-			RAM:         types.Int64Value(flavorResp.Memory),
+			// Log a warning or handle missing flavor specifically, while failing on hard network/API errors
+			core.LogAndAddWarning(ctx, &resp.Diagnostics, "Flavor not populated", fmt.Sprintf("Finding flavor %q: %v", instanceResp.FlavorId, err))
+		} else if flavorResp != nil {
+			flavor = &flavorModel{
+				Id:          types.StringValue(flavorResp.Id),
+				Description: types.StringValue(flavorResp.Description),
+				CPU:         types.Int64Value(flavorResp.Cpu),
+				RAM:         types.Int64Value(flavorResp.Memory),
+			}
 		}
 	}
 
@@ -1271,6 +1272,43 @@ type sqlserverflexClient interface {
 	ListFlavorsExecute(r sqlserverflex.ApiListFlavorsRequest) (*sqlserverflex.ListFlavorsResponse, error)
 }
 
+func getAllFlavors(ctx context.Context, client sqlserverflexClient, projectId, region string) ([]sqlserverflex.ListFlavors, error) {
+	var result []sqlserverflex.ListFlavors
+	req := client.ListFlavors(ctx, projectId, region).Size(100)
+	resp, err := client.ListFlavorsExecute(req)
+	if err != nil {
+		return nil, fmt.Errorf("error listing flavors: %w", err)
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("nil response received when listing flavors")
+	}
+	if resp.Flavors != nil {
+		result = append(result, resp.Flavors...)
+	}
+
+	currentPage := resp.Pagination.Page
+	totalPages := resp.Pagination.TotalPages
+	for currentPage < totalPages {
+		nextPage := currentPage + 1
+		resp, err = client.ListFlavorsExecute(req.Page(nextPage))
+		if err != nil {
+			return nil, fmt.Errorf("error listing flavors: %w", err)
+		}
+		if resp == nil {
+			return nil, fmt.Errorf("nil response received when listing flavors on page %d", nextPage)
+		}
+		if resp.Flavors != nil {
+			result = append(result, resp.Flavors...)
+		}
+		if resp.Pagination.Page <= currentPage {
+			break // Prevent infinite loop if page number does not advance
+		}
+		currentPage = resp.Pagination.Page
+		totalPages = resp.Pagination.TotalPages
+	}
+	return result, nil
+}
+
 func loadFlavorId(ctx context.Context, client sqlserverflexClient, model *Model, flavor *flavorModel) error {
 	if model == nil {
 		return fmt.Errorf("nil model")
@@ -1289,17 +1327,16 @@ func loadFlavorId(ctx context.Context, client sqlserverflexClient, model *Model,
 
 	projectId := model.ProjectId.ValueString()
 	region := model.Region.ValueString()
-	req := client.ListFlavors(ctx, projectId, region)
-	res, err := client.ListFlavorsExecute(req)
+	res, err := getAllFlavors(ctx, client, projectId, region)
 	if err != nil {
 		return fmt.Errorf("listing sqlserverflex flavors: %w", err)
 	}
 
 	avl := ""
-	if res.Flavors == nil {
+	if res == nil {
 		return fmt.Errorf("finding flavors for project %s", projectId)
 	}
-	for _, f := range res.Flavors {
+	for _, f := range res {
 		if f.Id == "" || f.Cpu == 0 || f.Memory == 0 {
 			continue
 		}
@@ -1318,12 +1355,11 @@ func loadFlavorId(ctx context.Context, client sqlserverflexClient, model *Model,
 }
 
 func getFlavor(ctx context.Context, client sqlserverflexClient, projectId, region, flavorId string) (*sqlserverflex.ListFlavors, error) {
-	req := client.ListFlavors(ctx, projectId, region)
-	flavorsResp, err := client.ListFlavorsExecute(req)
+	flavorsResp, err := getAllFlavors(ctx, client, projectId, region)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list flavors: %w", err)
 	}
-	for _, flavor := range flavorsResp.Flavors {
+	for _, flavor := range flavorsResp {
 		if flavor.Id == flavorId {
 			return &flavor, nil
 		}

--- a/stackit/internal/services/sqlserverflex/instance/resource.go
+++ b/stackit/internal/services/sqlserverflex/instance/resource.go
@@ -20,7 +20,7 @@ import (
 	int32planmodifier2 "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils/planmodifiers/int32planmodifier"
 	listplanmodifier2 "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils/planmodifiers/listplanmodifier"
 	objectplanmodifier2 "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils/planmodifiers/objectplanmodifier"
-	stringplanmodifierCustom "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils/planmodifiers/stringplanmodifier"
+	stringplanmodifier2 "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils/planmodifiers/stringplanmodifier"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -63,12 +63,13 @@ type Model struct {
 	ACL            types.List   `tfsdk:"acl"`
 	BackupSchedule types.String `tfsdk:"backup_schedule"`
 	Encryption     types.Object `tfsdk:"encryption"`
-	Flavor         types.Object `tfsdk:"flavor"`
-	FlavorId       types.String `tfsdk:"flavor_id"`
-	Storage        types.Object `tfsdk:"storage"`
-	Version        types.String `tfsdk:"version"`
-	Replicas       types.Int32  `tfsdk:"replicas"`
-	Edition        types.String `tfsdk:"edition"`
+	// Deprecated: Flavor is deprecated and will be removed after February 2027.
+	Flavor   types.Object `tfsdk:"flavor"`
+	FlavorId types.String `tfsdk:"flavor_id"`
+	Storage  types.Object `tfsdk:"storage"`
+	Version  types.String `tfsdk:"version"`
+	Replicas types.Int32  `tfsdk:"replicas"`
+	Edition  types.String `tfsdk:"edition"`
 	// Deprecated: Options is deprecated and will be removed after January 2027
 	Options       types.Object `tfsdk:"options"`
 	RetentionDays types.Int32  `tfsdk:"retention_days"`
@@ -108,7 +109,7 @@ var networkTypes = map[string]attr.Type{
 	"router_address":   basetypes.StringType{},
 }
 
-// Struct corresponding to Model.Flavor
+// Deprecated: Will be removed after February 2027. Struct corresponding to Model.Flavor
 type flavorModel struct {
 	Id          types.String `tfsdk:"id"`
 	Description types.String `tfsdk:"description"`
@@ -116,7 +117,7 @@ type flavorModel struct {
 	RAM         types.Int64  `tfsdk:"ram"`
 }
 
-// Types corresponding to flavorModel
+// Deprecated: Will be removed after February 2027. Types corresponding to flavorModel
 var flavorTypes = map[string]attr.Type{
 	"id":          basetypes.StringType{},
 	"description": basetypes.StringType{},
@@ -311,7 +312,7 @@ func handleV3Migration(ctx context.Context, planModel, configModel *Model, resp 
 }
 
 // Schema defines the schema for the resource.
-func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *instanceResource) Schema(_ context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	willBeRequired := " Will be required in the future. Set a value to prevent breaking changes."
 	descriptions := map[string]string{
 		"main":                 "SQLServer Flex instance resource schema. Must have a `region` specified in the provider configuration.",
@@ -327,7 +328,7 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 		"kek_key_version":      "Version of the key within the STACKIT-KMS to use for the encryption.",
 		"service_account":      "Service-Account linked to the Key within the STACKIT-KMS.",
 		"options":              "Custom parameters for the SQLServer Flex instance.",
-		"flavor_id":            "The flavor ID of the sqlserver Flex instance. Can only be set when `flavor` and `replicas` are not set. You can list available storage classes using the [STACKIT CLI](https://github.com/stackitcloud/stackit-cli):\n```bash\nstackit curl https://mssql-flex-service.api.stackit.cloud/v3/projects/{project_id}/regions/{region}/flavors\\?size=100\n```",
+		"flavor_id":            "The flavor ID of the SQLServer Flex instance. Can only be set when `flavor` and `replicas` are not set. You can list available storage classes using the [STACKIT CLI](https://github.com/stackitcloud/stackit-cli):\n```bash\nstackit curl https://mssql-flex-service.api.stackit.cloud/v3/projects/{project_id}/regions/{region}/flavors\\?size=100\n```",
 		"network":              "The network configuration of the instance." + willBeRequired,
 		"network.access_scope": "The network access scope of the instance. This feature is in private preview. Supplying this object is only permitted for enabled accounts. If your account does not have access, the request will be rejected.",
 		"network.acl":          "List of IPV4 cidr." + willBeRequired,
@@ -405,7 +406,7 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Computed:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifierCustom.CronNormalizationModifier{},
+					stringplanmodifier2.CronNormalizationModifier{},
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
@@ -488,6 +489,9 @@ func (r *instanceResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						path.Root("flavor_id").Expression(),
 						path.Root("flavor").Expression(),
 					),
+				},
+				PlanModifiers: []planmodifier.String{
+					UseStateForUnknownIfFlavorUnchanged(req),
 				},
 			},
 			"network": schema.SingleNestedAttribute{
@@ -824,7 +828,6 @@ func (r *instanceResource) Read(ctx context.Context, req resource.ReadRequest, r
 		// Read the flavor here from the API, because during an import the flavor should be set
 		flavorResp, err := getFlavor(ctx, r.client.DefaultAPI, projectId, region, instanceResp.FlavorId)
 		if err != nil {
-			// Log a warning or handle missing flavor specifically, while failing on hard network/API errors
 			core.LogAndAddWarning(ctx, &resp.Diagnostics, "Flavor not populated", fmt.Sprintf("Finding flavor %q: %v", instanceResp.FlavorId, err))
 		} else if flavorResp != nil {
 			flavor = &flavorModel{
@@ -1272,6 +1275,7 @@ type sqlserverflexClient interface {
 	ListFlavorsExecute(r sqlserverflex.ApiListFlavorsRequest) (*sqlserverflex.ListFlavorsResponse, error)
 }
 
+// Deprecated: getAllFlavors is deprecated and will be removed after February 2027. This function is only required for the v2 to v3 api migration.
 func getAllFlavors(ctx context.Context, client sqlserverflexClient, projectId, region string) ([]sqlserverflex.ListFlavors, error) {
 	var result []sqlserverflex.ListFlavors
 	req := client.ListFlavors(ctx, projectId, region).Size(100)
@@ -1309,6 +1313,7 @@ func getAllFlavors(ctx context.Context, client sqlserverflexClient, projectId, r
 	return result, nil
 }
 
+// Deprecated: loadFlavorId is deprecated and will be removed after February 2027. This function is only required for the v2 to v3 api migration.
 func loadFlavorId(ctx context.Context, client sqlserverflexClient, model *Model, flavor *flavorModel) error {
 	if model == nil {
 		return fmt.Errorf("nil model")
@@ -1354,6 +1359,7 @@ func loadFlavorId(ctx context.Context, client sqlserverflexClient, model *Model,
 	return nil
 }
 
+// Deprecated: getFlavor is deprecated and will be removed after February 2027. This function is only required for the v2 to v3 api migration.
 func getFlavor(ctx context.Context, client sqlserverflexClient, projectId, region, flavorId string) (*sqlserverflex.ListFlavors, error) {
 	flavorsResp, err := getAllFlavors(ctx, client, projectId, region)
 	if err != nil {

--- a/stackit/internal/services/sqlserverflex/instance/resource_test.go
+++ b/stackit/internal/services/sqlserverflex/instance/resource_test.go
@@ -3,7 +3,6 @@ package sqlserverflex
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1550,7 +1549,7 @@ func TestGetAllFlavors(t *testing.T) {
 				t.Errorf("getAllFlavors() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if !cmp.Equal(got, tt.want) {
 				t.Errorf("getAllFlavors() got = %v, want %v", got, tt.want)
 			}
 		})

--- a/stackit/internal/services/sqlserverflex/instance/resource_test.go
+++ b/stackit/internal/services/sqlserverflex/instance/resource_test.go
@@ -3,6 +3,7 @@ package sqlserverflex
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,21 +14,33 @@ import (
 )
 
 type sqlserverflexClientMocked struct {
-	returnError     bool
-	listFlavorsResp *sqlserverflex.ListFlavorsResponse
-	listFlavorsReq  sqlserverflex.ApiListFlavorsRequest
+	returnError      bool
+	listFlavorsResps []*sqlserverflex.ListFlavorsResponse
+	listFlavorsReq   sqlserverflex.ApiListFlavorsRequest
+	callsCount       int
+	failOnCall       int
 }
 
 func (c *sqlserverflexClientMocked) ListFlavors(_ context.Context, _, _ string) sqlserverflex.ApiListFlavorsRequest {
 	return c.listFlavorsReq
 }
 
-func (c *sqlserverflexClientMocked) ListFlavorsExecute(_ sqlserverflex.ApiListFlavorsRequest) (*sqlserverflex.ListFlavorsResponse, error) { // nolint:gocritic // function signature required by generated SDK
-	if c.returnError {
+func (c *sqlserverflexClientMocked) ListFlavorsExecute(_ sqlserverflex.ApiListFlavorsRequest) (*sqlserverflex.ListFlavorsResponse, error) { // nolint:gocritic // function signature required by the Go SDK
+	c.callsCount++
+	if c.returnError || (c.failOnCall > 0 && c.callsCount == c.failOnCall) {
 		return nil, fmt.Errorf("get flavors failed")
 	}
 
-	return c.listFlavorsResp, nil
+	if len(c.listFlavorsResps) == 0 {
+		return nil, nil
+	}
+
+	idx := c.callsCount - 1
+	if idx >= len(c.listFlavorsResps) {
+		return c.listFlavorsResps[len(c.listFlavorsResps)-1], nil
+	}
+
+	return c.listFlavorsResps[idx], nil
 }
 
 func TestMapFields(t *testing.T) {
@@ -865,8 +878,8 @@ func TestLoadFlavorId(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			client := &sqlserverflexClientMocked{
-				returnError:     tt.getFlavorsFails,
-				listFlavorsResp: tt.mockedResp,
+				returnError:      tt.getFlavorsFails,
+				listFlavorsResps: []*sqlserverflex.ListFlavorsResponse{tt.mockedResp},
 			}
 			model := &Model{
 				ProjectId: types.StringValue("pid"),
@@ -1336,8 +1349,8 @@ func TestGetFlavor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			client := &sqlserverflexClientMocked{
-				returnError:     tt.getFlavorsFails,
-				listFlavorsResp: tt.mockedResp,
+				returnError:      tt.getFlavorsFails,
+				listFlavorsResps: []*sqlserverflex.ListFlavorsResponse{tt.mockedResp},
 			}
 			got, err := getFlavor(context.Background(), client, "pid", "region", tt.flavorId)
 			if !tt.isValid && err == nil {
@@ -1351,6 +1364,194 @@ func TestGetFlavor(t *testing.T) {
 				if diff != "" {
 					t.Fatalf("Data does not match: %s", diff)
 				}
+			}
+		})
+	}
+}
+
+func TestGetAllFlavors(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		client    sqlserverflexClient
+		projectId string
+		region    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []sqlserverflex.ListFlavors
+		wantErr bool
+	}{
+		{
+			name: "single page success",
+			args: args{
+				ctx: context.Background(),
+				client: &sqlserverflexClientMocked{
+					listFlavorsResps: []*sqlserverflex.ListFlavorsResponse{
+						{
+							Flavors: []sqlserverflex.ListFlavors{
+								{
+									Id:          "fid-1",
+									Cpu:         2,
+									Description: "description-1",
+									Memory:      8,
+									NodeType:    "Single",
+								},
+							},
+							Pagination: sqlserverflex.Pagination{
+								Page:       1,
+								TotalPages: 1,
+							},
+						},
+					},
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want: []sqlserverflex.ListFlavors{
+				{
+					Id:          "fid-1",
+					Cpu:         2,
+					Description: "description-1",
+					Memory:      8,
+					NodeType:    "Single",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple pages success",
+			args: args{
+				ctx: context.Background(),
+				client: &sqlserverflexClientMocked{
+					listFlavorsResps: []*sqlserverflex.ListFlavorsResponse{
+						{
+							Flavors: []sqlserverflex.ListFlavors{
+								{
+									Id:          "fid-1",
+									Cpu:         2,
+									Description: "description-1",
+									Memory:      8,
+									NodeType:    "Single",
+								},
+							},
+							Pagination: sqlserverflex.Pagination{
+								Page:       1,
+								TotalPages: 2,
+							},
+						},
+						{
+							Flavors: []sqlserverflex.ListFlavors{
+								{
+									Id:          "fid-2",
+									Cpu:         4,
+									Description: "description-2",
+									Memory:      16,
+									NodeType:    "Replica",
+								},
+							},
+							Pagination: sqlserverflex.Pagination{
+								Page:       2,
+								TotalPages: 2,
+							},
+						},
+					},
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want: []sqlserverflex.ListFlavors{
+				{
+					Id:          "fid-1",
+					Cpu:         2,
+					Description: "description-1",
+					Memory:      8,
+					NodeType:    "Single",
+				},
+				{
+					Id:          "fid-2",
+					Cpu:         4,
+					Description: "description-2",
+					Memory:      16,
+					NodeType:    "Replica",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error on first page",
+			args: args{
+				ctx: context.Background(),
+				client: &sqlserverflexClientMocked{
+					returnError: true,
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error on second page",
+			args: args{
+				ctx: context.Background(),
+				client: &sqlserverflexClientMocked{
+					listFlavorsResps: []*sqlserverflex.ListFlavorsResponse{
+						{
+							Flavors: []sqlserverflex.ListFlavors{
+								{
+									Id:          "fid-1",
+									Cpu:         2,
+									Description: "description-1",
+									Memory:      8,
+									NodeType:    "Single",
+								},
+							},
+							Pagination: sqlserverflex.Pagination{
+								Page:       1,
+								TotalPages: 2,
+							},
+						},
+					},
+					failOnCall: 2,
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "empty response",
+			args: args{
+				ctx: context.Background(),
+				client: &sqlserverflexClientMocked{
+					listFlavorsResps: []*sqlserverflex.ListFlavorsResponse{
+						{
+							Flavors: []sqlserverflex.ListFlavors{},
+							Pagination: sqlserverflex.Pagination{
+								Page:       1,
+								TotalPages: 1,
+							},
+						},
+					},
+				},
+				projectId: "pid",
+				region:    "region",
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getAllFlavors(tt.args.ctx, tt.args.client, tt.args.projectId, tt.args.region)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAllFlavors() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAllFlavors() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/stackit/internal/services/sqlserverflex/instance/use_state_for_unknown_if_flavor_unchanged_modifier.go
+++ b/stackit/internal/services/sqlserverflex/instance/use_state_for_unknown_if_flavor_unchanged_modifier.go
@@ -1,0 +1,85 @@
+package sqlserverflex
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+type useStateForUnknownIfFlavorUnchangedModifier struct {
+	Req resource.SchemaRequest
+}
+
+// UseStateForUnknownIfFlavorUnchanged returns a plan modifier similar to UseStateForUnknown
+// if the RAM and CPU values are not changed in the plan. Otherwise, the plan modifier does nothing.
+func UseStateForUnknownIfFlavorUnchanged(req resource.SchemaRequest) planmodifier.String {
+	return useStateForUnknownIfFlavorUnchangedModifier{
+		Req: req,
+	}
+}
+
+func (m useStateForUnknownIfFlavorUnchangedModifier) Description(context.Context) string {
+	return "UseStateForUnknownIfFlavorUnchanged returns a plan modifier similar to UseStateForUnknown if the RAM and CPU values are not changed in the plan. Otherwise, the plan modifier does nothing."
+}
+
+func (m useStateForUnknownIfFlavorUnchangedModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m useStateForUnknownIfFlavorUnchangedModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) { // nolint:gocritic // function signature required by Terraform
+	// Do nothing if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	// The above checks are taken from the UseStateForUnknown plan modifier implementation
+	// (https://github.com/hashicorp/terraform-plugin-framework/blob/main/resource/schema/stringplanmodifier/use_state_for_unknown.go#L38)
+
+	var stateModel Model
+	diags := req.State.Get(ctx, &stateModel)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var stateFlavor = &flavorModel{}
+	if !(stateModel.Flavor.IsNull() || stateModel.Flavor.IsUnknown()) {
+		diags = stateModel.Flavor.As(ctx, stateFlavor, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	var planModel Model
+	diags = req.Plan.Get(ctx, &planModel)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var planFlavor = &flavorModel{}
+	if !(planModel.Flavor.IsNull() || planModel.Flavor.IsUnknown()) {
+		diags = planModel.Flavor.As(ctx, planFlavor, basetypes.ObjectAsOptions{})
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	if planFlavor.CPU.Equal(stateFlavor.CPU) && planFlavor.RAM.Equal(stateFlavor.RAM) {
+		resp.PlanValue = req.StateValue
+	}
+}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to STACKITTPR-772

## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
