### PR TITLE
feat(alb): add alt_port

### DIFF
--- a/docs/data-sources/application_load_balancer.md
+++ b/docs/data-sources/application_load_balancer.md
@@ -229,6 +229,7 @@ Read-Only:
 
 Read-Only:
 
+- `alt_port` (Number) Overrides the default port used for health check probes.
 - `healthy_threshold` (Number) Healthy threshold of the health checking.
 - `http_health_checks` (Attributes) Options for the HTTP health checking. (see [below for nested schema](#nestedatt--target_pools--active_health_check--http_health_checks))
 - `interval` (String) Interval duration of health checking in seconds.

--- a/docs/resources/application_load_balancer.md
+++ b/docs/resources/application_load_balancer.md
@@ -437,6 +437,7 @@ Required:
 
 Optional:
 
+- `alt_port` (Number) Overrides the default port used for health check probes.
 - `http_health_checks` (Attributes) Options for the HTTP health checking. (see [below for nested schema](#nestedatt--target_pools--active_health_check--http_health_checks))
 
 <a id="nestedatt--target_pools--active_health_check--http_health_checks"></a>

--- a/stackit/internal/services/alb/alb_acc_test.go
+++ b/stackit/internal/services/alb/alb_acc_test.go
@@ -106,6 +106,7 @@ var testConfigVarsMax = config.Variables{
 	"target_pool_port_3":                config.StringVariable("9001"),
 	"target_pool_port_4":                config.StringVariable("1234"),
 	"target_display_name":               config.StringVariable("example-target"),
+	"ahc_alt_port":                      config.StringVariable("8080"),
 	"ahc_interval":                      config.StringVariable("1s"),
 	"ahc_interval_jitter":               config.StringVariable("0.010s"),
 	"ahc_timeout":                       config.StringVariable("1s"),
@@ -167,6 +168,7 @@ func configVarsMaxUpdated() config.Variables {
 	tempConfig["ahc_http_ok_status_201"] = config.StringVariable("203")
 	tempConfig["ahc_timeout"] = config.StringVariable("5s")
 	tempConfig["ahc_healthy_threshold"] = config.StringVariable("5")
+	tempConfig["ahc_alt_port"] = config.StringVariable("8081")
 	tempConfig["acl"] = config.StringVariable("10.11.10.8/24")
 	return tempConfig
 }
@@ -390,6 +392,7 @@ func TestAccALBResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.name", testutil.ConvertConfigVariable(testConfigVarsMax["target_pool_name_1"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.target_port", testutil.ConvertConfigVariable(testConfigVarsMax["target_pool_port_1"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.targets.0.display_name", testutil.ConvertConfigVariable(testConfigVarsMax["target_display_name"])),
+					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.alt_port", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_alt_port"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.interval", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_interval"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.interval_jitter", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_interval_jitter"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.timeout", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_timeout"])),
@@ -479,6 +482,7 @@ func TestAccALBResourceMax(t *testing.T) {
 					resource.TestCheckResourceAttr("data.stackit_application_load_balancer.loadbalancer", "target_pools.0.name", testutil.ConvertConfigVariable(testConfigVarsMax["target_pool_name_1"])),
 					resource.TestCheckResourceAttr("data.stackit_application_load_balancer.loadbalancer", "target_pools.0.target_port", testutil.ConvertConfigVariable(testConfigVarsMax["target_pool_port_1"])),
 					resource.TestCheckResourceAttr("data.stackit_application_load_balancer.loadbalancer", "target_pools.0.targets.0.display_name", testutil.ConvertConfigVariable(testConfigVarsMax["target_display_name"])),
+					resource.TestCheckResourceAttr("data.stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.alt_port", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_alt_port"])),
 					resource.TestCheckResourceAttr("data.stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.interval", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_interval"])),
 					resource.TestCheckResourceAttr("data.stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.interval_jitter", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_interval_jitter"])),
 					resource.TestCheckResourceAttr("data.stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.timeout", testutil.ConvertConfigVariable(testConfigVarsMax["ahc_timeout"])),
@@ -616,6 +620,7 @@ func TestAccALBResourceMax(t *testing.T) {
 					testutil.CheckListAttr("stackit_application_load_balancer.loadbalancer", "listeners.0.http.hosts.0.rules.0.query_parameters", configVarsMaxUpdated()["query_parameters"]),
 					testutil.CheckListAttr("stackit_application_load_balancer.loadbalancer", "listeners.0.http.hosts.0.rules.0.headers", configVarsMaxUpdated()["headers"]),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.target_port", testutil.ConvertConfigVariable(configVarsMaxUpdated()["target_pool_port_1"])),
+					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.alt_port", testutil.ConvertConfigVariable(configVarsMaxUpdated()["ahc_alt_port"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.timeout", testutil.ConvertConfigVariable(configVarsMaxUpdated()["ahc_timeout"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.healthy_threshold", testutil.ConvertConfigVariable(configVarsMaxUpdated()["ahc_healthy_threshold"])),
 					resource.TestCheckResourceAttr("stackit_application_load_balancer.loadbalancer", "target_pools.0.active_health_check.http_health_checks.ok_status.0", testutil.ConvertConfigVariable(configVarsMaxUpdated()["ahc_http_ok_status_200"])),

--- a/stackit/internal/services/alb/applicationloadbalancer/datasource.go
+++ b/stackit/internal/services/alb/applicationloadbalancer/datasource.go
@@ -121,6 +121,7 @@ func (r *albDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 		"private_network_only":                   "Application Load Balancer is accessible only via a private network ip address. Not changeable after creation.",
 		"target_pools":                           "List of all target pools which will be used in the Application Load Balancer. Limited to 20.",
 		"active_health_checks":                   "Set this to customize active health checks for targets in this pool.",
+		"alt_port":                               "Overrides the default port used for health check probes.",
 		"healthy_threshold":                      "Healthy threshold of the health checking.",
 		"http_health_checks":                     "Options for the HTTP health checking.",
 		"http_health_checks.ok_status":           "List of HTTP status codes that indicate a healthy response.",
@@ -435,6 +436,10 @@ func (r *albDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, re
 							Description: descriptions["active_health_check"],
 							Computed:    true,
 							Attributes: map[string]schema.Attribute{
+								"alt_port": schema.Int32Attribute{
+									Description: descriptions["alt_port"],
+									Computed:    true,
+								},
 								"healthy_threshold": schema.Int32Attribute{
 									Description: descriptions["healthy_threshold"],
 									Computed:    true,

--- a/stackit/internal/services/alb/applicationloadbalancer/resource.go
+++ b/stackit/internal/services/alb/applicationloadbalancer/resource.go
@@ -273,6 +273,7 @@ var targetPoolTypes = map[string]attr.Type{
 
 // Struct corresponding to targetPool.ActiveHealthCheck
 type activeHealthCheck struct {
+	AltPort            types.Int32  `tfsdk:"alt_port"`
 	HealthyThreshold   types.Int32  `tfsdk:"healthy_threshold"`
 	HttpHealthChecks   types.Object `tfsdk:"http_health_checks"`
 	Interval           types.String `tfsdk:"interval"`
@@ -283,6 +284,7 @@ type activeHealthCheck struct {
 
 // Types corresponding to activeHealthCheck
 var activeHealthCheckTypes = map[string]attr.Type{
+	"alt_port":            types.Int32Type,
 	"healthy_threshold":   types.Int32Type,
 	"http_health_checks":  types.ObjectType{AttrTypes: httpHealthChecksTypes},
 	"interval":            types.StringType,
@@ -452,6 +454,7 @@ func (r *applicationLoadBalancerResource) Schema(_ context.Context, _ resource.S
 		"private_network_only":                   "Application Load Balancer is accessible only via a private network ip address. Not changeable after creation.",
 		"target_pools":                           "List of all target pools which will be used in the Application Load Balancer. Limited to 20.",
 		"active_health_checks":                   "Set this to customize active health checks for targets in this pool.",
+		"alt_port":                               "Overrides the default port used for health check probes.",
 		"healthy_threshold":                      "Healthy threshold of the health checking.",
 		"http_health_checks":                     "Options for the HTTP health checking.",
 		"http_health_checks.ok_status":           "List of HTTP status codes that indicate a healthy response.",
@@ -966,6 +969,13 @@ The example below creates the supporting infrastructure using the STACKIT Terraf
 							Description: descriptions["active_health_check"],
 							Optional:    true,
 							Attributes: map[string]schema.Attribute{
+								"alt_port": schema.Int32Attribute{
+									Description: descriptions["alt_port"],
+									Optional:    true,
+									Validators: []validator.Int32{
+										int32validator.Between(1, 65535),
+									},
+								},
 								"healthy_threshold": schema.Int32Attribute{
 									Description: descriptions["healthy_threshold"],
 									Required:    true,
@@ -1952,6 +1962,7 @@ func toActiveHealthCheckPayload(ctx context.Context, tp *targetPool) (*albSdk.Ac
 	}
 
 	return &albSdk.ActiveHealthCheck{
+		AltPort:            conversion.Int32ValueToPointer(activeHealthCheckModel.AltPort),
 		HealthyThreshold:   conversion.Int32ValueToPointer(activeHealthCheckModel.HealthyThreshold),
 		Interval:           conversion.StringValueToPointer(activeHealthCheckModel.Interval),
 		IntervalJitter:     conversion.StringValueToPointer(activeHealthCheckModel.IntervalJitter),
@@ -2774,6 +2785,7 @@ func mapActiveHealthCheck(ctx context.Context, activeHealthCheckResp *albSdk.Act
 	}
 
 	activeHealthCheckMap := map[string]attr.Value{
+		"alt_port":            types.Int32PointerValue(activeHealthCheckResp.AltPort),
 		"healthy_threshold":   types.Int32PointerValue(activeHealthCheckResp.HealthyThreshold),
 		"interval":            types.StringPointerValue(activeHealthCheckResp.Interval),
 		"interval_jitter":     types.StringPointerValue(activeHealthCheckResp.IntervalJitter),

--- a/stackit/internal/services/alb/applicationloadbalancer/resource_test.go
+++ b/stackit/internal/services/alb/applicationloadbalancer/resource_test.go
@@ -239,6 +239,7 @@ func fixtureModel(explicitBool *bool, mods ...func(m *Model)) *Model {
 						"active_health_check": types.ObjectValueMust(
 							activeHealthCheckTypes,
 							map[string]attr.Value{
+								"alt_port":            types.Int32Value(8080),
 								"healthy_threshold":   types.Int32Value(1),
 								"interval":            types.StringValue("2s"),
 								"interval_jitter":     types.StringValue("3s"),
@@ -424,6 +425,7 @@ func fixtureApplicationLoadBalancer(explicitBool *bool, mods ...func(m *albSdk.L
 					CustomCa:                  new("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURDekNDQWZPZ0F3SUJBZ0lVVHlQc1RXQzlseTdvK3dORlltMHV1MStQOElFd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF3d0tUWGxEZFhOMGIyMURRVEFlRncweU5UQXlNVGt4T1RJME1qQmFGdzB5TmpBeQpNVGt4T1RJME1qQmFNQlV4RXpBUkJnTlZCQU1NQ2sxNVEzVnpkRzl0UTBFd2dnRWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDUU1FWUtiaU54VTM3ZkV3Qk94a3ZDc2hCUiswTXd4d0xXOE1pMy9wdm8KbjNodXhqY203RWFLVzlyN2tJYW9IWGJUUzF0bk82ckhBSEtCRHh6dW9ZRDdDMlNNU2lMeGRkcXVOUnZwa0xhUAo4cUFYbmVRWTJWUDdMenNBZ3NDMDRQS0cwWUMxTmdGNXNKR3NpV0lSR0ltK2NzWUxuUE1ud2FBR3g0SXZZNm1ICkFtTTY0YjZRUkNnMzZMSytQNk45S1R2U1FMdnZtRmRrQTJzRFRvQ21OL0FtcDZ4TkRGcSthUUdMd2RRUXFIRFAKVGFVcVBtRXlpRkhLdkZVYUZNTlFWazhCMU9tOEFTbzY5bThVM0VhdDRaT1ZXMXRpdEUzOTNRa09kQTZaeXBNQwpySkpwZU5OTExKcTNtSU9XT2Q3R0V5QXZqVWZtSndHaHFFRlM3bE1HNjdobkFnTUJBQUdqVXpCUk1CMEdBMVVkCkRnUVdCQlNrL0lNNWphT0FKTDMvS255cTNjVnZhMDRZWkRBZkJnTlZIU01FR0RBV2dCU2svSU01amFPQUpMMy8KS255cTNjVnZhMDRZWkRBUEJnTlZIUk1CQWY4RUJUQURBUUgvTUEwR0NTcUdTSWIzRFFFQkN3VUFBNElCQVFCZQpaL21FOHJOSWJOYkhRZXAvVnBwc2hhWlV6Z2R5NG5zbWgwd3Z4TXVISVFQMEtIcnhMQ2toT243QTlmdTRtWS9QClErOFFxbG5qVHNNNGNxaXVGY2Q1VjFOazlWRi9lNVgzSFhDREhoL2pCRncrTzVUR1ZBUi83REJ3MzFsWXYvTHQKSGFra2pRQ2Rhd3V2SDNvc08vVWtFbE0vaTJLQytpWUJhdlRlbm05N0FSN1dHZ1cxNS9NSXF4TmFZRStuSnRoLwpkY1ZEMGI1cVN1WVFhRW1aM0N6TVVpMTg4UitnbzVvekNmMmNPYWErMy9MRVlBYUkzdktpU0U4S1Rzc2h5b0ttCk82WVpxclZ4UUNXQ0RUT3NkMjhrN2xIdDh3SitqelljakN1NjBEVXBnMVpwWStabm1yRTh2UFBEYi96WGhCbjYKL2xsWFRXT1VqbXVUS25Hc0lEUDUKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ=="),
 				},
 				ActiveHealthCheck: &albSdk.ActiveHealthCheck{
+					AltPort:            new(int32(8080)),
 					HealthyThreshold:   new(int32(1)),
 					UnhealthyThreshold: new(int32(5)),
 					Interval:           new("2s"),
@@ -844,6 +846,7 @@ func TestMapFields(t *testing.T) {
 								"active_health_check": types.ObjectValueMust(
 									activeHealthCheckTypes,
 									map[string]attr.Value{
+										"alt_port":            types.Int32Null(),
 										"healthy_threshold":   types.Int32Value(1),
 										"interval":            types.StringValue("2s"),
 										"interval_jitter":     types.StringValue("3s"),

--- a/stackit/internal/services/alb/testfiles/resource-max.tf
+++ b/stackit/internal/services/alb/testfiles/resource-max.tf
@@ -87,7 +87,7 @@ resource "stackit_network" "listener_network" {
   project_id       = var.project_id
   name             = var.network_name_listener
   ipv4_nameservers = ["1.1.1.1"]
-  ipv4_prefix      = "10.11.10.0/24"
+  ipv4_prefix      = "10.2.2.0/24"
   routed           = "true"
 }
 
@@ -95,7 +95,7 @@ resource "stackit_network" "target_network" {
   project_id       = var.project_id
   name             = var.network_name_targets
   ipv4_nameservers = ["1.1.1.1"]
-  ipv4_prefix      = "10.11.11.0/24"
+  ipv4_prefix      = "10.2.3.0/24"
   routed           = "true"
 }
 

--- a/stackit/internal/services/alb/testfiles/resource-max.tf
+++ b/stackit/internal/services/alb/testfiles/resource-max.tf
@@ -37,6 +37,7 @@ variable "labels_key_1" {}
 variable "labels_value_1" {}
 variable "labels_key_2" {}
 variable "labels_value_2" {}
+variable "ahc_alt_port" {}
 variable "ahc_interval" {}
 variable "ahc_interval_jitter" {}
 variable "ahc_timeout" {}
@@ -160,6 +161,7 @@ resource "stackit_application_load_balancer" "loadbalancer" {
     {
       name = var.target_pool_name_1
       active_health_check = {
+        alt_port            = var.ahc_alt_port
         interval            = var.ahc_interval
         interval_jitter     = var.ahc_interval_jitter
         timeout             = var.ahc_timeout

--- a/stackit/internal/services/alb/testfiles/resource-min.tf
+++ b/stackit/internal/services/alb/testfiles/resource-min.tf
@@ -40,7 +40,7 @@ resource "stackit_network" "network" {
   project_id       = var.project_id
   name             = var.network_name
   ipv4_nameservers = ["1.1.1.1"]
-  ipv4_prefix      = "192.168.3.0/25"
+  ipv4_prefix      = "10.0.0.0/25"
   routed           = "true"
 }
 


### PR DESCRIPTION
## Description
Adds attribute `altPort` to configure an alternative port for the health checks.
<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->


## Checklist

- [ ] Issue was linked above
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [x] Docs are up-to-date: `make generate-docs` (will be checked by CI)
- [ ] Unit tests got implemented or updated
- [ ] Acceptance tests got implemented or updated (see e.g. [here](https://github.com/stackitcloud/terraform-provider-stackit/blob/f5f99d170996b208672ae684b6da53420e369563/stackit/internal/services/dns/dns_acc_test.go))
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
