### PR TITLE
feat(albcertificate): increase cert lengths to 64kb

### DIFF
--- a/stackit/internal/services/albcertificates/certificate/resource.go
+++ b/stackit/internal/services/albcertificates/certificate/resource.go
@@ -187,7 +187,7 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.LengthAtMost(8192),
+					stringvalidator.LengthAtMost(65536),
 				},
 			},
 			"public_key": schema.StringAttribute{
@@ -197,7 +197,7 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.LengthAtMost(8192),
+					stringvalidator.LengthAtMost(65536),
 				},
 			},
 		},


### PR DESCRIPTION
## Description

relates to STACKITTPR-803

## Checklist

- [x] Issue was linked above
- [x] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [x] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
