### PR TITLE
fix(docs): add note about apply order to objectstorage backend example

### DIFF
--- a/docs/guides/aws_provider_s3_stackit.md
+++ b/docs/guides/aws_provider_s3_stackit.md
@@ -44,6 +44,8 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
    }
    ```
 
+  Important: Run terraform apply now to create the bucket and credentials before proceeding. The AWS provider requires these credential values to already exist during initialization.
+
 3. **Configure AWS Provider**
 
    Configure the AWS provider to connect to the STACKIT Object Storage bucket.

--- a/docs/guides/aws_provider_s3_stackit.md
+++ b/docs/guides/aws_provider_s3_stackit.md
@@ -44,7 +44,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
    }
    ```
 
-  Important: Run terraform apply now to create the bucket and credentials before proceeding. The AWS provider requires these credential values to already exist during initialization.
+  ~> Run terraform apply now to create the bucket and credentials before proceeding. The AWS provider requires these credential values to already exist during initialization.
 
 3. **Configure AWS Provider**
 

--- a/templates/guides/aws_provider_s3_stackit.md.tmpl
+++ b/templates/guides/aws_provider_s3_stackit.md.tmpl
@@ -44,6 +44,8 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
    }
    ```
 
+  Important: Run terraform apply now to create the bucket and credentials before proceeding. The AWS provider requires these credential values to already exist during initialization.
+
 3. **Configure AWS Provider**
 
    Configure the AWS provider to connect to the STACKIT Object Storage bucket.

--- a/templates/guides/aws_provider_s3_stackit.md.tmpl
+++ b/templates/guides/aws_provider_s3_stackit.md.tmpl
@@ -44,7 +44,7 @@ This guide outlines the process of utilizing the [AWS Terraform Provider](https:
    }
    ```
 
-  Important: Run terraform apply now to create the bucket and credentials before proceeding. The AWS provider requires these credential values to already exist during initialization.
+  ~> Run terraform apply now to create the bucket and credentials before proceeding. The AWS provider requires these credential values to already exist during initialization.
 
 3. **Configure AWS Provider**
 


### PR DESCRIPTION
## Description

Fixes #922 by adding a note about the initial terraform apply step required to generate STACKIT credentials before configuring the AWS provider.

## Checklist

- [x] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
