### PR TITLE
chore(telemetrylink,telemetryrouter): Deprecation of status field

### DIFF
--- a/docs/data-sources/telemetrylink.md
+++ b/docs/data-sources/telemetrylink.md
@@ -38,5 +38,5 @@ data "stackit_telemetrylink" "link" {
 - `description` (String) The description of the Telemetry Link resource.
 - `display_name` (String) The displayed name of the Telemetry Link resource.
 - `id` (String) Terraform's internal resource identifier. It is structured as "`resource_type`, `resource_id`,`region`".
-- `status` (String) The status of the TelemetryLink, possible values: Possible values are: `active`, `inactive`, `failed`, `reconciling`, `deleting`.
+- `status` (String, Deprecated) The status of the TelemetryLink, possible values: Possible values are: `active`, `inactive`, `failed`, `reconciling`, `deleting`.
 - `telemetry_router_id` (String) The Telemetry Router ID.

--- a/docs/data-sources/telemetryrouter_access_token.md
+++ b/docs/data-sources/telemetryrouter_access_token.md
@@ -41,4 +41,4 @@ data "stackit_telemetryrouter_access_token" "accessToken" {
 - `display_name` (String) The displayed name of the access token
 - `expiration_time` (String) The date and time an access token will expire at (inclusively)
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`region`,`instance_id`,`access_token_id`".
-- `status` (String) The status of the access token. Possible values are: `active`, `expired`, `deleting`.
+- `status` (String, Deprecated) The status of the access token. Possible values are: `active`, `expired`, `deleting`.

--- a/docs/data-sources/telemetryrouter_destination.md
+++ b/docs/data-sources/telemetryrouter_destination.md
@@ -42,7 +42,7 @@ data "stackit_telemetryrouter_destination" "destination" {
 - `description` (String) The description of the TelemetryRouter destination
 - `display_name` (String) The displayed name of the TelemetryRouter destination
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`region`,`instance_id`,`destionation_id`".
-- `status` (String) The status of the TelemetryRouter destination, possible values: Possible values are: `reconciling`, `active`, `deleting`.
+- `status` (String, Deprecated) The status of the TelemetryRouter destination, possible values: Possible values are: `reconciling`, `active`, `deleting`.
 
 <a id="nestedatt--config"></a>
 ### Nested Schema for `config`

--- a/docs/data-sources/telemetryrouter_instance.md
+++ b/docs/data-sources/telemetryrouter_instance.md
@@ -39,7 +39,7 @@ data "stackit_telemetryrouter_instance" "router" {
 - `display_name` (String) The display name of the TelemetryRouter instance
 - `filter` (Attributes) The TelemetryRouter global filter settings (see [below for nested schema](#nestedatt--filter))
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`region`,`instance_id`".
-- `status` (String) The status of the TelemetryRouter instance, possible values: Possible values are: `reconciling`, `active`, `deleting`.
+- `status` (String, Deprecated) The status of the TelemetryRouter instance, possible values: Possible values are: `reconciling`, `active`, `deleting`.
 - `uri` (String) The TelemetryRouter instance's URI
 
 <a id="nestedatt--filter"></a>

--- a/docs/resources/telemetrylink.md
+++ b/docs/resources/telemetrylink.md
@@ -53,7 +53,7 @@ resource "stackit_telemetrylink" "link2" {
 
 - `create_time` (String) The time the Telemetry Link was created.
 - `id` (String) Terraform's internal resource identifier. It is structured as "`resource_type`, `resource_id`,`region`".
-- `status` (String) The status of the TelemetryLink, possible values: Possible values are: `active`, `inactive`, `failed`, `reconciling`, `deleting`.
+- `status` (String, Deprecated) The status of the TelemetryLink, possible values: Possible values are: `active`, `inactive`, `failed`, `reconciling`, `deleting`.
 
 ## Import
 

--- a/docs/resources/telemetryrouter_access_token.md
+++ b/docs/resources/telemetryrouter_access_token.md
@@ -52,7 +52,7 @@ resource "stackit_telemetryrouter_access_token" "accessToken2" {
 - `creator_id` (String) The user who created the access token
 - `expiration_time` (String) The date and time an access token will expire at (inclusively)
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`region`,`instance_id`,`access_token_id`".
-- `status` (String) The status of the access token. Possible values are: `active`, `expired`, `deleting`.
+- `status` (String, Deprecated) The status of the access token. Possible values are: `active`, `expired`, `deleting`.
 
 ## Import
 

--- a/docs/resources/telemetryrouter_destination.md
+++ b/docs/resources/telemetryrouter_destination.md
@@ -103,7 +103,7 @@ resource "stackit_telemetryrouter_destination" "otlp" {
 - `credential_type` (String) The TelemetryRouter destination's credential type
 - `destination_id` (String) The TelemetryRouter destination ID
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`region`,`instance_id`,`destionation_id`".
-- `status` (String) The status of the TelemetryRouter destination, possible values: Possible values are: `reconciling`, `active`, `deleting`.
+- `status` (String, Deprecated) The status of the TelemetryRouter destination, possible values: Possible values are: `reconciling`, `active`, `deleting`.
 
 <a id="nestedatt--config"></a>
 ### Nested Schema for `config`

--- a/docs/resources/telemetryrouter_instance.md
+++ b/docs/resources/telemetryrouter_instance.md
@@ -62,7 +62,7 @@ resource "stackit_telemetryrouter_instance" "router2" {
 - `creation_time` (String) The date and time the creation of the TelemetryRouter instance was initiated
 - `id` (String) Terraform's internal resource identifier. It is structured as "`project_id`,`region`,`instance_id`".
 - `instance_id` (String) The TelemetryRouter instance ID
-- `status` (String) The status of the TelemetryRouter instance, possible values: Possible values are: `reconciling`, `active`, `deleting`.
+- `status` (String, Deprecated) The status of the TelemetryRouter instance, possible values: Possible values are: `reconciling`, `active`, `deleting`.
 - `uri` (String) The TelemetryRouter instance's URI
 
 <a id="nestedatt--filter"></a>

--- a/stackit/internal/services/telemetrylink/link/datasource.go
+++ b/stackit/internal/services/telemetrylink/link/datasource.go
@@ -111,8 +111,9 @@ func (d *telemetryLinkDataSource) Schema(_ context.Context, _ datasource.SchemaR
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}

--- a/stackit/internal/services/telemetrylink/link/resource.go
+++ b/stackit/internal/services/telemetrylink/link/resource.go
@@ -199,8 +199,9 @@ func (r *telemetryLinkResource) Schema(_ context.Context, _ resource.SchemaReque
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}

--- a/stackit/internal/services/telemetryrouter/accesstoken/datasource.go
+++ b/stackit/internal/services/telemetryrouter/accesstoken/datasource.go
@@ -120,8 +120,9 @@ func (d *telemetryRouterAccessTokenDataSource) Schema(_ context.Context, _ datas
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}

--- a/stackit/internal/services/telemetryrouter/accesstoken/resource.go
+++ b/stackit/internal/services/telemetryrouter/accesstoken/resource.go
@@ -210,8 +210,9 @@ func (r *telemetryRouterAccessTokenResource) Schema(_ context.Context, _ resourc
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}

--- a/stackit/internal/services/telemetryrouter/destination/datasource.go
+++ b/stackit/internal/services/telemetryrouter/destination/datasource.go
@@ -269,8 +269,9 @@ func (d *telemetryRouterDestinationDataSource) Schema(_ context.Context, _ datas
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}

--- a/stackit/internal/services/telemetryrouter/destination/resource.go
+++ b/stackit/internal/services/telemetryrouter/destination/resource.go
@@ -430,8 +430,9 @@ func (r *telemetryRouterDestinationResource) Schema(_ context.Context, _ resourc
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}

--- a/stackit/internal/services/telemetryrouter/instance/datasource.go
+++ b/stackit/internal/services/telemetryrouter/instance/datasource.go
@@ -138,8 +138,9 @@ func (d *telemetryRouterInstanceDataSource) Schema(_ context.Context, _ datasour
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}

--- a/stackit/internal/services/telemetryrouter/instance/resource.go
+++ b/stackit/internal/services/telemetryrouter/instance/resource.go
@@ -255,8 +255,9 @@ func (r *telemetryRouterInstanceResource) Schema(_ context.Context, _ resource.S
 				Computed:    true,
 			},
 			"status": schema.StringAttribute{
-				Description: schemaDescriptions["status"],
-				Computed:    true,
+				Description:        schemaDescriptions["status"],
+				DeprecationMessage: "status is deprecated and will be removed after February 2027.",
+				Computed:           true,
 			},
 		},
 	}


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->



## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
