### PR TITLE
feat(git): add ability for users to update git resources

### DIFF
--- a/docs/resources/git.md
+++ b/docs/resources/git.md
@@ -4,14 +4,11 @@ page_title: "stackit_git Resource - stackit"
 subcategory: ""
 description: |-
   Git Instance resource schema.
-  ~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our guide https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources for how to opt-in to use beta resources. This resource currently does not support updates. Changing the ACLs, flavor, or name will trigger resource recreation. Update functionality will be added soon. In the meantime, please proceed with caution. To update these attributes, please open a support ticket.
 ---
 
 # stackit_git (Resource)
 
 Git Instance resource schema.
-
-~> This resource is in beta and may be subject to breaking changes in the future. Use with caution. See our [guide](https://registry.terraform.io/providers/stackitcloud/stackit/latest/docs/guides/opting_into_beta_resources) for how to opt-in to use beta resources. This resource currently does not support updates. Changing the ACLs, flavor, or name will trigger resource recreation. Update functionality will be added soon. In the meantime, please proceed with caution. To update these attributes, please open a support ticket.
 
 ## Example Usage
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/stackitcloud/terraform-provider-stackit
 
 go 1.26.0
 
+replace (
+	github.com/stackitcloud/stackit-sdk-go/services/git => github.com/tomkillen/stackit-sdk-go/services/git v0.0.0-20260729221006-2d48dc4d514c
+	github.com/stackitcloud/stackit-sdk-go/services/git/v1betaapi/wait => github.com/tomkillen/stackit-sdk-go/services/git/v1betaapi/wait v0.0.0-20260729221006-2d48dc4d514c
+)
+
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -686,8 +686,6 @@ github.com/stackitcloud/stackit-sdk-go/services/dremio v0.4.0 h1:kAWRUptc9g6lA9X
 github.com/stackitcloud/stackit-sdk-go/services/dremio v0.4.0/go.mod h1:iMoiM8fM1mXC1Nz8FBiiQ08Yh+0C3yN0GPCdAbOlRXo=
 github.com/stackitcloud/stackit-sdk-go/services/edge v0.13.0 h1:MD475tdG7oSRquUr4SA4MIevVTb82sBPM2Fkf5J7aE0=
 github.com/stackitcloud/stackit-sdk-go/services/edge v0.13.0/go.mod h1:Ylse6gqGJtsd5TVmvha+hoLd1QQHLKvhY5dO15+q5kg=
-github.com/stackitcloud/stackit-sdk-go/services/git v0.14.0 h1:VZBneGprCmHqckcSMPs3puBlK8rBpLMtYKmBktwdoVE=
-github.com/stackitcloud/stackit-sdk-go/services/git v0.14.0/go.mod h1:YZEL+gaK+ELn5E9VtK8yvz5RcmCBH+JkRpf6YbNVSbM=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.13.0 h1:PQZ6n71CMadLU3DjJxJXiPHdK9Bz4hMttBREQD6no34=
 github.com/stackitcloud/stackit-sdk-go/services/iaas v1.13.0/go.mod h1:AbPN9BGkdjc+tVsXEX9Vr8BPDjdlDmG26K1FwCKZQVU=
 github.com/stackitcloud/stackit-sdk-go/services/intake v0.11.0 h1:zuZIWgm8ak6aOyvgHouIBSoAnUkNBy4HMSba5AHYI7U=
@@ -772,6 +770,8 @@ github.com/timonwong/loggercheck v0.11.0 h1:jdaMpYBl+Uq9mWPXv1r8jc5fC3gyXx4/WGwT
 github.com/timonwong/loggercheck v0.11.0/go.mod h1:HEAWU8djynujaAVX7QI65Myb8qgfcZ1uKbdpg3ZzKl8=
 github.com/tomarrell/wrapcheck/v2 v2.12.0 h1:H/qQ1aNWz/eeIhxKAFvkfIA+N7YDvq6TWVFL27Of9is=
 github.com/tomarrell/wrapcheck/v2 v2.12.0/go.mod h1:AQhQuZd0p7b6rfW+vUwHm5OMCGgp63moQ9Qr/0BpIWo=
+github.com/tomkillen/stackit-sdk-go/services/git v0.0.0-20260729221006-2d48dc4d514c h1:Ad1R0NV4Ff93FHw6XS6qVB3XMPb4m/IS3yaWBL1yZeY=
+github.com/tomkillen/stackit-sdk-go/services/git v0.0.0-20260729221006-2d48dc4d514c/go.mod h1:YZEL+gaK+ELn5E9VtK8yvz5RcmCBH+JkRpf6YbNVSbM=
 github.com/tommy-muehle/go-mnd/v2 v2.5.1 h1:NowYhSdyE/1zwK9QCLeRb6USWdoif80Ie+v+yU8u1Zw=
 github.com/tommy-muehle/go-mnd/v2 v2.5.1/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/ultraware/funlen v0.2.0 h1:gCHmCn+d2/1SemTdYMiKLAHFYxTYz7z9VIDRaTGyLkI=

--- a/stackit/internal/services/git/instance/resource.go
+++ b/stackit/internal/services/git/instance/resource.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -23,7 +24,6 @@ import (
 
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/conversion"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/core"
-	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/features"
 	gitUtils "github.com/stackitcloud/terraform-provider-stackit/stackit/internal/services/git/utils"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/utils"
 	"github.com/stackitcloud/terraform-provider-stackit/stackit/internal/validate"
@@ -36,18 +36,31 @@ var (
 	_ resource.ResourceWithImportState = &gitResource{}
 )
 
+// Default to an open access-control-list unless otherwise specified
+var defaultAclValue = types.ListValueMust(
+	types.StringType,
+	[]attr.Value{types.StringValue("0.0.0.0/0")},
+)
+
 // Model represents the schema for the git resource.
 type Model struct {
-	Id                    types.String `tfsdk:"id"` // Required by Terraform
-	ACL                   types.List   `tfsdk:"acl"`
+	Id types.String `tfsdk:"id"` // Required by Terraform
+
+	ProjectId  types.String `tfsdk:"project_id"`
+	InstanceId types.String `tfsdk:"instance_id"`
+
+	// Requires replacement on change
+	Name   types.String `tfsdk:"name"`
+	Flavor types.String `tfsdk:"flavor"`
+
+	// Updateable fields
+	ACL types.List `tfsdk:"acl"`
+
+	// Read-only fields
+	Created               types.String `tfsdk:"created"`
+	Url                   types.String `tfsdk:"url"`
 	ConsumedDisk          types.String `tfsdk:"consumed_disk"`
 	ConsumedObjectStorage types.String `tfsdk:"consumed_object_storage"`
-	Created               types.String `tfsdk:"created"`
-	Flavor                types.String `tfsdk:"flavor"`
-	InstanceId            types.String `tfsdk:"instance_id"`
-	Name                  types.String `tfsdk:"name"`
-	ProjectId             types.String `tfsdk:"project_id"`
-	Url                   types.String `tfsdk:"url"`
 	Version               types.String `tfsdk:"version"`
 }
 
@@ -63,16 +76,17 @@ type gitResource struct {
 
 // descriptions for the attributes in the Schema
 var descriptions = map[string]string{
+	"main":                    "Git Instance resource schema.",
 	"id":                      "Terraform's internal resource ID, structured as \"`project_id`,`instance_id`\".",
+	"project_id":              "STACKIT project ID to which the git instance is associated.",
+	"instance_id":             "ID linked to the git instance.",
+	"name":                    "Unique name linked to the git instance.",
+	"flavor":                  "Instance flavor. If not provided, defaults to git-100. For a list of available flavors, refer to our API documentation: `https://docs.api.stackit.cloud/documentation/git/version/v1beta`",
+	"created":                 "Instance creation timestamp in RFC3339 format.",
+	"url":                     "Url linked to the git instance.",
 	"acl":                     "Restricted ACL for instance access.",
 	"consumed_disk":           "How many bytes of disk space is consumed.",
 	"consumed_object_storage": "How many bytes of Object Storage is consumed.",
-	"created":                 "Instance creation timestamp in RFC3339 format.",
-	"flavor":                  "Instance flavor. If not provided, defaults to git-100. For a list of available flavors, refer to our API documentation: `https://docs.api.stackit.cloud/documentation/git/version/v1beta`",
-	"instance_id":             "ID linked to the git instance.",
-	"name":                    "Unique name linked to the git instance.",
-	"project_id":              "STACKIT project ID to which the git instance is associated.",
-	"url":                     "Url linked to the git instance.",
 	"version":                 "Version linked to the git instance.",
 }
 
@@ -83,7 +97,6 @@ func (g *gitResource) Configure(ctx context.Context, req resource.ConfigureReque
 		return
 	}
 
-	features.CheckBetaResourcesEnabled(ctx, &providerData, &resp.Diagnostics, "stackit_git", "resource")
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -104,16 +117,14 @@ func (g *gitResource) Metadata(_ context.Context, req resource.MetadataRequest, 
 // Schema defines the schema for the resource.
 func (g *gitResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: fmt.Sprintf(
-			"%s %s",
-			features.AddBetaDescription("Git Instance resource schema.", core.Resource),
-			"This resource currently does not support updates. Changing the ACLs, flavor, or name will trigger resource recreation. Update functionality will be added soon. In the meantime, please proceed with caution. To update these attributes, please open a support ticket.",
-		),
-		Description: "Git Instance resource schema.",
+		Description: descriptions["main"],
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description: descriptions["id"],
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"project_id": schema.StringAttribute{
 				Description: descriptions["project_id"],
@@ -133,15 +144,16 @@ func (g *gitResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 					validate.UUID(),
 					validate.NoSeparator(),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"acl": schema.ListAttribute{
 				Description: descriptions["acl"],
-				PlanModifiers: []planmodifier.List{
-					listplanmodifier.RequiresReplace(),
-				},
 				ElementType: types.StringType,
 				Optional:    true,
 				Computed:    true,
+				Default:     listdefault.StaticValue(defaultAclValue),
 			},
 			"consumed_disk": schema.StringAttribute{
 				Description: descriptions["consumed_disk"],
@@ -154,6 +166,9 @@ func (g *gitResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			"created": schema.StringAttribute{
 				Description: descriptions["created"],
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"flavor": schema.StringAttribute{
 				Description: descriptions["flavor"],
@@ -176,6 +191,9 @@ func (g *gitResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 			"url": schema.StringAttribute{
 				Description: descriptions["url"],
 				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"version": schema.StringAttribute{
 				Description: descriptions["version"],
@@ -299,15 +317,63 @@ func (g *gitResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	tflog.Info(ctx, fmt.Sprintf("read git instance %s", instanceId))
 }
 
-// Update attempts to update the resource. In this case, git instances cannot be updated.
-// Note: This method is intentionally left without update logic because changes
-// to 'project_id' or 'name' require the resource to be entirely replaced.
-// As a result, the Update function is redundant since any modifications will
-// automatically trigger a resource recreation through Terraform's built-in
-// lifecycle management.
-func (g *gitResource) Update(ctx context.Context, _ resource.UpdateRequest, resp *resource.UpdateResponse) { // nolint:gocritic // function signature required by Terraform
-	// git instances cannot be updated, so we log an error.
-	core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating git instance", "Git Instance can't be updated")
+// Updates the git instance.
+func (g *gitResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) { // nolint:gocritic // function signature required by Terraform
+	// Retrieve the planned values for the resource.
+	var model Model
+	diags := req.Plan.Get(ctx, &model)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx = core.InitProviderContext(ctx)
+
+	projectId := model.ProjectId.ValueString()
+	instanceId := model.InstanceId.ValueString()
+	ctx = tflog.SetField(ctx, "project_id", projectId)
+	ctx = tflog.SetField(ctx, "instance_id", instanceId)
+
+	payload, diags := toPatchPayload(ctx, &model)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	tflog.Info(ctx, "updating instance", map[string]interface{}{
+		"project_id": projectId,
+		"instanceId": instanceId,
+		"payload":    payload,
+	})
+
+	gitInstanceResp, err := g.client.DefaultAPI.PatchInstance(ctx, projectId, instanceId).
+		PatchInstancePayload(payload).
+		Execute()
+	if err != nil {
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating git instance", fmt.Sprintf("Calling API: %v", err))
+		return
+	}
+
+	// Wait for update
+	_, err = wait.UpdateGitInstanceWaitHandler(ctx, g.client.DefaultAPI, projectId, instanceId).WaitWithContext(ctx)
+	if err != nil {
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating git instance", fmt.Sprintf("Git instance update waiting: %v", err))
+		return
+	}
+
+	err = mapFields(ctx, gitInstanceResp, &model)
+	if err != nil {
+		core.LogAndAddError(ctx, &resp.Diagnostics, "Error updating git instance", fmt.Sprintf("Processing API response: %v", err))
+		return
+	}
+
+	// Set the updated state.
+	diags = resp.State.Set(ctx, model)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Info(ctx, "Git instance updated")
 }
 
 // Delete deletes the git instance and removes it from the Terraform state on success.
@@ -431,6 +497,28 @@ func toCreatePayload(ctx context.Context, model *Model) (git.CreateInstancePaylo
 
 	if !(model.Flavor.IsNull() || model.Flavor.IsUnknown()) {
 		payload.Flavor = conversion.StringValueToEnumPointer[git.CreateInstancePayloadFlavor](model.Flavor)
+	}
+
+	return payload, diags
+}
+
+// toPatchPayload creates the payload to update a git instance
+func toPatchPayload(ctx context.Context, model *Model) (git.PatchInstancePayload, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	if model == nil {
+		return git.PatchInstancePayload{}, diags
+	}
+
+	payload := git.PatchInstancePayload{}
+
+	if !(model.ACL.IsNull() || model.ACL.IsUnknown()) {
+		var acl []string
+		aclDiags := model.ACL.ElementsAs(ctx, &acl, false)
+		diags.Append(aclDiags...)
+		if !aclDiags.HasError() {
+			payload.Acl = acl
+		}
 	}
 
 	return payload, diags

--- a/stackit/internal/services/git/instance/resource_test.go
+++ b/stackit/internal/services/git/instance/resource_test.go
@@ -208,3 +208,80 @@ func TestToCreatePayload(t *testing.T) {
 		})
 	}
 }
+
+func TestToUpdatePayload(t *testing.T) {
+	tests := []struct {
+		description string
+		input       *Model
+		expected    git.PatchInstancePayload
+		expectError bool
+	}{
+		{
+			description: "null ACL omitted",
+			input: &Model{
+				Name: types.StringValue("example-instance"),
+				ACL:  types.ListNull(types.StringType),
+			},
+			expected:    git.PatchInstancePayload{},
+			expectError: false,
+		},
+		{
+			description: "unknown ACL omitted",
+			input: &Model{
+				Name: types.StringValue("example-instance"),
+				ACL:  types.ListUnknown(types.StringType),
+			},
+			expected:    git.PatchInstancePayload{},
+			expectError: false,
+		},
+		{
+			description: "simple ACL values",
+			input: &Model{
+				Name: types.StringValue("my-instance"),
+				ACL: types.ListValueMust(types.StringType, []attr.Value{
+					types.StringValue("10.0.0.1"),
+					types.StringValue("10.0.0.2"),
+				}),
+			},
+			expected: git.PatchInstancePayload{
+				Acl: []string{"10.0.0.1", "10.0.0.2"},
+			},
+			expectError: false,
+		},
+		{
+			description: "empty ACL still valid",
+			input: &Model{
+				Name: types.StringValue("my-instance"),
+				ACL:  types.ListValueMust(types.StringType, []attr.Value{}),
+			},
+			expected: git.PatchInstancePayload{
+				Acl: []string{},
+			},
+			expectError: false,
+		},
+		{
+			description: "nil input model",
+			input:       nil,
+			expected:    git.PatchInstancePayload{},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			output, diags := toPatchPayload(context.Background(), tt.input)
+
+			if tt.expectError && !diags.HasError() {
+				t.Fatalf("expected diagnostics error but got none")
+			}
+
+			if !tt.expectError && diags.HasError() {
+				t.Fatalf("unexpected diagnostics error: %v", diags)
+			}
+
+			if diff := cmp.Diff(tt.expected, output); diff != "" {
+				t.Fatalf("unexpected payload (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

resolves #1633 

Note: depends on adding the update waiter to stackit-sdk-go (see PR for stackit-sdk-go here https://github.com/stackitcloud/stackit-sdk-go/pull/9328)

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [x] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
